### PR TITLE
Fix #125

### DIFF
--- a/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
@@ -11,14 +11,18 @@
 
 import { ContainerModule } from "inversify";
 import { LocationDecorator, MoveCommand, TYPES } from "sprotty/lib";
+import { GLSP_TYPES } from "../../types";
 import {
     FeedbackEdgeEnd, HideEdgeCreationToolFeedbackCommand, HideNodeCreationToolFeedbackCommand, //
     ShowEdgeCreationSelectSourceFeedbackCommand, ShowEdgeCreationSelectTargetFeedbackCommand, //
     ShowNodeCreationToolFeedbackCommand
 } from "./creation-tool-feedback";
+import { FeedbackActionDispatcher } from "./feedback-action-dispatcher";
 import { FeedbackEdgeEndView } from "./view";
 
 const toolFeedbackModule = new ContainerModule(bind => {
+    bind(GLSP_TYPES.IFeedbackActionDispatcher).to(FeedbackActionDispatcher).inSingletonScope();
+
     // create node and edge tool feedback
     bind(TYPES.ICommand).toConstructor(ShowNodeCreationToolFeedbackCommand);
     bind(TYPES.ICommand).toConstructor(HideNodeCreationToolFeedbackCommand);

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/feedback-action-dispatcher.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/feedback-action-dispatcher.ts
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *  Philip Langer - initial API and implementation
+ ******************************************************************************/
+import { inject, injectable } from "inversify";
+import { Action, IActionDispatcher, ILogger, SModelRoot, TYPES } from "sprotty/lib";
+import { CommandStackObserver, ObservableCommandStack } from "../../base/command-stack";
+
+export interface IFeedbackEmitter { }
+
+/**
+ * Action dispatcher for actions that are meant to show tool feedback.
+ *
+ * The purpose of this action dispatcher is to re-establish the feedback
+ * after the model has been updated or reset by the server, as this would
+ * overwrite the already established feedback, in case it is drawn by
+ * extending the `SModelRoot`. Therefore, tools can register themselves
+ * as feedback emitters with actions they want to place for showing
+ * feedback. This dispatcher will then re-establish all feedback actions
+ * of the registered tools, whenever the `SModelRoot` has been set.
+ */
+export interface IFeedbackActionDispatcher {
+    /**
+     * Registers `actions` to be sent out by a `feedbackEmitter`.
+     * @param feedbackEmitter the emitter sending out feedback actions.
+     * @param actions the actions to be sent out.
+     */
+    registerFeedback(feedbackEmitter: IFeedbackEmitter, actions: Action[]): void;
+    /**
+     * Deregisters a `feedbackEmitter` from this dispatcher.
+     * @param feedbackEmitter the emitter sending out feedback actions.
+     * @param actions the actions to be sent out after deregistration.
+     */
+    deregisterFeedback(feedbackEmitter: IFeedbackEmitter, actions: Action[]): void;
+}
+
+@injectable()
+export class FeedbackActionDispatcher implements IFeedbackActionDispatcher, CommandStackObserver {
+
+    protected feedbackEmitters: Map<IFeedbackEmitter, Action[]> = new Map;
+
+    constructor(
+        @inject(ObservableCommandStack) protected commandStack: ObservableCommandStack,
+        @inject(TYPES.IActionDispatcherProvider) protected actionDispatcher: () => Promise<IActionDispatcher>,
+        @inject(TYPES.ILogger) protected logger: ILogger) {
+        this.commandStack.registerObserver(this);
+    }
+
+    registerFeedback(feedbackEmitter: IFeedbackEmitter, actions: Action[]): void {
+        this.feedbackEmitters.set(feedbackEmitter, actions);
+        this.dispatch(actions, feedbackEmitter);
+    }
+
+    deregisterFeedback(feedbackEmitter: IFeedbackEmitter, actions: Action[]): void {
+        this.feedbackEmitters.delete(feedbackEmitter);
+        this.dispatch(actions, feedbackEmitter);
+    }
+
+    private dispatch(actions: Action[], feedbackEmitter: IFeedbackEmitter) {
+        this.actionDispatcher()
+            .then(dispatcher => dispatcher.dispatchAll(actions))
+            .then(() => this.logger.info(this, `Dispatched feedback actions for ${feedbackEmitter}`))
+            .catch(reason => this.logger.error(this, 'Failed to dispatch feedback actions', reason));
+    }
+
+    beforeServerUpdate(model: SModelRoot): void {
+        this.feedbackEmitters.forEach((actions, feedbackEmitter) =>
+            this.dispatch(actions, feedbackEmitter));
+    }
+
+}

--- a/client/packages/glsp-sprotty/src/features/tools/delete-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/delete-tool.ts
@@ -22,7 +22,7 @@ export class DelKeyDeleteTool implements Tool {
     static ID = "glsp.delete-keyboard";
     readonly id = DelKeyDeleteTool.ID;
 
-    protected deleteKeyListener: DeleteKeyListener = new DeleteKeyListener();;
+    protected deleteKeyListener: DeleteKeyListener = new DeleteKeyListener();
 
     constructor(@inject(KeyTool) protected readonly keytool: KeyTool) { }
 

--- a/client/packages/glsp-sprotty/src/types.ts
+++ b/client/packages/glsp-sprotty/src/types.ts
@@ -11,6 +11,7 @@
 
 export const GLSP_TYPES = {
     ToolManager: Symbol.for("ToolManager"),
+    IFeedbackActionDispatcher: Symbol.for("IFeedbackActionDispatcher"),
     ToolFactory: Symbol.for("Factory<Tool>"),
     TypeHintsService: Symbol.for("TypeHintsService")
 }


### PR DESCRIPTION
Introduces a feedback action dispatcher that stores the feedback actions
that have been dispatched by feedback emitters (such as tools) in order
to be able to restore the feedback after the server updated or re-set
the model.