### PR TITLE
Fix issue #23

### DIFF
--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-manager.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-manager.ts
@@ -19,10 +19,4 @@ export abstract class GLSPDiagramManager extends DiagramManagerImpl {
         return options => new GLSPDiagramWidget(options)
     }
 
-
-
-
-
-
-
 }

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-widget.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-widget.ts
@@ -22,4 +22,5 @@ export class GLSPDiagramWidget extends DiagramWidget {
 
         this.modelSource.handle(new RequestOperationsAction())
     }
+
 }

--- a/client/packages/workflow-sprotty/css/dark/diagram.css
+++ b/client/packages/workflow-sprotty/css/dark/diagram.css
@@ -8,10 +8,14 @@
 @import "page.css";
 @import "popup.css";
 
+.sprotty {
+    height: 100%;
+}
 
 .sprotty-graph {
     font-size: 15pt;
     background: rgb(179, 196, 202);
+    height: 100%;
 }
 
 .sprotty-text {

--- a/client/packages/workflow-sprotty/css/light/diagram.css
+++ b/client/packages/workflow-sprotty/css/light/diagram.css
@@ -8,10 +8,14 @@
 @import "page.css";
 @import "popup.css";
 
+.sprotty {
+    height: 100%;
+}
 
 .sprotty-graph {
     font-size: 15pt;
-    background: rgb(179, 196, 202);
+    background: rgb(245, 252, 255);
+    height: 100%;
 }
 
 .sprotty-text {


### PR DESCRIPTION
Adjusts the css to allow the sprotty div and the enclosed SVG span 100 %
of the widget size. #23 