### PR TITLE
Update copyright headers to epl-2.0

### DIFF
--- a/client/packages/glsp-sprotty/src/features/operation/set-operations.ts
+++ b/client/packages/glsp-sprotty/src/features/operation/set-operations.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  *     Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/palette/connection-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/palette/connection-tool.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/palette/creation-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/palette/creation-tool.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/palette/delete-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/palette/delete-tool.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/palette/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/palette/di.config.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/palette/operation-service.ts
+++ b/client/packages/glsp-sprotty/src/features/palette/operation-service.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/save/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/save/di.config.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/save/model.ts
+++ b/client/packages/glsp-sprotty/src/features/save/model.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/save/save.ts
+++ b/client/packages/glsp-sprotty/src/features/save/save.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/tool/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/tool/di.config.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/tool/execute-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tool/execute-tool.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-sprotty/src/features/tool/move-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tool/move-tool.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/client/packages/glsp-sprotty/src/utils/operation.ts
+++ b/client/packages/glsp-sprotty/src/utils/operation.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-manager.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-manager.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-widget.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-widget.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-palette-contribution.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-palette-contribution.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-sprotty-connector.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-sprotty-connector.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/frontend-extension.ts
+++ b/client/packages/glsp-theia-extension/src/browser/frontend-extension.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/language/graphical-langauge-client-contribution.ts
+++ b/client/packages/glsp-theia-extension/src/browser/language/graphical-langauge-client-contribution.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/language/graphical-language-client-provider.ts
+++ b/client/packages/glsp-theia-extension/src/browser/language/graphical-language-client-provider.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/language/graphical-language-client-services.ts
+++ b/client/packages/glsp-theia-extension/src/browser/language/graphical-language-client-services.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/language/graphical-language-client.ts
+++ b/client/packages/glsp-theia-extension/src/browser/language/graphical-language-client.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/browser/language/graphical-languages-frontend-contribution.ts
+++ b/client/packages/glsp-theia-extension/src/browser/language/graphical-languages-frontend-contribution.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/common/graphical-language-server-protocol.ts
+++ b/client/packages/glsp-theia-extension/src/common/graphical-language-server-protocol.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/glsp-theia-extension/src/node/graphical-language-server-contribution.ts
+++ b/client/packages/glsp-theia-extension/src/node/graphical-language-server-contribution.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/browser/diagram/di.config.ts
+++ b/client/packages/workflow-glsp-extension/src/browser/diagram/di.config.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/browser/diagram/thememanager.ts
+++ b/client/packages/workflow-glsp-extension/src/browser/diagram/thememanager.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/browser/diagram/workflow-diagram-manager..ts
+++ b/client/packages/workflow-glsp-extension/src/browser/diagram/workflow-diagram-manager..ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/browser/frontend-extension.ts
+++ b/client/packages/workflow-glsp-extension/src/browser/frontend-extension.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/browser/language/workflow-gl-client-contribution.ts
+++ b/client/packages/workflow-glsp-extension/src/browser/language/workflow-gl-client-contribution.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/common/workflow-language.ts
+++ b/client/packages/workflow-glsp-extension/src/common/workflow-language.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/node/backend-extension.ts
+++ b/client/packages/workflow-glsp-extension/src/node/backend-extension.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-glsp-extension/src/node/workflow-gl-server-contribution.ts
+++ b/client/packages/workflow-glsp-extension/src/node/workflow-gl-server-contribution.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-sprotty/src/di.config.ts
+++ b/client/packages/workflow-sprotty/src/di.config.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-sprotty/src/model-factory.ts
+++ b/client/packages/workflow-sprotty/src/model-factory.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-sprotty/src/model-schema.ts
+++ b/client/packages/workflow-sprotty/src/model-schema.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-sprotty/src/model.ts
+++ b/client/packages/workflow-sprotty/src/model.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/client/packages/workflow-sprotty/src/workflow-views.tsx
+++ b/client/packages/workflow-sprotty/src/workflow-views.tsx
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/ExampleServerLauncher.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/ExampleServerLauncher.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfiguration.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfiguration.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowOperationConfiguration.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowOperationConfiguration.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowOperationHandlerProvider.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowOperationHandlerProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowPopupFactory.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowPopupFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerListener.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerListener.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateAutomatedTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateAutomatedTaskHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateDecisionNodeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateDecisionNodeHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateEdgeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateEdgeHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateManualTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateManualTaskHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateMergeNodeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateMergeNodeHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateWeightedEdgeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateWeightedEdgeHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/DeleteWorkflowElementHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/DeleteWorkflowElementHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ActivityNode.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ActivityNode.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/Icon.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/Icon.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/TaskNode.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/TaskNode.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/WeightedEdge.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/WeightedEdge.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/example/workflow-example/src/test/java/org/chillisp/server/DummyTest.java
+++ b/server/example/workflow-example/src/test/java/org/chillisp/server/DummyTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/AbstractActionHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/AbstractActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionMessage.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionMessage.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionRegistry.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionRegistry.java
@@ -2,9 +2,9 @@
 
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ActionKind.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ActionKind.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CenterAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CenterAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ChangeBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ChangeBoundsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CollapseExpandAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CollapseExpandAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CollapseExpandAllAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CollapseExpandAllAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ComputedBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ComputedBoundsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateConnectionOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateConnectionOperationAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateNodeOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateNodeOperationAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/DeleteElementOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/DeleteElementOperationAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ExecuteOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ExecuteOperationAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ExportSVGAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ExportSVGAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/FitToScreenAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/FitToScreenAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/MoveOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/MoveOperationAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/OpenAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/OpenAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsChangeHintsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsChangeHintsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestExportSvgAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestExportSvgAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestLayersAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestLayersAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestModelAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestMoveHintsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestMoveHintsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestOperationsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestOperationsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestPopupModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestPopupModelAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SaveModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SaveModelAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SelectAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SelectAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SelectAllAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SelectAllAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ServerStatusAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ServerStatusAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetBoundsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetBoundsChangeHintsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetBoundsChangeHintsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetLayersAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetLayersAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetModelAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetMoveHintsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetMoveHintsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetOperationsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetOperationsAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetPopupModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetPopupModelAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ToogleLayerAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ToogleLayerAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/UpdateModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/UpdateModelAction.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/ModelFactory.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/ModelFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/PopupModelFactory.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/PopupModelFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/GsonConfigurator.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/GsonConfigurator.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/SModelElementTypeAdapter.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/SModelElementTypeAdapter.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageClient.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageClient.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License v2.0
  *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ *  http://www.eclipse.org/legal/epl-v20.html
  *    
  *  Contributors:
  *  	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageClientAware.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageClientAware.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License v2.0
  *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ *  http://www.eclipse.org/legal/epl-v20.html
  *    
  *  Contributors:
  *  	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageServer.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageServer.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelElementOpenListener.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelElementOpenListener.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelExpansionListener.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelExpansionListener.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelSelectionListener.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelSelectionListener.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelState.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelState.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelStateProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelStateProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelTypeConfiguration.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelTypeConfiguration.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/Operation.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/Operation.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/OperationConfiguration.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/OperationConfiguration.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/OperationHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/OperationHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/OperationKind.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/OperationKind.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/ActionHandlerProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/ActionHandlerProvider.java
