### PR TITLE
Add travis deployment configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ git:
 before_install:
   - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
   - git submodule update --init --recursive
-
-branches:
-  only:
-  - master
-  - ci-configuration-test
-  
 matrix:
   include:
     - language: java
@@ -23,6 +17,15 @@ matrix:
       install: true
       script:
         - mvn clean verify
+      branches:
+        only:
+        - master
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script: bash ../scripts/deployMaven.sh
+        on:
+          branch: master
 
     - language: node_js
       node_js:
@@ -33,3 +36,16 @@ matrix:
         yarn: true
         directories:
           - node_modules
+      before_deploy:
+      - printf "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n" >> ~/.npmrc
+      - yarn
+      branches:
+        only:
+        - master
+      deploy:
+        provider: script
+        script: bash ../scripts/deployNPM.sh
+        on:
+          branch: master
+        skip_cleanup: true
+

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "rebuild:electron": "theia rebuild:electron",
     "publish": "yarn && yarn publish:latest",
     "watch": "lerna-watch",
-    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git --force-publish"
+    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git --force-publish",
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary=next --npm-tag=next --force-publish --skip-git --yes"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/scripts/deployMaven.sh
+++ b/scripts/deployMaven.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if 	git diff --name-only HEAD^| grep -q "^server" 
+
+then 
+	echo "Deploy maven snapshot plugins"
+	cd ../server
+	mvn deploy --settings ./settings.xml -Dmaven.test.skip=true
+else	echo "No maven pacakges have been changed. Skip deployment"
+fi
+

--- a/scripts/deployNPM.sh
+++ b/scripts/deployNPM.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if 	git diff --name-only HEAD^| grep -q "^client" 
+
+then 
+	echo "Deploy next-packages to npm"
+	cd ../client
+	yarn run publish:next
+else	echo "No NPM packages have been changed. Skip deployment"
+fi
+

--- a/server/settings.xml
+++ b/server/settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Updates Travis configuration and adds deployment steps:
* Successful builds on master that affect npm code (i.e. file changes in client directory) will trigger deployment of the glsp npm packages with the "next" tag (i.e. snapshot release)
* Successful builds on master that affect java code (i.e file changes in the server directors) will trigger
deployment of the maven modules to sonatype snapshot repository)
