### PR TITLE
Update server side sprotty dependencies

### DIFF
--- a/server/example/workflow-example/pom.xml
+++ b/server/example/workflow-example/pom.xml
@@ -25,9 +25,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.typefox.sprotty</groupId>
-			<artifactId>diagram-layout-engine</artifactId>
-			<version>0.3.0</version>
+			<groupId>org.eclipse.sprotty</groupId>
+			<artifactId>org.eclipse.sprotty.layout</artifactId>
+			<version>0.5.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfiguration.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfiguration.java
@@ -13,19 +13,21 @@ package com.eclipsesource.glsp.example.workflow;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.sprotty.HtmlRoot;
+import org.eclipse.sprotty.PreRenderedElement;
+import org.eclipse.sprotty.SCompartment;
+import org.eclipse.sprotty.SEdge;
+import org.eclipse.sprotty.SGraph;
+import org.eclipse.sprotty.SLabel;
+import org.eclipse.sprotty.SModelElement;
+
 import com.eclipsesource.glsp.api.model.ModelTypeConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
 import com.eclipsesource.glsp.example.workflow.schema.Icon;
 import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
 import com.eclipsesource.glsp.example.workflow.schema.WeightedEdge;
 
-import io.typefox.sprotty.api.HtmlRoot;
-import io.typefox.sprotty.api.PreRenderedElement;
-import io.typefox.sprotty.api.SCompartment;
-import io.typefox.sprotty.api.SEdge;
-import io.typefox.sprotty.api.SGraph;
-import io.typefox.sprotty.api.SLabel;
-import io.typefox.sprotty.api.SModelElement;
+
 
 public class WorkflowModelTypeConfiguration implements ModelTypeConfiguration {
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowPopupFactory.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowPopupFactory.java
@@ -13,14 +13,14 @@ package com.eclipsesource.glsp.example.workflow;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import org.eclipse.sprotty.HtmlRoot;
+import org.eclipse.sprotty.PreRenderedElement;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
-
-import io.typefox.sprotty.api.HtmlRoot;
-import io.typefox.sprotty.api.PreRenderedElement;
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
 
 public class WorkflowPopupFactory implements PopupModelFactory {
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
@@ -25,8 +25,8 @@ import com.eclipsesource.glsp.example.workflow.handler.CreateWeightedEdgeHandler
 import com.eclipsesource.glsp.example.workflow.handler.DeleteWorkflowElementHandler;
 import com.eclipsesource.glsp.example.workflow.handler.SimulateCommandHandler;
 import com.eclipsesource.glsp.server.ServerModule;
-import com.eclipsesource.glsp.server.operationhandler.DeleteHandler;
 import com.eclipsesource.glsp.server.operationhandler.ChangeBoundsOperationHandler;
+import com.eclipsesource.glsp.server.operationhandler.DeleteHandler;
 
 public class WorkflowServerRuntimeModule extends ServerModule {
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateDecisionNodeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateDecisionNodeHandler.java
@@ -9,9 +9,11 @@
  * 	Camille Letavernier - initial API and implementation
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.handler;
-
 import java.util.Optional;
 import java.util.function.Function;
+
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SModelElement;
 
 import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
@@ -19,9 +21,6 @@ import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
-
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SModelElement;
 
 public class CreateDecisionNodeHandler extends CreateNodeOperationHandler {
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateEdgeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateEdgeHandler.java
@@ -13,6 +13,10 @@ package com.eclipsesource.glsp.example.workflow.handler;
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.SEdge;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+import org.eclipse.sprotty.SNode;
 
 import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
@@ -20,11 +24,6 @@ import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
-
-import io.typefox.sprotty.api.SEdge;
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
-import io.typefox.sprotty.api.SNode;
 
 public class CreateEdgeHandler implements OperationHandler {
 	private static Logger log= Logger.getLogger(CreateEdgeHandler.class);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateMergeNodeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateMergeNodeHandler.java
@@ -13,15 +13,15 @@ package com.eclipsesource.glsp.example.workflow.handler;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SModelElement;
+
 import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
-
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SModelElement;
 
 public class CreateMergeNodeHandler extends CreateNodeOperationHandler {
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -14,16 +14,16 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.eclipse.sprotty.LayoutOptions;
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SCompartment;
+import org.eclipse.sprotty.SLabel;
+import org.eclipse.sprotty.SModelElement;
+
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.schema.Icon;
 import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
-
-import io.typefox.sprotty.api.LayoutOptions;
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SCompartment;
-import io.typefox.sprotty.api.SLabel;
-import io.typefox.sprotty.api.SModelElement;
 
 public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateWeightedEdgeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateWeightedEdgeHandler.java
@@ -13,6 +13,9 @@ package com.eclipsesource.glsp.example.workflow.handler;
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+import org.eclipse.sprotty.SNode;
 
 import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
@@ -21,10 +24,6 @@ import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.WeightedEdge;
-
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
-import io.typefox.sprotty.api.SNode;
 
 public class CreateWeightedEdgeHandler implements OperationHandler {
 	private static Logger log= Logger.getLogger(CreateWeightedEdgeHandler.class);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/SimulateCommandHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/SimulateCommandHandler.java
@@ -17,12 +17,11 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.SModelElement;
 
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.handler.ServerCommandHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
-
-import io.typefox.sprotty.api.SModelElement;
 
 public class SimulateCommandHandler implements ServerCommandHandler {
 	private static Logger logger = Logger.getLogger(SimulateCommandHandler.class);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ActivityNode.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ActivityNode.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.schema;
 
-import io.typefox.sprotty.api.SNode;
+import org.eclipse.sprotty.SNode;
 
 public class ActivityNode extends SNode {
 	public static final String TYPE = "node:activity";

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/Icon.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/Icon.java
@@ -10,8 +10,8 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.schema;
 
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SShapeElement;
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SShapeElement;
 
 public class Icon extends SShapeElement {
 	public static final String TYPE = "icon";

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/TaskNode.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/TaskNode.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.schema;
 
-import io.typefox.sprotty.api.SNode;
+import org.eclipse.sprotty.SNode;
 
 public class TaskNode extends SNode {
 	public static final String TYPE="node:task";

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/WeightedEdge.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/WeightedEdge.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.schema;
 
-import io.typefox.sprotty.api.SEdge;
+import org.eclipse.sprotty.SEdge;
 
 public class WeightedEdge extends SEdge {
 	public static final String TYPE = "edge:weighted";

--- a/server/glsp-api/pom.xml
+++ b/server/glsp-api/pom.xml
@@ -40,15 +40,15 @@
 
 		<!-- https://mvnrepository.com/artifact/io.typefox.sprotty/diagram-api -->
 		<dependency>
-			<groupId>io.typefox.sprotty</groupId>
-			<artifactId>diagram-api</artifactId>
-			<version>0.3.0</version>
+			<groupId>org.eclipse.sprotty</groupId>
+			<artifactId>org.eclipse.sprotty</artifactId>
+			<version>0.5.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
-			<groupId>io.typefox.sprotty</groupId>
-			<artifactId>diagram-server</artifactId>
-			<version>0.3.0</version>
+			<groupId>org.eclipse.sprotty</groupId>
+			<artifactId>org.eclipse.sprotty.server</artifactId>
+			<version>0.5.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/AbstractActionHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/AbstractActionHandler.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 
 import com.eclipsesource.glsp.api.handler.ActionHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
-import com.eclipsesource.glsp.api.model.ModelStateProvider;
 
 public abstract class AbstractActionHandler implements ActionHandler {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ChangeBoundsOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ChangeBoundsOperationAction.java
@@ -12,7 +12,7 @@ package com.eclipsesource.glsp.api.action.kind;
 
 import java.util.Arrays;
 
-import io.typefox.sprotty.api.ElementAndBounds;
+import org.eclipse.sprotty.ElementAndBounds;
 
 public class ChangeBoundsOperationAction extends ExecuteOperationAction {
 	private ElementAndBounds[] newBounds;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ComputedBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ComputedBoundsAction.java
@@ -12,10 +12,10 @@ package com.eclipsesource.glsp.api.action.kind;
 
 import java.util.Arrays;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.ElementAndAlignment;
+import org.eclipse.sprotty.ElementAndBounds;
 
-import io.typefox.sprotty.api.ElementAndAlignment;
-import io.typefox.sprotty.api.ElementAndBounds;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class ComputedBoundsAction extends Action {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateConnectionOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateConnectionOperationAction.java
@@ -10,8 +10,6 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import com.eclipsesource.glsp.api.operations.OperationKind;
-
 public class CreateConnectionOperationAction extends ExecuteOperationAction {
 
 	private String elementTypeId;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateNodeOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/CreateNodeOperationAction.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import io.typefox.sprotty.api.Point;
+import org.eclipse.sprotty.Point;
 
 public class CreateNodeOperationAction extends ExecuteOperationAction {
 	

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/DeleteElementOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/DeleteElementOperationAction.java
@@ -12,8 +12,6 @@ package com.eclipsesource.glsp.api.action.kind;
 
 import java.util.Arrays;
 
-import com.eclipsesource.glsp.api.operations.OperationKind;
-
 public class DeleteElementOperationAction extends ExecuteOperationAction {
 	
 	private String[] elementIds;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/MoveOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/MoveOperationAction.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import io.typefox.sprotty.api.Point;
+import org.eclipse.sprotty.Point;
 
 public class MoveOperationAction extends ExecuteOperationAction {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsAction.java
@@ -10,9 +10,9 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class RequestBoundsAction extends Action {
 	private SModelRoot newRoot;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestPopupModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestPopupModelAction.java
@@ -10,9 +10,9 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.Bounds;
 
-import io.typefox.sprotty.api.Bounds;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class RequestPopupModelAction extends Action {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ServerStatusAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ServerStatusAction.java
@@ -10,9 +10,9 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.ServerStatus;
 
-import io.typefox.sprotty.api.ServerStatus;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class ServerStatusAction extends Action {
 	private String severity;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetBoundsAction.java
@@ -12,9 +12,9 @@ package com.eclipsesource.glsp.api.action.kind;
 
 import java.util.Arrays;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.ElementAndBounds;
 
-import io.typefox.sprotty.api.ElementAndBounds;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class SetBoundsAction extends Action {
 	private ElementAndBounds[] bounds;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetModelAction.java
@@ -10,9 +10,9 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class SetModelAction extends Action {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetPopupModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetPopupModelAction.java
@@ -10,10 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import com.eclipsesource.glsp.api.action.Action;
+import org.eclipse.sprotty.Bounds;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.Bounds;
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.action.Action;
 
 public class SetPopupModelAction extends Action {
 	private SModelRoot newRoot;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/UpdateModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/UpdateModelAction.java
@@ -12,10 +12,10 @@ package com.eclipsesource.glsp.api.action.kind;
 
 import java.util.Arrays;
 
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.types.Match;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public class UpdateModelAction extends Action {
 	private SModelRoot newRoot;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.di;
 
+import org.eclipse.sprotty.ILayoutEngine;
+
 import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.api.handler.ActionHandler;
@@ -28,8 +30,6 @@ import com.eclipsesource.glsp.api.provider.ServerCommandHandlerProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
-
-import io.typefox.sprotty.api.ILayoutEngine;
 
 public abstract class GLSPModule extends AbstractModule {
 	private Multibinder<ActionHandler> actionHandlerBinder;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/ModelFactory.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/ModelFactory.java
@@ -10,9 +10,9 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.factory;
 
-import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
 
 public interface ModelFactory {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/PopupModelFactory.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/PopupModelFactory.java
@@ -10,10 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.factory;
 
-import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
 
 public interface PopupModelFactory {
 	SModelRoot createPopuModel(SModelElement element, RequestPopupModelAction action);

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/handler/OperationHandler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/handler/OperationHandler.java
@@ -12,10 +12,10 @@ package com.eclipsesource.glsp.api.handler;
 
 import java.util.Optional;
 
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.model.ModelState;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public interface OperationHandler extends Handler<ExecuteOperationAction> {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
@@ -15,13 +15,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.sprotty.server.json.PropertyBasedTypeAdapter;
+
 import com.eclipsesource.glsp.api.action.Action;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
-
-import io.typefox.sprotty.server.json.PropertyBasedTypeAdapter;
 
 public class ActionTypeAdapter extends PropertyBasedTypeAdapter<Action> {
 	private Map<String, Class<? extends Action>> actionKinds;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/GsonConfigurator.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/GsonConfigurator.java
@@ -10,12 +10,12 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.json;
 
+import org.eclipse.sprotty.server.json.EnumTypeAdapter;
+
 import com.eclipsesource.glsp.api.action.ActionRegistry;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapterFactory;
 import com.google.inject.Inject;
-
-import io.typefox.sprotty.server.json.EnumTypeAdapter;
 
 public class GsonConfigurator {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/SModelElementTypeAdapter.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/SModelElementTypeAdapter.java
@@ -13,13 +13,13 @@ package com.eclipsesource.glsp.api.json;
 import java.lang.reflect.Constructor;
 import java.util.Map;
 
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.server.json.PropertyBasedTypeAdapter;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
-
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.server.json.PropertyBasedTypeAdapter;
 
 public class SModelElementTypeAdapter extends PropertyBasedTypeAdapter<SModelElement> {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageServer.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GraphicalLanguageServer.java
@@ -14,11 +14,10 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.sprotty.ServerStatus;
 
 import com.eclipsesource.glsp.api.action.ActionMessage;
 import com.eclipsesource.glsp.api.model.ModelStateProvider;
-
-import io.typefox.sprotty.api.ServerStatus;
 
 public interface GraphicalLanguageServer extends GraphicalLanguageClientAware,ModelStateProvider {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelState.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelState.java
@@ -12,10 +12,10 @@ package com.eclipsesource.glsp.api.model;
 
 import java.util.Set;
 
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.utils.ModelOptions.ParsedModelOptions;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public interface ModelState {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelTypeConfiguration.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelTypeConfiguration.java
@@ -13,11 +13,11 @@ package com.eclipsesource.glsp.api.model;
 import java.util.Collections;
 import java.util.Map;
 
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.server.json.EnumTypeAdapter;
+
 import com.eclipsesource.glsp.api.json.SModelElementTypeAdapter;
 import com.google.gson.GsonBuilder;
-
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.server.json.EnumTypeAdapter;
 
 /**
  * This configuration class provides the information necessary to determine the

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/OperationHandlerProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/OperationHandlerProvider.java
@@ -11,7 +11,6 @@
 package com.eclipsesource.glsp.api.provider;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
 
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Match.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Match.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.types;
 
-import io.typefox.sprotty.api.SModelElement;
+import org.eclipse.sprotty.SModelElement;
 
 public class Match {
 	private SModelElement left;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/LayoutUtil.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/LayoutUtil.java
@@ -14,19 +14,18 @@ package com.eclipsesource.glsp.api.utils;
 
 import java.util.ArrayList;
 
-import com.eclipsesource.glsp.api.action.kind.ComputedBoundsAction;
+import org.eclipse.sprotty.Alignable;
+import org.eclipse.sprotty.Bounds;
+import org.eclipse.sprotty.BoundsAware;
+import org.eclipse.sprotty.Dimension;
+import org.eclipse.sprotty.ElementAndAlignment;
+import org.eclipse.sprotty.ElementAndBounds;
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SEdge;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.Alignable;
-import io.typefox.sprotty.api.Bounds;
-import io.typefox.sprotty.api.BoundsAware;
-import io.typefox.sprotty.api.Dimension;
-import io.typefox.sprotty.api.ElementAndAlignment;
-import io.typefox.sprotty.api.ElementAndBounds;
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SEdge;
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelIndex;
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.action.kind.ComputedBoundsAction;
 
 public final class LayoutUtil {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/SModelIndex.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/SModelIndex.java
@@ -16,8 +16,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import io.typefox.sprotty.api.SEdge;
-import io.typefox.sprotty.api.SModelElement;
+import org.eclipse.sprotty.SEdge;
+import org.eclipse.sprotty.SModelElement;
 
 public class SModelIndex {
 	private final Map<String, SModelElement> idToElement;

--- a/server/glsp-server/pom.xml
+++ b/server/glsp-server/pom.xml
@@ -31,6 +31,11 @@
 			<artifactId>guice</artifactId>
 			<version>4.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sprotty</groupId>
+			<artifactId>org.eclipse.sprotty</artifactId>
+			<version>0.5.0-SNAPSHOT</version>
+		</dependency>
 
 
 	</dependencies>

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGraphicalLanguageServer.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGraphicalLanguageServer.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.ServerStatus;
 
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.ActionMessage;
@@ -26,8 +27,6 @@ import com.eclipsesource.glsp.api.jsonrpc.GraphicalLanguageClient;
 import com.eclipsesource.glsp.api.jsonrpc.GraphicalLanguageServer;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.server.model.ModelStateImpl;
-
-import io.typefox.sprotty.api.ServerStatus;
 
 public class DefaultGraphicalLanguageServer implements GraphicalLanguageServer {
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
@@ -22,9 +22,9 @@ import com.eclipsesource.glsp.api.action.kind.CollapseExpandAction;
 import com.eclipsesource.glsp.api.action.kind.CollapseExpandAllAction;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
 import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.google.inject.Inject;
 
-import io.typefox.sprotty.api.SModelIndex;
 
 public class CollapseExpandActionHandler extends AbstractActionHandler {
 	@Inject

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
@@ -14,14 +14,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.ComputedBoundsAction;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.LayoutUtil;
 import com.google.inject.Inject;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public class ComputedBoundsActionHandler extends AbstractActionHandler {
 	@Inject

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
@@ -12,6 +12,9 @@ package com.eclipsesource.glsp.server.actionhandler;
 
 import java.util.Optional;
 
+import org.eclipse.sprotty.ILayoutEngine;
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
 import com.eclipsesource.glsp.api.action.kind.SetModelAction;
@@ -19,9 +22,6 @@ import com.eclipsesource.glsp.api.action.kind.UpdateModelAction;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
-import io.typefox.sprotty.api.ILayoutEngine;
-import io.typefox.sprotty.api.SModelRoot;
 
 @Singleton
 public class ModelSubmissionHandler {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.ActionKind;
@@ -27,8 +29,6 @@ import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public class OperationActionHandler extends AbstractActionHandler {
 	@Inject

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
@@ -22,8 +24,6 @@ import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.ModelOptions;
 import com.eclipsesource.glsp.api.utils.ModelOptions.ParsedModelOptions;
 import com.google.inject.Inject;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public class RequestModelActionHandler extends AbstractActionHandler {
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
@@ -14,6 +14,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
@@ -22,9 +25,6 @@ import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.google.inject.Inject;
-
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
 
 public class RequestPopupModelActionHandler extends AbstractActionHandler {
 	@Inject

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.SModelRoot;
 
 import com.eclipsesource.glsp.api.action.AbstractActionHandler;
 import com.eclipsesource.glsp.api.action.Action;
@@ -26,8 +27,6 @@ import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.model.ModelTypeConfiguration;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-
-import io.typefox.sprotty.api.SModelRoot;
 
 public class SaveModelActionHandler extends AbstractActionHandler {
 	private static final Logger LOG = Logger.getLogger(SaveModelActionHandler.class);

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/FileBasedModelFactory.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/FileBasedModelFactory.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.SGraph;
+import org.eclipse.sprotty.SModelRoot;
 
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
 import com.eclipsesource.glsp.api.factory.ModelFactory;
@@ -22,9 +24,6 @@ import com.eclipsesource.glsp.api.model.ModelTypeConfiguration;
 import com.eclipsesource.glsp.api.utils.ModelOptions;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-
-import io.typefox.sprotty.api.SGraph;
-import io.typefox.sprotty.api.SModelRoot;
 
 /**
  * A base class which can be used for all modelfactories that load an SModel

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/ModelStateImpl.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/ModelStateImpl.java
@@ -13,11 +13,11 @@ package com.eclipsesource.glsp.server.model;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.eclipsesource.glsp.api.utils.ModelOptions.ParsedModelOptions;
-import com.eclipsesource.glsp.api.model.ModelState;
-import com.eclipsesource.glsp.api.utils.SModelIndex;
+import org.eclipse.sprotty.SModelRoot;
 
-import io.typefox.sprotty.api.SModelRoot;
+import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.api.utils.ModelOptions.ParsedModelOptions;
+import com.eclipsesource.glsp.api.utils.SModelIndex;
 
 public class ModelStateImpl implements ModelState {
 	private ParsedModelOptions options;

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/ChangeBoundsOperationHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/ChangeBoundsOperationHandler.java
@@ -13,20 +13,19 @@ package com.eclipsesource.glsp.server.operationhandler;
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.Bounds;
+import org.eclipse.sprotty.Dimension;
+import org.eclipse.sprotty.ElementAndBounds;
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+import org.eclipse.sprotty.SNode;
 
 import com.eclipsesource.glsp.api.action.kind.ChangeBoundsOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-
-import io.typefox.sprotty.api.Bounds;
-import io.typefox.sprotty.api.Dimension;
-import io.typefox.sprotty.api.ElementAndBounds;
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
-import io.typefox.sprotty.api.SNode;
 
 /**
  * Generic handler implementation for {@link ChangeBoundsOperationAction}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/CreateNodeOperationHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/CreateNodeOperationHandler.java
@@ -14,15 +14,15 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.eclipse.sprotty.Point;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+
 import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-
-import io.typefox.sprotty.api.Point;
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
 
 public abstract class CreateNodeOperationHandler implements OperationHandler {
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/DeleteHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/DeleteHandler.java
@@ -16,17 +16,16 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
+import org.eclipse.sprotty.SEdge;
+import org.eclipse.sprotty.SModelElement;
+import org.eclipse.sprotty.SModelRoot;
+import org.eclipse.sprotty.SNode;
 
 import com.eclipsesource.glsp.api.action.kind.DeleteElementOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ExecuteOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-
-import io.typefox.sprotty.api.SEdge;
-import io.typefox.sprotty.api.SModelElement;
-import io.typefox.sprotty.api.SModelRoot;
-import io.typefox.sprotty.api.SNode;
 
 /**
  * Generic handler implementation for {@link DeleteElementOperationAction}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,13 @@
 	<artifactId>glsp-parent</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
-
+	<repositories>
+		<repository>
+			<id>sonatype</id>
+			<name>Sonatype</name>
+			<url>https://oss.sonatype.org/content/groups/public</url>
+		</repository>
+	</repositories>
 	<licenses>
 		<license>
 			<name>Eclipse Public License - v 2.0</name>


### PR DESCRIPTION
This change includes:
- Update to newest snapshot version of the sprotty maven packages (0.5.0)
- Refactoring of corresponding imports due to namespace change ("org.eclipse.sprotty")