### PR TITLE
Extract OperationService binding  from theia-glsp

### DIFF
--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-manager.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-diagram-manager.ts
@@ -9,9 +9,10 @@
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
 import { EditorPreferences } from "@theia/editor/lib/browser";
-import { inject, injectable } from "inversify";
+import { inject, injectable, Container } from "inversify";
 import { DiagramManagerImpl, DiagramWidgetFactory } from "theia-glsp/lib";
 import { GLSPDiagramWidget } from "./glsp-diagram-widget";
+import { OP_TYPES, OperationService } from "glsp-sprotty/lib";
 
 @injectable()
 export abstract class GLSPDiagramManager extends DiagramManagerImpl {
@@ -19,8 +20,18 @@ export abstract class GLSPDiagramManager extends DiagramManagerImpl {
     @inject(EditorPreferences)
     protected readonly editorPreferences: EditorPreferences;
 
+    @inject(OP_TYPES.OperationService) protected operationService: OperationService
     protected get diagramWidgetFactory(): DiagramWidgetFactory {
         return options => new GLSPDiagramWidget(options, this.editorPreferences);
     }
 
+
+    protected createDiagramContainer(containerId: string): Container {
+        const diContainer = super.createDiagramContainer(containerId);
+        if (diContainer.isBound(OP_TYPES.OperationService)) {
+            diContainer.rebind<OperationService>(OP_TYPES.OperationService).toConstantValue(this.operationService)
+        }
+        return diContainer
+
+    }
 }

--- a/client/packages/glsp-theia-extension/src/browser/frontend-extension.ts
+++ b/client/packages/glsp-theia-extension/src/browser/frontend-extension.ts
@@ -17,6 +17,7 @@ import { GraphicalLanguageClientContribution } from "./language/graphical-langau
 import { GraphicalLanguageClientFactory } from "./language/graphical-language-client";
 import { GraphicalLanguageClientProvider, GraphicalLanguageClientProviderImpl } from "./language/graphical-language-client-provider";
 import { GraphicalLanguagesFrontendContribution } from "./language/graphical-languages-frontend-contribution";
+import { OP_TYPES, OperationServiceImpl } from "glsp-sprotty/lib";
 export default new ContainerModule(bind => {
 
     bind(GraphicalLanguageClientFactory).toSelf().inSingletonScope();
@@ -28,5 +29,6 @@ export default new ContainerModule(bind => {
     bind(GraphicalLanguageClientProvider).toDynamicValue(ctx => ctx.container.get(GraphicalLanguageClientProviderImpl)).inSingletonScope()
 
     bind(GLSPTheiaSprottyConnector).toSelf().inSingletonScope();
+    bind(OP_TYPES.OperationService).to(OperationServiceImpl).inSingletonScope()
 
 });


### PR DESCRIPTION
This is a preparation PR for #20. 

Extracts the (re)-binding of the OperationService to the SprottyDI container from the theia-glsp submodule. 
This is glsp-specific code (i.e. palette specific) and should not be in the general theia-sprotty glue code repository

Our contributions to the glue code repository for now are :
* Extraction of a generic TheiaSprottyConnector
* Adaption of the existing TheiaSprottyConnector to conform to this interface (and renaming to LSPTheiaSprottyConnector)
* Implementation of TheiaSelectionConnector