### PR TITLE
Fix #105 "stamp" mode not working

### DIFF
--- a/client/packages/glsp-sprotty/src/features/tool-manager/tool-manager.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-manager/tool-manager.ts
@@ -87,11 +87,11 @@ export class DefaultToolManager implements ToolManager {
     }
 
     enableStandardTools() {
-        this.disableActiveTools();
         this.enable(this.standardTools.map(tool => tool.id));
     }
 
     enable(toolIds: string[]) {
+        this.disableActiveTools();
         const tools = toolIds.map(id => this.tool(id))
         tools.forEach(tool => {
             if (tool !== undefined) {

--- a/client/packages/glsp-sprotty/src/features/tools/key-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/key-tool.ts
@@ -16,8 +16,8 @@ import { Action, KeyListener, KeyTool, on, SModelElement, SModelRoot } from "spr
 export class ExtendedKeyTool extends KeyTool {
     protected handleExtendedKeyListenerEvent<K extends keyof ExtendedKeyListener>(methodName: K, model: SModelRoot, event: KeyboardEvent) {
         const actions = this.keyListeners
-            .filter(isExtendedKeyListener)
-            .map(listener => listener[methodName].apply(listener, [model, event]))
+            .filter(l => l instanceof ExtendedKeyListener)
+            .map(listener => (listener as ExtendedKeyListener)[methodName].apply(listener, [model, event]))
             .reduce((a, b) => a.concat(b));
         if (actions.length > 0) {
             event.preventDefault();
@@ -55,8 +55,4 @@ export class ExtendedKeyListener extends KeyListener {
     keyUp(element: SModelElement, event: KeyboardEvent): Action[] {
         return [];
     }
-}
-
-export function isExtendedKeyListener(object: any): object is ExtendedKeyListener {
-    return 'keyUp' in object;
 }


### PR DESCRIPTION
Modifies the <i>StandardToolsEnablingKeyListener</i> to ensure that the StandardTools get enabled after a CreationTool has been used in "stamp-mode" (i.e. while holding ctrl)

In addition, this contains a minor refactoring for the <i>ExtendedKeyTool</i> which was using (and exporting) an unsafe custom type guard function instead of a simple 'instanceof' check