@@ -3,9 +3,9 @@ package com.eclipsesource.glsp.api.provider;
 
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/ActionProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/ActionProvider.java
@@ -2,9 +2,9 @@
 
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/OperationHandlerProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/OperationHandlerProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Philip Langer - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/BoundsChangeHint.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/BoundsChangeHint.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/DragAndDropHint.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/DragAndDropHint.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Layer.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Layer.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Match.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Match.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/LayoutUtil.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/LayoutUtil.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/ModelOptions.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/ModelOptions.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License v2.0
  *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ *  http://www.eclipse.org/legal/epl-v20.html
  *    
  *  Contributors:
  *  	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/SModelIndex.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/SModelIndex.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGraphicalLanguageServer.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGraphicalLanguageServer.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerLauncher.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerLauncher.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License v2.0
  *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ *  http://www.eclipse.org/legal/epl-v20.html
  *    
  *  Contributors:
  *  	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestOperationsHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestOperationsHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SelectActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SelectActionHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/FileBasedModelFactory.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/FileBasedModelFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/ModelStateImpl.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/ModelStateImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/CreateNodeOperationHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/CreateNodeOperationHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/DeleteHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/DeleteHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/MoveNodeHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/MoveNodeHandler.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Camille Letavernier - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionHandlerProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionHandlerProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Copyright (c) 2018 EclipseSource Services GmbH and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-v20.html
  *   
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation


### PR DESCRIPTION
Update the coypright headers of all .java and .ts files to EPL2.0  (previous EPL1.0)