### PR TITLE
Fix #111- Introduce observable command stack

### DIFF
--- a/client/packages/glsp-sprotty/src/base/command-stack.ts
+++ b/client/packages/glsp-sprotty/src/base/command-stack.ts
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+import { inject, injectable } from "inversify";
+import { AnimationFrameSyncer, CommandExecutionContext, CommandResult, CommandStack, CommandStackOptions, ICommand, ILogger, IModelFactory, IViewerProvider, SetModelCommand, SModelRoot, TYPES, UpdateModelCommand } from "sprotty/lib";
+
+
+export interface CommandStackObserver {
+    /*Is called before an update model request from the server is applied*/
+    beforeServerUpdate(model: SModelRoot): void
+}
+@injectable()
+export class ObservableCommandStack extends CommandStack {
+    protected observers: CommandStackObserver[] = []
+
+    private notifyObservers = false
+    public serverSideUpdate: boolean = false
+    constructor(@inject(TYPES.IModelFactory) protected modelFactory: IModelFactory,
+        @inject(TYPES.IViewerProvider) protected viewerProvider: IViewerProvider,
+        @inject(TYPES.ILogger) protected logger: ILogger,
+        @inject(TYPES.AnimationFrameSyncer) protected syncer: AnimationFrameSyncer,
+        @inject(TYPES.CommandStackOptions) protected options: CommandStackOptions) {
+        super(modelFactory, viewerProvider, logger, syncer, options);
+    }
+
+    registerObserver(observer: CommandStackObserver): boolean | void {
+        if (this.observers.indexOf(observer) < 0) {
+            this.observers.push(observer)
+            return true
+        }
+        return false
+    }
+    deregisterObserver(observer: CommandStackObserver): boolean | void {
+        const index = this.observers.indexOf(observer)
+        if (index >= 0) {
+            this.observers.splice(index, 1)
+            return true
+        }
+        return false
+    }
+    async update(model: SModelRoot): Promise<void> {
+        if (this.viewer === undefined)
+            this.viewer = await this.viewerProvider();
+        if (this.notifyObservers && this.serverSideUpdate) {
+            this.observers.forEach(obs => obs.beforeServerUpdate(model))
+            this.notifyObservers = false
+            this.serverSideUpdate = false
+        }
+        this.viewer.update(model);
+    }
+
+    protected handleCommand(command: ICommand,
+        operation: (context: CommandExecutionContext) => CommandResult,
+        beforeResolve: (command: ICommand, context: CommandExecutionContext) => void) {
+
+        if (isObservedCommand) {
+            this.notifyObservers = true
+        }
+        super.handleCommand(command, operation, beforeResolve)
+    }
+
+}
+
+function isObservedCommand(command: ICommand) {
+    return (command instanceof SetModelCommand || command instanceof UpdateModelCommand)
+}

--- a/client/packages/glsp-sprotty/src/base/di.config.ts
+++ b/client/packages/glsp-sprotty/src/base/di.config.ts
@@ -16,7 +16,8 @@ const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) =>
     if (isBound(TYPES.ICommandStack)) {
         unbind(TYPES.ICommandStack)
     }
-    bind(TYPES.ICommandStack).to(ObservableCommandStack).inSingletonScope()
+    bind(ObservableCommandStack).toSelf().inSingletonScope()
+    bind(TYPES.ICommandStack).toService(ObservableCommandStack)
 
 })
 

--- a/client/packages/glsp-sprotty/src/base/di.config.ts
+++ b/client/packages/glsp-sprotty/src/base/di.config.ts
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * 	Tobias Ortmayr - initial API and implementation
+ ******************************************************************************/
+import { ContainerModule } from "inversify";
+import { TYPES } from "sprotty/lib";
+import { ObservableCommandStack } from "./command-stack";
+
+const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    if (isBound(TYPES.ICommandStack)) {
+        unbind(TYPES.ICommandStack)
+    }
+    bind(TYPES.ICommandStack).to(ObservableCommandStack).inSingletonScope()
+
+})
+
+export default defaultGLSPModule;

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -9,6 +9,7 @@
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
 export * from 'sprotty/lib';
+export * from './base/command-stack';
 export * from './features/execute/execute-command';
 export * from './features/execute/model';
 export * from './features/operation/operation-actions';
@@ -27,11 +28,13 @@ export * from './features/tools/move-tool';
 export * from './features/tools/resize-tool';
 export * from './lib/model';
 export * from './types';
-export { saveModule, toolManagerModule, executeModule, toolFeedbackModule };
+export { saveModule, toolManagerModule, executeModule, toolFeedbackModule, defaultGLSPModule};
 
 
+import defaultGLSPModule from './base/di.config';
 import executeModule from './features/execute/di.config';
 import saveModule from './features/save/di.config';
 import toolFeedbackModule from './features/tool-feedback/di.config';
 import toolManagerModule from './features/tool-manager/di.config';
