### PR TITLE
Refactor Filebased Modelfactory #64

### DIFF
--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfiguration.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfiguration.java
@@ -13,12 +13,11 @@ package com.eclipsesource.glsp.example.workflow;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.eclipsesource.glsp.api.factory.FileBasedModelFactory;
+import com.eclipsesource.glsp.api.model.ModelTypeConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
 import com.eclipsesource.glsp.example.workflow.schema.Icon;
 import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
 import com.eclipsesource.glsp.example.workflow.schema.WeightedEdge;
-import com.google.inject.Singleton;
 
 import io.typefox.sprotty.api.HtmlRoot;
 import io.typefox.sprotty.api.PreRenderedElement;
@@ -28,29 +27,25 @@ import io.typefox.sprotty.api.SGraph;
 import io.typefox.sprotty.api.SLabel;
 import io.typefox.sprotty.api.SModelElement;
 
-@Singleton
-public class WorkflowModelFactory extends FileBasedModelFactory {
+public class WorkflowModelTypeConfiguration implements ModelTypeConfiguration {
 
 	@Override
-	protected Map<String, Class<? extends SModelElement>> getModelTypeSchema() {
-		return new HashMap<String, Class<? extends SModelElement>>() {
-			private static final long serialVersionUID = 1L;
-			{
-				put("graph", SGraph.class);
-				put("label:heading", SLabel.class);
-				put("label:text", SLabel.class);
-				put("comp:comp", SCompartment.class);
-				put("comp:header", SCompartment.class);
-				put("label:icon", SLabel.class);
-				put("edge", SEdge.class);
-				put("html", HtmlRoot.class);
-				put("pre-rendered", PreRenderedElement.class);
-				put(WeightedEdge.TYPE, WeightedEdge.class);
-				put(Icon.TYPE, Icon.class);
-				put(ActivityNode.TYPE, ActivityNode.class);
-				put(TaskNode.TYPE, TaskNode.class);
-			}
-		};
+	public Map<String, Class<? extends SModelElement>> getModelTypes() {
+		Map<String, Class<? extends SModelElement>> conf = new HashMap<>();
+		conf.put("graph", SGraph.class);
+		conf.put("label:heading", SLabel.class);
+		conf.put("label:text", SLabel.class);
+		conf.put("comp:comp", SCompartment.class);
+		conf.put("comp:header", SCompartment.class);
+		conf.put("label:icon", SLabel.class);
+		conf.put("edge", SEdge.class);
+		conf.put("html", HtmlRoot.class);
+		conf.put("pre-rendered", PreRenderedElement.class);
+		conf.put(WeightedEdge.TYPE, WeightedEdge.class);
+		conf.put(Icon.TYPE, Icon.class);
+		conf.put(ActivityNode.TYPE, ActivityNode.class);
+		conf.put(TaskNode.TYPE, TaskNode.class);
+		return conf;
 
 	}
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
@@ -10,24 +10,24 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow;
 
-import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
 import com.eclipsesource.glsp.api.model.ModelSelectionListener;
+import com.eclipsesource.glsp.api.model.ModelTypeConfiguration;
 import com.eclipsesource.glsp.api.operations.OperationConfiguration;
 import com.eclipsesource.glsp.server.ServerModule;
 
 public class WorkflowServerRuntimeModule extends ServerModule {
-	
+
 	@Override
 	protected void bindOperationHandlerProviders() {
 		bindOperationHandlerProvider().to(WorkflowOperationHandlerProvider.class);
 	}
 
 	@Override
-	public Class<? extends ModelFactory> bindModelFactory() {
-		return WorkflowModelFactory.class;
+	public Class<? extends ModelTypeConfiguration> bindModelTypeConfiguration() {
+		return WorkflowModelTypeConfiguration.class;
 	}
 
 	@Override

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -17,6 +17,7 @@ import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
 import com.eclipsesource.glsp.api.model.ModelSelectionListener;
 import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.api.model.ModelTypeConfiguration;
 import com.eclipsesource.glsp.api.operations.OperationConfiguration;
 import com.eclipsesource.glsp.api.provider.ActionHandlerProvider;
 import com.eclipsesource.glsp.api.provider.ActionProvider;
@@ -49,6 +50,7 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(ModelElementOpenListener.class).to(bindModelElementOpenListener());
 		bind(ILayoutEngine.class).to(bindLayoutEngine());
 		bind(OperationConfiguration.class).to(bindOperationConfiguration());
+		bind(ModelTypeConfiguration.class).to(bindModelTypeConfiguration());
 	}
 
 	protected void bindProviders() {
@@ -69,7 +71,7 @@ public abstract class GLSPModule extends AbstractModule {
 	protected abstract void bindActionHandlerProviders();
 
 	protected abstract void bindOperationHandlerProviders();
-
+	
 	protected final LinkedBindingBuilder<ActionProvider> bindActionProvider() {
 		return actionProviderBinder.addBinding();
 	}
@@ -109,4 +111,9 @@ public abstract class GLSPModule extends AbstractModule {
 	protected Class<? extends ILayoutEngine> bindLayoutEngine() {
 		return ILayoutEngine.NullImpl.class;
 	}
+
+	protected Class<? extends ModelTypeConfiguration> bindModelTypeConfiguration() {
+		return ModelTypeConfiguration.NullImpl.class;
+	}
+
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelTypeConfiguration.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelTypeConfiguration.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+package com.eclipsesource.glsp.api.model;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.eclipsesource.glsp.api.json.SModelElementTypeAdapter;
+import com.google.gson.GsonBuilder;
+
+import io.typefox.sprotty.api.SModelElement;
+import io.typefox.sprotty.server.json.EnumTypeAdapter;
+
+/**
+ * This configuration class provides the information necessary to determine the
+ * corresponding Java class for a SModelElement. For this the type property is
+ * used.
+ * 
+ * @author Tobias Ortmayr
+ *
+ */
+public interface ModelTypeConfiguration {
+
+	/**
+	 * Returns a map which enables the identification of the corresponding Java
+	 * class for each SModelElement based on its type property. This mappings will
+	 * be reused by GSON for proper JSON-to-Java conversion.
+	 */
+	Map<String, Class<? extends SModelElement>> getModelTypes();
+
+	default GsonBuilder configureGSON() {
+		GsonBuilder builder = new GsonBuilder();
+		builder.registerTypeAdapterFactory(new SModelElementTypeAdapter.Factory(getModelTypes()))
+				.registerTypeAdapterFactory(new EnumTypeAdapter.Factory());
+		return builder;
+
+	}
+
+	public static final class NullImpl implements ModelTypeConfiguration {
+
+		@Override
+		public Map<String, Class<? extends SModelElement>> getModelTypes() {
+			return Collections.emptyMap();
+		}
+
+	}
+
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/ModelOptions.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/ModelOptions.java
@@ -11,8 +11,9 @@
 package com.eclipsesource.glsp.api.utils;
 
 import java.util.Map;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
+
 
 public final class ModelOptions {
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
@@ -11,8 +11,11 @@
 package com.eclipsesource.glsp.server;
 
 import com.eclipsesource.glsp.api.di.GLSPModule;
+import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.jsonrpc.GraphicalLanguageServer;
 import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.server.model.FileBasedModelFactory;
+import com.eclipsesource.glsp.server.model.ModelStateImpl;
 import com.eclipsesource.glsp.server.provider.DefaultActionHandlerProvider;
 import com.eclipsesource.glsp.server.provider.DefaultActionProvider;
 
@@ -27,12 +30,18 @@ public abstract class ServerModule extends GLSPModule {
 	protected void bindActionHandlerProviders() {
 		bindActionHandlerProvider().to(DefaultActionHandlerProvider.class);
 	}
-	
 
+	@Override
+	protected Class<? extends ModelFactory> bindModelFactory() {
+		return FileBasedModelFactory.class;
+	}
+
+	@Override
 	protected Class<? extends GraphicalLanguageServer> bindGraphicalLanguageServer() {
 		return DefaultGraphicalLanguageServer.class;
 	}
 
+	@Override
 	protected Class<? extends ModelState> bindModelState() {
 		return ModelStateImpl.class;
 	}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/ModelStateImpl.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/ModelStateImpl.java
@@ -8,7 +8,7 @@
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
-package com.eclipsesource.glsp.server;
+package com.eclipsesource.glsp.server.model;
 
 import java.util.HashSet;
 import java.util.Set;


### PR DESCRIPTION
Refactors  and extracts common functionality from the filebased Modelfactory.  We have now three independent components which are  responsible for loading,saving and model configuration.
In addition, the filebased Modelfactory is now completely generic and  injected by default.
This also solves the issue with the @singleton annotation mentioned in #61 