### PR TITLE
 Rebase glsp on sprotty "next"

### DIFF
--- a/client/packages/glsp-sprotty/package.json
+++ b/client/packages/glsp-sprotty/package.json
@@ -6,7 +6,7 @@
     "src"
   ],
   "dependencies": {
-   "sprotty" :"latest"
+   "sprotty" :"next"
   },
   "devDependencies": {
     "rimraf": "latest",

--- a/client/packages/glsp-sprotty/src/features/tools/delete-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/delete-tool.ts
@@ -9,7 +9,7 @@
  * 	Philip Langer - initial API and implementation
  ******************************************************************************/
 import { inject, injectable } from "inversify";
-import { Action, isCtrlOrCmd, isSelectable, KeyListener, KeyTool, MouseListener, MouseTool, SModelElement, SModelRoot } from "sprotty/lib";
+import { Action, DeleteElementAction, isCtrlOrCmd, isSelectable, KeyListener, KeyTool, MouseListener, MouseTool, SModelElement, SModelRoot } from "sprotty/lib";
 import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
 import { EnableStandardToolsAction, Tool } from "./tool-manager";
 
@@ -39,13 +39,9 @@ export class DelKeyDeleteTool implements Tool {
 export class DeleteKeyListener extends KeyListener {
     keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Delete')) {
-            const actions: Action[] = [];
-            element.root.index.all()
-                .filter(e => isSelectable(e) && e.selected)
-                .filter(e => e.id != e.root.id)
-                .map(e => new DeleteElementAction(e.id))
-                .forEach(action => actions.push(action));
-            return actions;
+            const deleteElementIds = Array.from(element.root.index.all().filter(e => isSelectable(e) && e.selected)
+                .filter(e => e.id !== e.root.id).map(e => e.id))
+            return [new DeleteElementAction(deleteElementIds)]
         }
         return [];
     }
@@ -81,16 +77,10 @@ export class DeleteToolMouseListener extends MouseListener {
         }
 
         const result: Action[] = [];
-        result.push(new DeleteElementAction(target.id));
+        result.push(new DeleteElementAction([target.id]));
         if (!isCtrlOrCmd(event)) {
             result.push(new EnableStandardToolsAction());
         }
         return result;
     }
-}
-
-export class DeleteElementAction implements Action {
-    public static KIND = "executeOperation_delete-node";
-    kind = DeleteElementAction.KIND;
-    constructor(public elementId: string) { }
 }

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -9,7 +9,7 @@
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
 import { Emitter, Event } from "@theia/core/lib/common";
-import { Action, ActionHandlerRegistry, ActionMessage, CreateConnectionAction, DeleteElementAction, ExecuteNodeCreationToolAction, ExecuteServerCommandAction, IActionDispatcher, ICommand, ILogger, ModelSource, MoveElementAction, RequestOperationsAction, SaveModelAction, SetOperationsCommand, SModelStorage, SwitchEditModeCommand, TYPES, ViewerOptions } from "glsp-sprotty/lib";
+import { Action, ActionHandlerRegistry, ActionMessage, CreateConnectionAction, DeleteElementCommand, ExecuteNodeCreationToolAction, ExecuteServerCommandAction, IActionDispatcher, ICommand, ILogger, ModelSource, MoveElementAction, RequestOperationsAction, SaveModelAction, SetOperationsCommand, SModelStorage, SwitchEditModeCommand, TYPES, ViewerOptions } from "glsp-sprotty/lib";
 import { inject, injectable } from "inversify";
 import { TheiaDiagramServer } from "theia-glsp/lib";
 
@@ -37,7 +37,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         registry.register(ExecuteNodeCreationToolAction.KIND, this)
         registry.register(CreateConnectionAction.KIND, this)
         registry.register(MoveElementAction.KIND, this)
