### PR TITLE
Feature for executing commands on server side

### DIFF
--- a/client/examples/workspace/example1.wf
+++ b/client/examples/workspace/example1.wf
@@ -33,6 +33,7 @@
               },
               "type": "icon",
               "id": "task1_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "M",
@@ -81,6 +82,7 @@
               },
               "type": "icon",
               "id": "task2_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "A",
@@ -128,6 +130,7 @@
               },
               "type": "icon",
               "id": "task3_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "M",
@@ -176,6 +179,7 @@
               },
               "type": "icon",
               "id": "task4_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "A",
@@ -224,6 +228,7 @@
               },
               "type": "icon",
               "id": "task5_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "M",
@@ -272,6 +277,7 @@
               },
               "type": "icon",
               "id": "task6_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "M",
@@ -320,6 +326,7 @@
               },
               "type": "icon",
               "id": "task7_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "M",
@@ -368,6 +375,7 @@
               },
               "type": "icon",
               "id": "task8_icon",
+              "commandId":"simulate-command",
               "children": [
                 {
                   "text": "M",

--- a/client/packages/glsp-sprotty/src/features/execute/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/execute/di.config.ts
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+import { ContainerModule } from "inversify";
+import { TYPES } from "sprotty/lib";
+import { ExecuteCommandMouseListener } from "./execute-command";
+
+const executeCommandModule = new ContainerModule(bind => {
+    bind(TYPES.MouseListener).to(ExecuteCommandMouseListener);
+})
+
+export default executeCommandModule;

--- a/client/packages/glsp-sprotty/src/features/execute/execute-command.ts
+++ b/client/packages/glsp-sprotty/src/features/execute/execute-command.ts
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+import { Action, MouseListener, SModelElement, findParentByFeature } from "sprotty/lib";
+import { isCommandExecutor } from "./model";
+
+export class ExecuteServerCommandAction implements Action {
+    static readonly KIND = "executeServerCommand"
+    kind = ExecuteServerCommandAction.KIND;
+
+    constructor(public readonly commandId: String) { }
+}
+
+export class ExecuteCommandMouseListener extends MouseListener {
+    doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+        const result: Action[] = [];
+        let commandExecutorTarget = findParentByFeature(target, isCommandExecutor)
+        if (commandExecutorTarget) {
+            result.push(new ExecuteServerCommandAction(commandExecutorTarget.commandId));
+        }
+
+        return result;
+    }
+
+}

--- a/client/packages/glsp-sprotty/src/features/execute/execute-command.ts
+++ b/client/packages/glsp-sprotty/src/features/execute/execute-command.ts
@@ -14,16 +14,15 @@ import { isCommandExecutor } from "./model";
 export class ExecuteServerCommandAction implements Action {
     static readonly KIND = "executeServerCommand"
     kind = ExecuteServerCommandAction.KIND;
+    constructor(public readonly commandId: String, public readonly options?: { [key: string]: string }) { }
 
-    constructor(public readonly commandId: String) { }
 }
-
 export class ExecuteCommandMouseListener extends MouseListener {
     doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
         const result: Action[] = [];
         let commandExecutorTarget = findParentByFeature(target, isCommandExecutor)
         if (commandExecutorTarget) {
-            result.push(new ExecuteServerCommandAction(commandExecutorTarget.commandId));
+            result.push(new ExecuteServerCommandAction(commandExecutorTarget.commandId, { invokerId: commandExecutorTarget.id }));
         }
 
         return result;

--- a/client/packages/glsp-sprotty/src/features/execute/model.ts
+++ b/client/packages/glsp-sprotty/src/features/execute/model.ts
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+import { SModelExtension, SModelElement } from "sprotty/lib";
+
+export const executeCommandFeature = Symbol('executeFeature');
+
+export interface CommandExecutor extends SModelExtension {
+    commandId: string
+}
+
+export function isCommandExecutor(element: SModelElement): element is SModelElement & CommandExecutor {
+    return element.hasFeature(executeCommandFeature)
+}

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -8,6 +8,8 @@ export * from './features/palette/delete-tool'
 export * from './features/palette/operation-service'
 export * from './features/tool/move-tool'
 export * from './features/tool/execute-tool'
+export * from './features/execute/model'
+export * from './features/execute/execute-command'
 
 export * from './lib/model'
 
@@ -18,7 +20,8 @@ export * from './utils/operation'
 import saveModule from './features/save/di.config'
 import paletteModule from './features/palette/di.config'
 import moveToolModule from './features/tool/di.config'
+import executeModule from './features/execute/di.config'
 
-export { saveModule, paletteModule, moveToolModule }
+export { saveModule, paletteModule, moveToolModule, executeModule }
 
 

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -9,7 +9,7 @@
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
 import { Emitter, Event } from "@theia/core/lib/common";
-import { Action, ActionHandlerRegistry, ActionMessage, CreateConnectionAction, DeleteElementAction, ExecuteNodeCreationToolAction, IActionDispatcher, ICommand, ILogger, ModelSource, MoveElementAction, RequestOperationsAction, SaveModelAction, SetOperationsCommand, SModelStorage, SwitchEditModeCommand, TYPES, ViewerOptions } from "glsp-sprotty/lib";
+import { Action, ActionHandlerRegistry, ActionMessage, CreateConnectionAction, DeleteElementAction, ExecuteNodeCreationToolAction, IActionDispatcher, ICommand, ILogger, ModelSource, MoveElementAction, RequestOperationsAction, SaveModelAction, SetOperationsCommand, SModelStorage, SwitchEditModeCommand, TYPES, ViewerOptions, ExecuteServerCommandAction } from "glsp-sprotty/lib";
 import { inject, injectable } from "inversify";
 import { TheiaDiagramServer } from "theia-glsp/lib";
 
@@ -38,6 +38,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         registry.register(CreateConnectionAction.KIND, this)
         registry.register(MoveElementAction.KIND, this)
         registry.register(DeleteElementAction.KIND, this)
+        registry.register(ExecuteServerCommandAction.KIND, this)
         // Register an empty handler for SwitchEditMode, to avoid runtime exceptions.
         // We don't want to support SwitchEditMode, but sprotty still sends some corresponding
         // actions.

--- a/client/packages/workflow-sprotty/src/di.config.ts
+++ b/client/packages/workflow-sprotty/src/di.config.ts
@@ -22,6 +22,7 @@ import { WeightedEdgeView, IconView, ActivityNodeView, TaskNodeView, WorkflowEdg
 import { WorkflowModelFactory } from "./model-factory";
 import { TaskNode, WeightedEdge, Icon, ActivityNode } from "./model";
 import { saveModule, paletteModule, moveToolModule, GLSPGraph } from "glsp-sprotty/lib"
+import executeCommandModule from "glsp-sprotty/lib/features/execute/di.config";
 
 
 const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -52,7 +53,7 @@ export default function createContainer(widgetId: string): Container {
 
     container.load(defaultModule, selectModule, moveModule, boundsModule, undoRedoModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
-        workflowDiagramModule, saveModule, paletteModule, moveToolModule);
+        workflowDiagramModule, saveModule, paletteModule, moveToolModule, executeCommandModule);
 
 
     overrideViewerOptions(container, {

--- a/client/packages/workflow-sprotty/src/model.ts
+++ b/client/packages/workflow-sprotty/src/model.ts
@@ -8,7 +8,7 @@
  * Contributors:
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
-import { RectangularNode, SEdge, LayoutContainer, SShapeElement, Bounds, boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature, Expandable, expandFeature, Point, SParentElement, toRadians, } from "glsp-sprotty/lib";
+import { RectangularNode, SEdge, LayoutContainer, SShapeElement, Bounds, boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature, Expandable, expandFeature, Point, SParentElement, toRadians, CommandExecutor, isCommandExecutor, executeCommandFeature, } from "glsp-sprotty/lib";
 import { ActivityNodeSchema } from "./model-schema";
 
 export class TaskNode extends RectangularNode implements Expandable {
@@ -74,7 +74,8 @@ export class ActivityNode extends RotatableRectangularNode {
 }
 
 
-export class Icon extends SShapeElement implements LayoutContainer {
+export class Icon extends SShapeElement implements LayoutContainer, CommandExecutor {
+    commandId: string
     layout: string
     layoutOptions?: { [key: string]: string | number | boolean; };
     bounds: Bounds
@@ -84,6 +85,6 @@ export class Icon extends SShapeElement implements LayoutContainer {
     };
 
     hasFeature(feature: symbol): boolean {
-        return feature === boundsFeature || feature === layoutContainerFeature || feature === layoutableChildFeature || feature === fadeFeature;
+        return feature === executeCommandFeature || feature === boundsFeature || feature === layoutContainerFeature || feature === layoutableChildFeature || feature === fadeFeature;
     }
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
@@ -23,12 +23,12 @@ import com.eclipsesource.glsp.example.workflow.handler.CreateManualTaskHandler;
 import com.eclipsesource.glsp.example.workflow.handler.CreateMergeNodeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.CreateWeightedEdgeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.DeleteWorkflowElementHandler;
+import com.eclipsesource.glsp.example.workflow.handler.SimulateCommandHandler;
 import com.eclipsesource.glsp.server.ServerModule;
 import com.eclipsesource.glsp.server.operationhandler.DeleteHandler;
 import com.eclipsesource.glsp.server.operationhandler.MoveNodeHandler;
 
 public class WorkflowServerRuntimeModule extends ServerModule {
-
 
 	@Override
 	public Class<? extends ModelTypeConfiguration> bindModelTypeConfiguration() {
@@ -71,6 +71,11 @@ public class WorkflowServerRuntimeModule extends ServerModule {
 		bindOperationHandler().to(DeleteWorkflowElementHandler.class);
 		bindOperationHandler().to(MoveNodeHandler.class);
 		bindOperationHandler().to(DeleteHandler.class);
+	}
+
+	@Override
+	protected void multiBindServerCommandHandlers() {
+		bindServerCommandHandler().to(SimulateCommandHandler.class);
 	}
 
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -61,6 +61,7 @@ public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 		Icon icon = new Icon();
 		icon.setId("task" + nodeCounter + "_icon");
 		icon.setLayout("stack");
+		icon.setCommandId(SimulateCommandHandler.SIMULATE_COMMAND_ID);
 		LayoutOptions layoutOptions = new LayoutOptions();
 		layoutOptions.setHAlign("center");
 		layoutOptions.setResizeContainer(false);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/SimulateCommandHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/SimulateCommandHandler.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr- initial API and implementation
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.workflow.handler;
+
+import static com.eclipsesource.glsp.api.utils.OptionsUtil.getValue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.log4j.Logger;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.handler.ServerCommandHandler;
+import com.eclipsesource.glsp.api.model.ModelState;
+
+import io.typefox.sprotty.api.SModelElement;
+
+public class SimulateCommandHandler implements ServerCommandHandler {
+	private static Logger logger = Logger.getLogger(SimulateCommandHandler.class);
+	public static final String SIMULATE_COMMAND_ID = "simulate-command";
+	public static final String OPTIONS_INVOKER_ID = "invokerId";
+
+	@Override
+	public boolean handles(String commandId) {
+		return SIMULATE_COMMAND_ID.equals(commandId);
+	}
+
+	@Override
+	public Optional<Action> execute(String commandId, Map<String, String> options, ModelState modelState) {
+		Optional<Action> result = Optional.empty();
+		if (SIMULATE_COMMAND_ID.equals(commandId)) {
+			getValue(options, OPTIONS_INVOKER_ID).ifPresent(id -> {
+				SModelElement invoker = modelState.getCurrentModelIndex().get(id);
+				if (invoker != null) {
+					logger.info("Start simulation of " + invoker.getId());
+					double duration = ThreadLocalRandom.current().nextDouble(0d, 10d);
+					logger.info("Task simulation finished within " + duration + " seconds");
+				}
+
+			});
+		}
+
+		return result;
+	}
+
+}

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/Icon.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/Icon.java
@@ -13,13 +13,22 @@ package com.eclipsesource.glsp.example.workflow.schema;
 import io.typefox.sprotty.api.Point;
 import io.typefox.sprotty.api.SShapeElement;
 
-public class Icon extends SShapeElement{
-	public static final String TYPE="icon";
+public class Icon extends SShapeElement {
+	public static final String TYPE = "icon";
 	private String layout;
-	
+	private String commandId;
+
 	public Icon() {
 		setType(Icon.TYPE);
 		setPosition(new Point());
+	}
+
+	public String getCommandId() {
+		return commandId;
+	}
+
+	public void setCommandId(String commandId) {
+		this.commandId = commandId;
 	}
 
 	public String getLayout() {
@@ -29,6 +38,5 @@ public class Icon extends SShapeElement{
 	public void setLayout(String layout) {
 		this.layout = layout;
 	}
-	
-	
+
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ExecuteServerCommandAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ExecuteServerCommandAction.java
@@ -10,31 +10,41 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.eclipsesource.glsp.api.action.Action;
 
 public class ExecuteServerCommandAction extends Action {
 
-	private String commandID;
+	private String commandId;
+	private Map<String, String> options;
 
 	public ExecuteServerCommandAction() {
 		super(ActionKind.EXECUTE_SERVER_COMMAND);
-
+		options= new HashMap<>();
 	}
 
-	public ExecuteServerCommandAction(String commandID) {
+	public ExecuteServerCommandAction(String commandId, Map<String, String> options) {
 		this();
-		this.commandID = commandID;
+		this.commandId = commandId;
+		this.options = options;
 	}
 
-	public String getCommandID() {
-		return commandID;
+	public String getCommandId() {
+		return commandId;
+	}
+
+	public Map<String, String> getOptions() {
+		return options;
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((commandID == null) ? 0 : commandID.hashCode());
+		result = prime * result + ((commandId == null) ? 0 : commandId.hashCode());
+		result = prime * result + ((options == null) ? 0 : options.hashCode());
 		return result;
 	}
 
@@ -47,10 +57,15 @@ public class ExecuteServerCommandAction extends Action {
 		if (getClass() != obj.getClass())
 			return false;
 		ExecuteServerCommandAction other = (ExecuteServerCommandAction) obj;
-		if (commandID == null) {
-			if (other.commandID != null)
+		if (commandId == null) {
+			if (other.commandId != null)
 				return false;
-		} else if (!commandID.equals(other.commandID))
+		} else if (!commandId.equals(other.commandId))
+			return false;
+		if (options == null) {
+			if (other.options != null)
+				return false;
+		} else if (!options.equals(other.options))
 			return false;
 		return true;
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/handler/ServerCommandHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/handler/ServerCommandHandler.java
@@ -12,12 +12,16 @@ package com.eclipsesource.glsp.api.handler;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.model.ModelState;
 
 public interface ServerCommandHandler extends Handler<String> {
 
-	default public void execute(String commandId) {
-		execute(commandId, Collections.emptyMap());
+	default public void execute(String commandId, ModelState modelState) {
+		execute(commandId, Collections.emptyMap(), modelState);
 	}
 
-	public void execute(String commandId, Map<String, String> options);
+	public Optional<Action> execute(String commandId, Map<String, String> options, ModelState modelState);
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelState.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelState.java
@@ -40,8 +40,7 @@ public interface ModelState {
 	boolean needsClientLayout();
 
 	void setNeedsClientLayout(boolean value);
-	
+
 	SModelIndex getCurrentModelIndex();
-	
 
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/HandlerProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/HandlerProvider.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import com.eclipsesource.glsp.api.handler.Handler;
 
 public interface HandlerProvider<E extends Handler<T>, T> {
-
+	
 	Set<E> getHandlers();
 
 	default boolean isHandled(T object) {

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/ModelOptions.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/ModelOptions.java
@@ -10,15 +10,16 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.utils;
 
+import static com.eclipsesource.glsp.api.utils.OptionsUtil.getBoolValue;
+import static com.eclipsesource.glsp.api.utils.OptionsUtil.getValue;
+
 import java.util.Map;
 import java.util.Optional;
-
-
 
 public final class ModelOptions {
 
 	public static final String NEEDS_CLIENT_LAYOUT = "needsClientLayout";
-	public static final Object SOURCE_URI = "sourceUri";
+	public static final String SOURCE_URI = "sourceUri";
 
 	private ModelOptions() {
 	}
@@ -32,12 +33,8 @@ public final class ModelOptions {
 		Optional<String> sourceUri;
 
 		private ParsedModelOptions(Map<String, String> options) {
-			if (options.containsKey(NEEDS_CLIENT_LAYOUT)) {
-				needsClientLayout = Boolean.parseBoolean(options.get(NEEDS_CLIENT_LAYOUT));
-			}
-			if (options.containsKey(SOURCE_URI)) {
-				sourceUri = Optional.of(options.get(SOURCE_URI));
-			}
+			needsClientLayout = getBoolValue(options, NEEDS_CLIENT_LAYOUT);
+			sourceUri = getValue(options, SOURCE_URI);
 		}
 
 		public boolean needsClientLayout() {

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/OptionsUtil.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/OptionsUtil.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+package com.eclipsesource.glsp.api.utils;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utility class for the handling of String-based option-maps
+ * 
+ * @author Tobias Ortmayr
+ *
+ */
+public class OptionsUtil {
+	private OptionsUtil() {
+
+	}
+
+	public static Optional<String> getValue(Map<String, String> options, String key) {
+		return Optional.ofNullable(options.get(key));
+	}
+
+	public static Optional<Integer> getIntValue(Map<String, String> options, String key) {
+		try {
+			return Optional.ofNullable(Integer.parseInt(options.get(key)));
+		} catch (NumberFormatException ex) {
+			return Optional.empty();
+		}
+	}
+
+	public static Optional<Float> getFloatValue(Map<String, String> options, String key) {
+		try {
+			return Optional.ofNullable(Float.parseFloat(options.get(key)));
+		} catch (NumberFormatException ex) {
+			return Optional.empty();
+		}
+	}
+
+	public static boolean getBoolValue(Map<String, String> options, String key) {
+		return Boolean.parseBoolean(options.get(key));
+	}
+}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
@@ -19,6 +19,7 @@ import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
 import com.eclipsesource.glsp.api.provider.ServerCommandHandlerProvider;
 import com.eclipsesource.glsp.server.actionhandler.CollapseExpandActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.ComputedBoundsActionHandler;
+import com.eclipsesource.glsp.server.actionhandler.ExecuteServerCommandActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.OpenActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.OperationActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestModelActionHandler;
@@ -83,6 +84,7 @@ public abstract class ServerModule extends GLSPModule {
 		bindActionHandler().to(RequestPopupModelActionHandler.class);
 		bindActionHandler().to(SaveModelActionHandler.class);
 		bindActionHandler().to(SelectActionHandler.class);
+		bindActionHandler().to(ExecuteServerCommandActionHandler.class);
 	}
 
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ExecuteServerCommandActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ExecuteServerCommandActionHandler.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+package com.eclipsesource.glsp.server.actionhandler;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.eclipsesource.glsp.api.action.AbstractActionHandler;
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.ExecuteServerCommandAction;
+import com.eclipsesource.glsp.api.handler.ServerCommandHandler;
+import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.api.provider.ServerCommandHandlerProvider;
+import com.google.inject.Inject;
+
+public class ExecuteServerCommandActionHandler extends AbstractActionHandler {
+	@Inject
+	ServerCommandHandlerProvider commandHandlerProvider;
+
+	@Override
+	protected Collection<Action> handleableActionsKinds() {
+		return Arrays.asList(new ExecuteServerCommandAction());
+	}
+
+	@Override
+	public Optional<Action> execute(Action action, ModelState modelState) {
+		if (action instanceof ExecuteServerCommandAction) {
+			ExecuteServerCommandAction commandAction = (ExecuteServerCommandAction) action;
+			Optional<ServerCommandHandler> handler = commandHandlerProvider.getHandler(commandAction.getCommandId());
+			if (handler.isPresent()) {
+				return handler.get().execute(commandAction.getCommandId(), commandAction.getOptions(), modelState);
+			}
+		}
+		return Optional.empty();
+	}
+
+}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
@@ -22,6 +22,7 @@ import com.eclipsesource.glsp.api.action.kind.ComputedBoundsAction;
 import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.DeleteElementOperationAction;
+import com.eclipsesource.glsp.api.action.kind.ExecuteServerCommandAction;
 import com.eclipsesource.glsp.api.action.kind.ExportSVGAction;
 import com.eclipsesource.glsp.api.action.kind.FitToScreenAction;
 import com.eclipsesource.glsp.api.action.kind.MoveOperationAction;
@@ -89,6 +90,7 @@ public class DefaultActionProvider implements ActionProvider {
 		defaultActions.add(new SetPopupModelAction());
 		defaultActions.add(new ToogleLayerAction());
 		defaultActions.add(new UpdateModelAction());
+		defaultActions.add(new ExecuteServerCommandAction());
 	}
 
 	@Override

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultServerCommandHandlerProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultServerCommandHandlerProvider.java
@@ -17,6 +17,7 @@ import com.eclipsesource.glsp.api.provider.ServerCommandHandlerProvider;
 import com.google.inject.Inject;
 
 public class DefaultServerCommandHandlerProvider implements ServerCommandHandlerProvider {
+	@Inject
 	private Set<ServerCommandHandler> handlers;
 
 	@Inject


### PR DESCRIPTION
This PR adds a sprotty feature extension which enables sprotty elements to act as command executor.
A commandExecutor has a command Id property. On double-click the commandExecutor sends a ExecuteServerCommandAction to the server.

* Implementation of the 'CommandExecutor" sprotty feature.
* Implementation and registration of the ExecuteServerCommand action on client/server side