### PR TITLE
Implement server side handling of multiple clients/diagrams #39

### DIFF
--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/AbstractActionHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/AbstractActionHandler.java
@@ -18,7 +18,6 @@ import com.eclipsesource.glsp.api.model.ModelStateProvider;
 
 public abstract class AbstractActionHandler implements ActionHandler {
 
-	private ModelStateProvider modelStateProvider;
 
 	protected abstract Collection<Action> handleableActionsKinds();
 
@@ -32,14 +31,8 @@ public abstract class AbstractActionHandler implements ActionHandler {
 	 * Processes and action and returns the response action which should be send to
 	 * the client. If no response to the client is need a NoOpAction is returned
 	 */
-	public abstract Optional<Action> execute(Action action);
+	public abstract Optional<Action> execute(Action action,ModelState modelState);
 
-	public void setModelStateProvider(ModelStateProvider modelStateProvider) {
-		this.modelStateProvider = modelStateProvider;
-	}
 
-	protected ModelState getModelState() {
-		return modelStateProvider.getModelState();
-	}
 
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionHandler.java
@@ -12,14 +12,12 @@ package com.eclipsesource.glsp.api.action;
 
 import java.util.Optional;
 
-import com.eclipsesource.glsp.api.model.ModelStateProvider;
+import com.eclipsesource.glsp.api.model.ModelState;
 
 public interface ActionHandler {
-	
+
 	public boolean handles(Action action);
 
-	public Optional<Action> execute(Action action);
-
-	public void setModelStateProvider(ModelStateProvider provider);
+	public Optional<Action> execute(Action action, ModelState modelState);
 
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionRegistry.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionRegistry.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import com.eclipsesource.glsp.api.model.ModelStateProvider;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.provider.ActionHandlerProvider;
 import com.eclipsesource.glsp.api.provider.ActionProvider;
 import com.google.inject.Inject;
@@ -58,7 +58,6 @@ public class ActionRegistry {
 		});
 	}
 
-	
 	public Set<Action> getAllActions() {
 		return Collections.unmodifiableSet(registeredActions);
 	}
@@ -80,11 +79,10 @@ public class ActionRegistry {
 	 * @param action Action which should be processed
 	 * @return true if a registered consumer was found and the action was accepted
 	 */
-	public Optional<Action> delegateToHandler(Action action, ModelStateProvider modelStateProvider) {
+	public Optional<Action> delegateToHandler(Action action, ModelState modelState) {
 		ActionHandler handler = actionHandlers.get(action.getKind());
 		if (handler != null) {
-			handler.setModelStateProvider(modelStateProvider);
-			return handler.execute(action);
+			return handler.execute(action, modelState);
 		}
 		return Optional.empty();
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -34,7 +34,6 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(GraphicalLanguageServer.class).to(bindGraphicalLanguageServer());
 		bind(PopupModelFactory.class).to(bindPopupModelFactory());
 		bind(ModelFactory.class).to(bindModelFactory());
-		bind(ModelState.class).to(bindModelState());
 		bind(ModelSelectionListener.class).to(bindModelSelectionListener());
 		bind(ModelExpansionListener.class).to(bindModelExpansionListener());
 		bind(ModelElementOpenListener.class).to(bindModelElementOpenListener());
@@ -47,10 +46,7 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(ServerCommandHandlerProvider.class).to(bindServerCommandHandler());
 	}
 
-
 	protected abstract Class<? extends GraphicalLanguageServer> bindGraphicalLanguageServer();
-
-	protected abstract Class<? extends ModelState> bindModelState();
 
 	protected Class<? extends ActionProvider> bindActionProvider() {
 		return ActionProvider.NullImpl.class;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelStateProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelStateProvider.java
@@ -11,7 +11,13 @@
 package com.eclipsesource.glsp.api.model;
 
 public interface ModelStateProvider {
-	
-	ModelState getModelState();
+	/**
+	 * Returns the model state for a given clientId. Note that each sprotty diagram
+	 * is counted as an individual client.
+	 * 
+	 * @param clientId clientId/widgetId
+	 * @return the corresponding model state
+	 */
+	ModelState getModelState(String clientId);
 
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGraphicalLanguageServer.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGraphicalLanguageServer.java
@@ -10,8 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.server;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
 
@@ -23,6 +25,7 @@ import com.eclipsesource.glsp.api.action.ActionRegistry;
 import com.eclipsesource.glsp.api.jsonrpc.GraphicalLanguageClient;
 import com.eclipsesource.glsp.api.jsonrpc.GraphicalLanguageServer;
 import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.server.model.ModelStateImpl;
 
 import io.typefox.sprotty.api.ServerStatus;
 
@@ -31,16 +34,14 @@ public class DefaultGraphicalLanguageServer implements GraphicalLanguageServer {
 	static Logger log = Logger.getLogger(DefaultGraphicalLanguageServer.class);
 
 	private ServerStatus status;
-	private String clientId;
 	private ActionRegistry actionRegistry;
-	private ModelState modelState;
-
 	private GraphicalLanguageClient clientProxy;
+	private Map<String, ModelState> clientModelStates;
 
 	@Inject
-	public DefaultGraphicalLanguageServer(ActionRegistry actionRegistry, ModelState modelState) {
+	public DefaultGraphicalLanguageServer(ActionRegistry actionRegistry) {
 		this.actionRegistry = actionRegistry;
-		this.modelState = modelState;
+		clientModelStates = new ConcurrentHashMap<>();
 	}
 
 	@Override
@@ -55,21 +56,20 @@ public class DefaultGraphicalLanguageServer implements GraphicalLanguageServer {
 	@Override
 	public void process(ActionMessage message) {
 		log.debug("process " + message);
-		if (this.clientId == null) {
-			clientId = message.getClientId();
-		}
-		if (clientId.equals(message.getClientId())) {
-			Action requestAction = message.getAction();
-			if (actionRegistry.hasHandler(requestAction)) {
-				Optional<Action> responseOpt = actionRegistry.delegateToHandler(requestAction, this);
-				if (responseOpt.isPresent()) {
-					ActionMessage response = new ActionMessage(clientId, responseOpt.get());
-					clientProxy.process(response);
-				}
-			} else {
-				log.warn("No action handler registered for action kind: \"" + message.getAction().getKind() + "\"");
+		String clientId = message.getClientId();
+		ModelState modelState = getModelState(clientId);
+
+		Action requestAction = message.getAction();
+		if (actionRegistry.hasHandler(requestAction)) {
+			Optional<Action> responseOpt = actionRegistry.delegateToHandler(requestAction, modelState);
+			if (responseOpt.isPresent()) {
+				ActionMessage response = new ActionMessage(clientId, responseOpt.get());
+				clientProxy.process(response);
 			}
+		} else {
+			log.warn("No action handler registered for action kind: \"" + message.getAction().getKind() + "\"");
 		}
+
 	}
 
 	@Override
@@ -89,7 +89,12 @@ public class DefaultGraphicalLanguageServer implements GraphicalLanguageServer {
 	}
 
 	@Override
-	public ModelState getModelState() {
+	public synchronized ModelState getModelState(String clientId) {
+		ModelState modelState = clientModelStates.get(clientId);
+		if (modelState == null) {
+			modelState = new ModelStateImpl();
+			clientModelStates.put(clientId, modelState);
+		}
 		return modelState;
 	}
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
@@ -44,9 +44,4 @@ public abstract class ServerModule extends GLSPModule {
 		return DefaultGraphicalLanguageServer.class;
 	}
 
-	@Override
-	protected Class<? extends ModelState> bindModelState() {
-		return ModelStateImpl.class;
-	}
-
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
@@ -21,6 +21,7 @@ import com.eclipsesource.glsp.api.action.kind.ActionKind;
 import com.eclipsesource.glsp.api.action.kind.CollapseExpandAction;
 import com.eclipsesource.glsp.api.action.kind.CollapseExpandAllAction;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.google.inject.Inject;
 
 import io.typefox.sprotty.api.SModelIndex;
@@ -35,22 +36,22 @@ public class CollapseExpandActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		switch (action.getKind()) {
 		case ActionKind.COLLAPSE_EXPAND:
-			return handleCollapseExpandAction((CollapseExpandAction) action);
+			return handleCollapseExpandAction((CollapseExpandAction) action, modelState);
 		case ActionKind.COLLAPSE_EXPAND_ALL:
-			return handleCollapseExpandAllAction((CollapseExpandAllAction) action);
+			return handleCollapseExpandAllAction((CollapseExpandAllAction) action, modelState);
 		default:
 			return Optional.empty();
 		}
 	}
 
-	private Optional<Action> handleCollapseExpandAllAction(CollapseExpandAllAction action) {
-		Set<String> expandedElements = getModelState().getExpandedElements();
+	private Optional<Action> handleCollapseExpandAllAction(CollapseExpandAllAction action, ModelState modelState) {
+		Set<String> expandedElements = modelState.getExpandedElements();
 		expandedElements.clear();
 		if (action.isExpand()) {
-			new SModelIndex(getModelState().getCurrentModel()).allIds().forEach(id -> expandedElements.add(id));
+			new SModelIndex(modelState.getCurrentModel()).allIds().forEach(id -> expandedElements.add(id));
 		}
 		if (expansionListener != null) {
 			expansionListener.expansionChanged(action);
@@ -58,8 +59,8 @@ public class CollapseExpandActionHandler extends AbstractActionHandler {
 		return Optional.empty();
 	}
 
-	private Optional<Action> handleCollapseExpandAction(CollapseExpandAction action) {
-		Set<String> expandedElements = getModelState().getExpandedElements();
+	private Optional<Action> handleCollapseExpandAction(CollapseExpandAction action, ModelState modelState) {
+		Set<String> expandedElements = modelState.getExpandedElements();
 		if (action.getCollapseIds() != null) {
 			expandedElements.removeAll(Arrays.asList(action.getCollapseIds()));
 		}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.ComputedBoundsAction;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.LayoutUtil;
 import com.google.inject.Inject;
 
@@ -32,15 +33,15 @@ public class ComputedBoundsActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		if (action instanceof ComputedBoundsAction) {
 			ComputedBoundsAction computedBoundsAction = (ComputedBoundsAction) action;
 
 			synchronized (submissionHandler.getModelLock()) {
-				SModelRoot model = getModelState().getCurrentModel();
+				SModelRoot model = modelState.getCurrentModel();
 				if (model != null && model.getRevision() == computedBoundsAction.getRevision()) {
 					LayoutUtil.applyBounds(model, computedBoundsAction);
-					return submissionHandler.handleSubmission(model, true, getModelState());
+					return submissionHandler.handleSubmission(model, true, modelState);
 				}
 			}
 		}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
@@ -20,6 +20,7 @@ import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.OpenAction;
 import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
+import com.eclipsesource.glsp.api.model.ModelState;
 
 public class OpenActionHandler extends AbstractActionHandler {
 	@Inject
@@ -31,7 +32,7 @@ public class OpenActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		if (action instanceof OpenAction) {
 			if (modelElementOpenListener != null) {
 				modelElementOpenListener.elementOpened((OpenAction) action);

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
@@ -24,6 +24,7 @@ import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.DeleteElementOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.action.kind.MoveOperationAction;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.operations.OperationHandler;
 import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
 
@@ -42,24 +43,24 @@ public class OperationActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		switch (action.getKind()) {
 		case ActionKind.CREATE_NODE_OPERATION:
 		case ActionKind.CREATE_CONNECTION_OPERATION:
 		case ActionKind.DELETE_ELEMENT_OPERATION:
 		case ActionKind.MOVE_OPERATION:
-			return doHandle((ExecuteOperationAction) action);
+			return doHandle((ExecuteOperationAction) action, modelState);
 		default:
 			return Optional.empty();
 		}
 	}
 
-	public Optional<Action> doHandle(ExecuteOperationAction action) {
+	public Optional<Action> doHandle(ExecuteOperationAction action, ModelState modelState) {
 		if (operationHandlerProvider.isHandled(action)) {
 			OperationHandler handler = operationHandlerProvider.getOperationHandler(action).get();
-			Optional<SModelRoot> modelRoot = handler.execute(action, getModelState());
+			Optional<SModelRoot> modelRoot = handler.execute(action, modelState);
 			if (modelRoot.isPresent()) {
-				return submissionHandler.handleSubmission(modelRoot.get(), false, getModelState());
+				return submissionHandler.handleSubmission(modelRoot.get(), false, modelState);
 			}
 		}
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
@@ -18,6 +18,7 @@ import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
 import com.eclipsesource.glsp.api.factory.ModelFactory;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.ModelOptions;
 import com.eclipsesource.glsp.api.utils.ModelOptions.ParsedModelOptions;
 import com.google.inject.Inject;
@@ -34,15 +35,15 @@ public class RequestModelActionHandler extends AbstractActionHandler {
 
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		if (action instanceof RequestModelAction) {
 			RequestModelAction requestAction = (RequestModelAction) action;
 			ParsedModelOptions options = ModelOptions.parse(requestAction.getOptions());
-			getModelState().setNeedsClientLayout(options.needsClientLayout());
+			modelState.setNeedsClientLayout(options.needsClientLayout());
 			SModelRoot model = modelFactory.loadModel(requestAction);
-			getModelState().setCurrentModel(model);
-			getModelState().setOptions(options);
-			return submissionHandler.handleSubmission(model, false, getModelState());
+			modelState.setCurrentModel(model);
+			modelState.setOptions(options);
+			return submissionHandler.handleSubmission(model, false, modelState);
 		}
 		return Optional.empty();
 	}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestOperationsHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestOperationsHandler.java
@@ -18,6 +18,7 @@ import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestOperationsAction;
 import com.eclipsesource.glsp.api.action.kind.SetOperationsAction;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.operations.Operation;
 import com.eclipsesource.glsp.api.operations.OperationConfiguration;
 import com.google.inject.Inject;
@@ -32,7 +33,7 @@ public class RequestOperationsHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		if (action instanceof RequestOperationsAction) {
 			RequestOperationsAction requestAction = (RequestOperationsAction) action;
 			Optional<Operation[]> operations = Optional.ofNullable(operationConfiguration)

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
@@ -19,6 +19,7 @@ import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
 import com.eclipsesource.glsp.api.action.kind.SetPopupModelAction;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.google.inject.Inject;
 
@@ -35,10 +36,10 @@ public class RequestPopupModelActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		if (action instanceof RequestPopupModelAction) {
 			RequestPopupModelAction requestAction = (RequestPopupModelAction) action;
-			SModelRoot model = getModelState().getCurrentModel();
+			SModelRoot model = modelState.getCurrentModel();
 			SModelElement element = SModelIndex.find(model, requestAction.getElementId());
 			if (popupModelFactory != null) {
 				SModelRoot popupModel = popupModelFactory.createPopuModel(element, requestAction);

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
@@ -30,7 +30,7 @@ import com.google.inject.Inject;
 import io.typefox.sprotty.api.SModelRoot;
 
 public class SaveModelActionHandler extends AbstractActionHandler {
-	private static final Logger LOG= Logger.getLogger(SaveModelActionHandler.class);
+	private static final Logger LOG = Logger.getLogger(SaveModelActionHandler.class);
 	private static final String FILE_PREFIX = "file://";
 
 	@Inject
@@ -42,11 +42,11 @@ public class SaveModelActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action, ModelState modelState) {
 		if (action instanceof SaveModelAction) {
 			SaveModelAction saveAction = (SaveModelAction) action;
 			if (saveAction != null) {
-				saveModelState(getModelState());
+				saveModelState(modelState);
 			}
 		}
 		return Optional.empty();

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SelectActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SelectActionHandler.java
@@ -21,6 +21,7 @@ import com.eclipsesource.glsp.api.action.kind.ActionKind;
 import com.eclipsesource.glsp.api.action.kind.SelectAction;
 import com.eclipsesource.glsp.api.action.kind.SelectAllAction;
 import com.eclipsesource.glsp.api.model.ModelSelectionListener;
+import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.google.inject.Inject;
 
@@ -34,22 +35,22 @@ public class SelectActionHandler extends AbstractActionHandler {
 	}
 
 	@Override
-	public Optional<Action> execute(Action action) {
+	public Optional<Action> execute(Action action,ModelState modelState) {
 		switch (action.getKind()) {
 		case ActionKind.SELECT:
-			return handleSelectAction((SelectAction) action);
+			return handleSelectAction((SelectAction) action, modelState);
 		case ActionKind.SELECT_ALL:
-			return handleSelectAllAction((SelectAllAction) action);
+			return handleSelectAllAction((SelectAllAction) action,modelState);
 		default:
 			return Optional.empty();
 		}
 
 	}
 
-	private Optional<Action> handleSelectAllAction(SelectAllAction action) {
-		Set<String> selectedElements = getModelState().getSelectedElements();
+	private Optional<Action> handleSelectAllAction(SelectAllAction action,ModelState modelState) {
+		Set<String> selectedElements = modelState.getSelectedElements();
 		if (action.isSelect()) {
-			new SModelIndex(getModelState().getCurrentModel()).allIds().forEach(id -> selectedElements.add(id));
+			new SModelIndex(modelState.getCurrentModel()).allIds().forEach(id -> selectedElements.add(id));
 		} else
 			selectedElements.clear();
 		if (modelSelectionListener != null) {
@@ -58,8 +59,8 @@ public class SelectActionHandler extends AbstractActionHandler {
 		return Optional.empty();
 	}
 
-	private Optional<Action> handleSelectAction(SelectAction action) {
-		Set<String> selectedElements = getModelState().getSelectedElements();
+	private Optional<Action> handleSelectAction(SelectAction action,ModelState modelState) {
+		Set<String> selectedElements = modelState.getSelectedElements();
 		if (action.getDeselectedElementsIDs() != null) {
 			selectedElements.removeAll(Arrays.asList(action.getDeselectedElementsIDs()));
 		}


### PR DESCRIPTION
This PR enables the handling of multiple clients/diagram with one instance of DefaultGraphicalLanguageServer.

For each connected client the server maintains an own model state. The  state object is chosen via clientId of the actionMessage and then delegated to the corresponding action handler. 

This partly fixes #39. Selecting a tool from the palette doesn't work reliably with multiple clients (probably related to the Operation Service handling). But since this is a client side problem I will open a  separate issue once this is merged. 
In addition, reopening a diagram doesn't work yet but I opened #76 for that.