+
 

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -10,7 +10,7 @@
  ******************************************************************************/
 import { Emitter, Event } from "@theia/core/lib/common";
 // tslint:disable-next-line:max-line-length
-import { Action, ActionHandlerRegistry, ActionMessage, CommandStack, ExecuteServerCommandAction, IActionDispatcher, ICommand, ILogger, ModelSource, ObservableCommandStack, OperationKind, RequestBoundsCommand, RequestOperationsAction, SaveModelAction, SetModelAction, SetModelCommand, SetOperationsAction, SModelStorage, SwitchEditModeCommand, TYPES, UpdateModelAction, UpdateModelCommand, ViewerOptions } from "glsp-sprotty/lib";
+import { Action, ActionHandlerRegistry, ActionMessage, ExecuteServerCommandAction, IActionDispatcher, ICommand, ILogger, ModelSource, ObservableCommandStack, OperationKind, RequestBoundsCommand, RequestOperationsAction, SaveModelAction, SetModelCommand, SetOperationsAction, SModelStorage, SwitchEditModeCommand, TYPES, UpdateModelCommand, ViewerOptions } from "glsp-sprotty/lib";
 import { inject, injectable } from "inversify";
 import { TheiaDiagramServer } from "theia-glsp/lib";
 
@@ -24,7 +24,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         @inject(TYPES.ViewerOptions) viewerOptions: ViewerOptions,
         @inject(TYPES.SModelStorage) storage: SModelStorage,
         @inject(TYPES.ILogger) logger: ILogger,
-        @inject(TYPES.ICommandStack) protected readonly commandStack: CommandStack
+        @inject(ObservableCommandStack) protected commandStack: ObservableCommandStack
     ) {
         super(actionDispatcher, actionHandlerRegistry, viewerOptions, storage, logger)
     }
@@ -51,10 +51,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         } else if (message.action.kind === RequestBoundsCommand.KIND ||
             message.action.kind === SetModelCommand.KIND ||
             message.action.kind === UpdateModelCommand.KIND) {
-            if (this.commandStack instanceof ObservableCommandStack)
-                this.commandStack.serverSideUpdate = true
-        } else if (message.action instanceof SetModelAction ||
-            message.action instanceof UpdateModelAction) {
+            this.commandStack.serverSideUpdate = true;
         }
         super.messageReceived(message)
     }

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -10,7 +10,7 @@
  ******************************************************************************/
 import { Emitter, Event } from "@theia/core/lib/common";
 // tslint:disable-next-line:max-line-length
-import { Action, ActionHandlerRegistry, ActionMessage, ExecuteServerCommandAction, IActionDispatcher, ICommand, ILogger, ModelSource, OperationKind, RequestOperationsAction, SaveModelAction, SetOperationsAction, SModelStorage, SwitchEditModeCommand, TYPES, ViewerOptions } from "glsp-sprotty/lib";
+import { Action, ActionHandlerRegistry, ActionMessage, CommandStack, ExecuteServerCommandAction, IActionDispatcher, ICommand, ILogger, ModelSource, ObservableCommandStack, OperationKind, RequestBoundsCommand, RequestOperationsAction, SaveModelAction, SetModelAction, SetModelCommand, SetOperationsAction, SModelStorage, SwitchEditModeCommand, TYPES, UpdateModelAction, UpdateModelCommand, ViewerOptions } from "glsp-sprotty/lib";
 import { inject, injectable } from "inversify";
 import { TheiaDiagramServer } from "theia-glsp/lib";
 
@@ -23,7 +23,8 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         @inject(TYPES.ActionHandlerRegistry) actionHandlerRegistry: ActionHandlerRegistry,
         @inject(TYPES.ViewerOptions) viewerOptions: ViewerOptions,
         @inject(TYPES.SModelStorage) storage: SModelStorage,
-        @inject(TYPES.ILogger) logger: ILogger
+        @inject(TYPES.ILogger) logger: ILogger,
+        @inject(TYPES.ICommandStack) protected readonly commandStack: CommandStack
     ) {
         super(actionDispatcher, actionHandlerRegistry, viewerOptions, storage, logger)
     }
@@ -47,6 +48,13 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
     messageReceived(message: ActionMessage) {
         if (message.action instanceof SetOperationsAction) {
             this.actionDispatcher.dispatch(message.action)
+        } else if (message.action.kind === RequestBoundsCommand.KIND ||
+            message.action.kind === SetModelCommand.KIND ||
+            message.action.kind === UpdateModelCommand.KIND) {
+            if (this.commandStack instanceof ObservableCommandStack)
+                this.commandStack.serverSideUpdate = true
+        } else if (message.action instanceof SetModelAction ||
+            message.action instanceof UpdateModelAction) {
         }
         super.messageReceived(message)
     }