-        registry.register(DeleteElementAction.KIND, this)
+        registry.register(DeleteElementCommand.KIND, this)
         registry.register(ExecuteServerCommandAction.KIND, this)
         // Register an empty handler for SwitchEditMode, to avoid runtime exceptions.
         // We don't want to support SwitchEditMode, but sprotty still sends some corresponding

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7582,9 +7582,10 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sprotty@latest:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.4.2.tgz#10d4c17932a317990f15bba25957e021218c8adb"
+sprotty@next:
+  version "0.5.0-next.3be64bd"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.5.0-next.3be64bd.tgz#4c2a3ca05c58d85598fcd1d376918fbf44897df4"
+  integrity sha512-PWo2QeoAxk+WH6SSn05gg72h0A9ta+/yTtwmQFEGsIzu5xFOqDcp3ryAmiUoJCaCRsc8lVpD9D2efBo3xn6fOA==
   dependencies:
     file-saver "1.3.3"
     inversify "^4.3.0"

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ActionKind.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ActionKind.java
@@ -46,7 +46,7 @@ public final class ActionKind {
 	public static final String SAVE_MODEL = "saveModel";
 	public static final String CREATE_CONNECTION_OPERATION = EXECUTE_OPERATION + "_" + OperationKind.CREATE_CONNECTION;
 	public static final String CREATE_NODE_OPERATION = EXECUTE_OPERATION + "_" + OperationKind.CREATE_NODE;
-	public static final String DELETE_ELEMENT_OPERATION = EXECUTE_OPERATION + "_" + OperationKind.DELETE_ELEMENT;
+	public static final String DELETE_ELEMENT_OPERATION = "delete";
 	public static final String MOVE_OPERATION = EXECUTE_OPERATION + "_" + OperationKind.MOVE;
 	public static final String EXECUTE_SERVER_COMMAND = "executeServerCommand";
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/DeleteElementOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/DeleteElementOperationAction.java
@@ -10,34 +10,36 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
+import java.util.Arrays;
+
 import com.eclipsesource.glsp.api.operations.OperationKind;
 
 public class DeleteElementOperationAction extends ExecuteOperationAction {
 	
-	private String elementId;
+	private String[] elementIds;
 	
 	public DeleteElementOperationAction() {
 		super(ActionKind.DELETE_ELEMENT_OPERATION);
 	}
 	
-	public DeleteElementOperationAction(String elementId) {
+	public DeleteElementOperationAction(String[] elementIds) {
 		this();
-		this.elementId = elementId;
+		this.elementIds = elementIds;
 	}
 
-	public String getElementId() {
-		return elementId;
+	public String[] getElementIds() {
+		return elementIds;
 	}
 
-	public void setElementId(String elementId) {
-		this.elementId = elementId;
+	public void setElementIds(String[] elementIds) {
+		this.elementIds = elementIds;
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((elementId == null) ? 0 : elementId.hashCode());
+		result = prime * result + Arrays.hashCode(elementIds);
 		return result;
 	}
 
@@ -50,12 +52,11 @@ public class DeleteElementOperationAction extends ExecuteOperationAction {
 		if (getClass() != obj.getClass())
 			return false;
 		DeleteElementOperationAction other = (DeleteElementOperationAction) obj;
-		if (elementId == null) {
-			if (other.elementId != null)
-				return false;
-		} else if (!elementId.equals(other.elementId))
+		if (!Arrays.equals(elementIds, other.elementIds))
 			return false;
 		return true;
 	}
+
+
 
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/DeleteHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/DeleteHandler.java
@@ -15,8 +15,6 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.swing.text.ElementIterator;
-
 import org.apache.log4j.Logger;
 
 import com.eclipsesource.glsp.api.action.kind.DeleteElementOperationAction;


### PR DESCRIPTION
This changes rebases our implementation on the current sprotty version ("next") (as mentioned in #20)
Sprotty has  also introduced a <b> DeleteElementAction </b> which is now in conflict with the <b>DeleteElementAction</b> of GLSP. As a consequence I removed our Action definition and reused the action provided by sprotty. 
When working on issue #92 we should also check if there are other sprotty actions which we can reuse.