--- a/client/packages/workflow-sprotty/src/di.config.ts
+++ b/client/packages/workflow-sprotty/src/di.config.ts
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 // tslint:disable-next-line:max-line-length
+import { boundsModule, buttonModule, CenterCommand, CenterKeyboardListener, configureModelElement, ConsoleLogger, defaultGLSPModule, defaultModule, DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, FitToScreenCommand, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelSourceModule, moveModule, openModule, overrideViewerOptions, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, saveModule, SButton, SCompartment, SCompartmentView, ScrollMouseListener, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, toolManagerModule, TYPES, undoRedoModule, ViewportCommand } from "glsp-sprotty/lib";
 import { boundsModule, buttonModule, CenterCommand, CenterKeyboardListener, configureModelElement, ConsoleLogger, defaultModule, DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, FitToScreenCommand, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelSourceModule, moveModule, openModule, overrideViewerOptions, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, saveModule, SButton, SCompartment, SCompartmentView, ScrollMouseListener, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, toolFeedbackModule, toolManagerModule, TYPES, undoRedoModule, ViewportCommand } from "glsp-sprotty/lib";
 import executeCommandModule from "glsp-sprotty/lib/features/execute/di.config";
 import { Container, ContainerModule } from "inversify";
@@ -58,7 +59,7 @@ const workflowViewportModule = new ContainerModule(bind => {
 export default function createContainer(widgetId: string): Container {
     const container = new Container();
 
-    container.load(defaultModule, selectModule, moveModule, boundsModule, undoRedoModule, workflowViewportModule,
+    container.load(defaultModule, defaultGLSPModule, selectModule, moveModule, boundsModule, undoRedoModule, workflowViewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
         workflowDiagramModule, saveModule, executeCommandModule, toolManagerModule, toolFeedbackModule);
 

--- a/client/packages/workflow-sprotty/src/di.config.ts
+++ b/client/packages/workflow-sprotty/src/di.config.ts
@@ -10,8 +10,7 @@
  ******************************************************************************/
 
 // tslint:disable-next-line:max-line-length
-import { boundsModule, buttonModule, CenterCommand, CenterKeyboardListener, configureModelElement, ConsoleLogger, defaultGLSPModule, defaultModule, DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, FitToScreenCommand, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelSourceModule, moveModule, openModule, overrideViewerOptions, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, saveModule, SButton, SCompartment, SCompartmentView, ScrollMouseListener, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, toolManagerModule, TYPES, undoRedoModule, ViewportCommand } from "glsp-sprotty/lib";
-import { boundsModule, buttonModule, CenterCommand, CenterKeyboardListener, configureModelElement, ConsoleLogger, defaultModule, DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, FitToScreenCommand, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelSourceModule, moveModule, openModule, overrideViewerOptions, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, saveModule, SButton, SCompartment, SCompartmentView, ScrollMouseListener, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, toolFeedbackModule, toolManagerModule, TYPES, undoRedoModule, ViewportCommand } from "glsp-sprotty/lib";
+import { boundsModule, buttonModule, CenterCommand, CenterKeyboardListener, configureModelElement, ConsoleLogger, defaultGLSPModule, defaultModule, DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, FitToScreenCommand, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelSourceModule, moveModule, openModule, overrideViewerOptions, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, saveModule, SButton, SCompartment, SCompartmentView, ScrollMouseListener, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, toolFeedbackModule, toolManagerModule, TYPES, undoRedoModule, ViewportCommand } from "glsp-sprotty/lib";
 import executeCommandModule from "glsp-sprotty/lib/features/execute/di.config";
 import { Container, ContainerModule } from "inversify";
 import { ActivityNode, Icon, TaskNode, WeightedEdge } from "./model";
@@ -61,7 +60,7 @@ export default function createContainer(widgetId: string): Container {
 
     container.load(defaultModule, defaultGLSPModule, selectModule, moveModule, boundsModule, undoRedoModule, workflowViewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
-        workflowDiagramModule, saveModule, executeCommandModule, toolManagerModule, toolFeedbackModule);
+        workflowDiagramModule, saveModule, executeCommandModule, toolManagerModule, toolFeedbackModule, defaultGLSPModule);
 
     overrideViewerOptions(container, {
         needsClientLayout: true,


### PR DESCRIPTION
This change provides an extension of the sprotty command stack which is observable.
Registered instances of <i>CommandStackObserver</i> get notified if an update command was triggered from the server and can process the model before it's delegated to the viewer.

This should provide the necessary functionality for tools to (re)apply their visual feedback if the server updates the model during tool execution.