### PR TITLE
Fix #143 Match operation element type id and actual type id

### DIFF
--- a/client/examples/workspace/example1.wf
+++ b/client/examples/workspace/example1.wf
@@ -13,7 +13,7 @@
         "x": 10.0,
         "y": 200.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task1",
       "children": [
         {
@@ -62,7 +62,7 @@
         "x": 200.0,
         "y": 200.0
       },
-      "type": "node:task",
+      "type": "task:automated",
       "id": "task2",
       "children": [
         {
@@ -110,7 +110,7 @@
         "x": 400.0,
         "y": 150.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task3",
       "children": [
         {
@@ -159,7 +159,7 @@
         "x": 400.0,
         "y": 250.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task4",
       "children": [
         {
@@ -208,7 +208,7 @@
         "x": 600.0,
         "y": 200.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task5",
       "children": [
         {
@@ -257,7 +257,7 @@
         "x": 493.0,
         "y": 349.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task6",
       "children": [
         {
@@ -306,7 +306,7 @@
         "x": 600.0,
         "y": 500.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task7",
       "children": [
         {
@@ -355,7 +355,7 @@
         "x": 400.0,
         "y": 450.0
       },
-      "type": "node:task",
+      "type": "task:manual",
       "id": "task8",
       "children": [
         {
@@ -399,7 +399,7 @@
         "x": 350.0,
         "y": 216.0
       },
-      "type": "node:activity",
+      "type": "activityNode:decision",
       "id": "activityNode9"
     },
     {
@@ -408,7 +408,7 @@
         "x": 650.0,
         "y": 316.0
       },
-      "type": "node:activity",
+      "type": "activityNode:decision",
       "id": "activityNode11"
     },
     {
@@ -417,7 +417,7 @@
         "x": 550.0,
         "y": 216.0
       },
-      "type": "node:activity",
+      "type": "activityNode:merge",
       "id": "activityNode10"
     },
     {
@@ -426,7 +426,7 @@
         "x": 550.0,
         "y": 466.0
       },
-      "type": "node:activity",
+      "type": "activityNode:merge",
       "id": "activityNode12"
     },
     {

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-palette-contribution.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-palette-contribution.ts
@@ -68,25 +68,25 @@ export class GLSPPaletteContribution implements MenuContribution, CommandContrib
 
         commands.registerHandler(PaletteCommands.CREATE_AUTOMATED_TASK.id,
             new DiagramCommandHandler(this.shell, widget =>
-                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.wf-automated-task`]))
+                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.task:automated`]))
             )
         )
 
         commands.registerHandler(PaletteCommands.CREATE_MANUAL_TASK.id,
             new DiagramCommandHandler(this.shell, widget =>
-                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.wf-manual-task`]))
+                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.task:manual`]))
             )
         )
 
         commands.registerHandler(PaletteCommands.CREATE_DECISION_NODE.id,
             new DiagramCommandHandler(this.shell, widget =>
-                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.wf-decision-node`]))
+                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.activityNode:decision`]))
             )
         )
 
         commands.registerHandler(PaletteCommands.CREATE_MERGE_NODE.id,
             new DiagramCommandHandler(this.shell, widget =>
-                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.wf-merge-node`]))
+                widget.actionDispatcher.dispatch(new EnableToolsAction([`${NodeCreationTool.ID}.activityNode:merge`]))
             )
         )
 
@@ -98,13 +98,13 @@ export class GLSPPaletteContribution implements MenuContribution, CommandContrib
 
         commands.registerHandler(PaletteCommands.CREATE_WEIGHTED_EDGE.id,
             new DiagramCommandHandler(this.shell, widget =>
-                widget.actionDispatcher.dispatch(new EnableToolsAction([`${EdgeCreationTool.ID}.wf-weighted-edge`]))
+                widget.actionDispatcher.dispatch(new EnableToolsAction([`${EdgeCreationTool.ID}.edge:weighted`]))
             )
         )
 
         commands.registerHandler(PaletteCommands.CREATE_EDGE.id,
             new DiagramCommandHandler(this.shell, widget =>
-                widget.actionDispatcher.dispatch(new EnableToolsAction([`${EdgeCreationTool.ID}.wf-edge`]))
+                widget.actionDispatcher.dispatch(new EnableToolsAction([`${EdgeCreationTool.ID}.edge`]))
             )
         )
     }

--- a/client/packages/workflow-sprotty/src/di.config.ts
+++ b/client/packages/workflow-sprotty/src/di.config.ts
@@ -29,7 +29,8 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     rebind(TYPES.IModelFactory).to(WorkflowModelFactory).inSingletonScope()
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, 'graph', GLSPGraph, SGraphView);
-    configureModelElement(context, 'node:task', TaskNode, TaskNodeView);
+    configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);
+    configureModelElement(context, 'task:manual', TaskNode, TaskNodeView);
     configureModelElement(context, 'label:heading', SLabel, SLabelView);
     configureModelElement(context, 'label:text', SLabel, SLabelView);
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
@@ -44,7 +45,8 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     configureModelElement(context, 'edge:weighted', WeightedEdge, WeightedEdgeView)
     configureModelElement(context, 'resize-handle', SResizeHandle, SResizeHandleView);
     configureModelElement(context, 'icon', Icon, IconView);
-    configureModelElement(context, 'node:activity', ActivityNode, DiamondNodeView)
+    configureModelElement(context, 'activityNode:merge', ActivityNode, DiamondNodeView)
+    configureModelElement(context, 'activityNode:decision', ActivityNode, DiamondNodeView)
     configureModelElement(context, 'node', RectangularNode, RectangularNodeView)
 });
 

--- a/client/packages/workflow-sprotty/src/model-factory.ts
+++ b/client/packages/workflow-sprotty/src/model-factory.ts
@@ -26,11 +26,11 @@ export class WorkflowModelFactory extends SGraphFactory {
     }
 
     isTaskNodeSchema(schema: SModelElementSchema): schema is TaskNodeSchema {
-        return getBasicType(schema) === 'node' && getSubType(schema) === 'task'
+        return getBasicType(schema) === 'task'
     }
 
     isActivityNodeSchema(schema: SModelElementSchema): schema is ActivityNodeSchema {
-        return getBasicType(schema) === 'node' && getSubType(schema) === 'activity'
+        return getBasicType(schema) === 'activityNode'
     }
     isWeightedEdgeSchema(schema: SModelElementSchema): schema is WeightedEdgeSchema {
         return getBasicType(schema) === 'edge' && getSubType(schema) === 'weighted'

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfigurationProvider.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowModelTypeConfigurationProvider.java
@@ -10,6 +10,22 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow;
 
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.AUTOMATED_TASK;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.COMP_COMP;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.COMP_HEADER;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.DECISION_NODE;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.EDGE;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.GRAPH;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.HTML;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.ICON;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.LABEL_HEADING;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.LABEL_ICON;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.LABEL_TEXT;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.MANUAL_TASK;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.MERGE_NODE;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.PRE_RENDERED;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.WEIGHTED_EDGE;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -36,37 +52,40 @@ public class WorkflowModelTypeConfigurationProvider implements ModelTypeConfigur
 	@Override
 	public Map<String, Class<? extends SModelElement>> getTypeToClassMappings() {
 		Map<String, Class<? extends SModelElement>> mapping = new HashMap<>();
-		mapping.put("graph", SGraph.class);
-		mapping.put("label:heading", SLabel.class);
-		mapping.put("label:text", SLabel.class);
-		mapping.put("comp:comp", SCompartment.class);
-		mapping.put("comp:header", SCompartment.class);
-		mapping.put("label:icon", SLabel.class);
-		mapping.put("edge", SEdge.class);
-		mapping.put("html", HtmlRoot.class);
-		mapping.put("pre-rendered", PreRenderedElement.class);
-		mapping.put(WeightedEdge.TYPE, WeightedEdge.class);
-		mapping.put(Icon.TYPE, Icon.class);
-		mapping.put(ActivityNode.TYPE, ActivityNode.class);
-		mapping.put(TaskNode.TYPE, TaskNode.class);
+		mapping.put(GRAPH, SGraph.class);
+		mapping.put(LABEL_HEADING, SLabel.class);
+		mapping.put(LABEL_TEXT, SLabel.class);
+		mapping.put(COMP_COMP, SCompartment.class);
+		mapping.put(COMP_HEADER, SCompartment.class);
+		mapping.put(LABEL_ICON, SLabel.class);
+		mapping.put(EDGE, SEdge.class);
+		mapping.put(HTML, HtmlRoot.class);
+		mapping.put(PRE_RENDERED, PreRenderedElement.class);
+		mapping.put(WEIGHTED_EDGE, WeightedEdge.class);
+		mapping.put(ICON, Icon.class);
+		mapping.put(MERGE_NODE, ActivityNode.class);
+		mapping.put(DECISION_NODE, ActivityNode.class);
+		mapping.put(MANUAL_TASK, TaskNode.class);
+		mapping.put(AUTOMATED_TASK, TaskNode.class);
 		return mapping;
 	}
 
 	@Override
 	public List<NodeTypeHint> getNodeTypeHints() {
-		return Arrays.asList(createDefaultNodeTypeHint(ActivityNode.TYPE), createDefaultNodeTypeHint(TaskNode.TYPE));
+		return Arrays.asList(createDefaultNodeTypeHint(DECISION_NODE), createDefaultNodeTypeHint(MERGE_NODE),
+				createDefaultNodeTypeHint(MANUAL_TASK), createDefaultNodeTypeHint(AUTOMATED_TASK));
 	}
 
 	@Override
 	public EdgeTypeHint createDefaultEdgeTypeHint(String elementId) {
 		EdgeTypeHint hint = ModelTypeConfigurationProvider.super.createDefaultEdgeTypeHint(elementId);
-		hint.setSourceElementTypeIds(Arrays.asList(TaskNode.TYPE, ActivityNode.TYPE));
-		hint.setTargetElementTypeIds(Arrays.asList(TaskNode.TYPE, ActivityNode.TYPE));
+		hint.setSourceElementTypeIds(Arrays.asList(MANUAL_TASK, AUTOMATED_TASK, DECISION_NODE, MERGE_NODE));
+		hint.setTargetElementTypeIds(Arrays.asList(MANUAL_TASK, AUTOMATED_TASK, DECISION_NODE, MERGE_NODE));
 		return hint;
 	}
 
 	@Override
 	public List<EdgeTypeHint> getEdgeTypeHints() {
-		return Arrays.asList(createDefaultEdgeTypeHint(WeightedEdge.TYPE), createDefaultEdgeTypeHint("edge"));
+		return Arrays.asList(createDefaultEdgeTypeHint(WEIGHTED_EDGE), createDefaultEdgeTypeHint(EDGE));
 	}
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowOperationConfiguration.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowOperationConfiguration.java
@@ -1,37 +1,41 @@
-/*******************************************************************************
- * Copyright (c) 2018 EclipseSource Services GmbH and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v20.html
- *   
- * Contributors:
- * 	Tobias Ortmayr - initial API and implementation
- ******************************************************************************/
+/********************************************************************************
+ * Copyright (c) 2018-2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
 package com.eclipsesource.glsp.example.workflow;
+
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.AUTOMATED_TASK;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.DECISION_NODE;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.EDGE;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.MANUAL_TASK;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.MERGE_NODE;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.WEIGHTED_EDGE;
 
 import com.eclipsesource.glsp.api.action.kind.RequestOperationsAction;
 import com.eclipsesource.glsp.api.operations.Operation;
 import com.eclipsesource.glsp.api.operations.OperationConfiguration;
 
 public class WorkflowOperationConfiguration implements OperationConfiguration {
-	public static final String AUTOMATED_TASK_ID = "wf-automated-task";
-	public static final String MANUAL_TASK_ID = "wf-manual-task";
-	public static final String DECISION_NODE_ID = "wf-decision-node";
-	public static final String MERGE_NODE_ID = "wf-merge-node";
-	public static final String WEIGHTED_EDGE_ID = "wf-weighted-edge";
-	public static final String EDGE_ID = "wf-edge";
 
 	@Override
 	public Operation[] getOperations(RequestOperationsAction action) {
-
-		Operation createAutomatedTask = new Operation("Automated Task", AUTOMATED_TASK_ID, Operation.Kind.CREATE_NODE);
-		Operation createManualTask = new Operation("Manual Task", MANUAL_TASK_ID, Operation.Kind.CREATE_NODE);
-		Operation createDecisionNode = new Operation("Decision Node", DECISION_NODE_ID, Operation.Kind.CREATE_NODE);
-		Operation createMergeNode = new Operation("Merge Node", MERGE_NODE_ID, Operation.Kind.CREATE_NODE);
-		Operation createWeightedEdge = new Operation("Weighted Edge", WEIGHTED_EDGE_ID,
-				Operation.Kind.CREATE_CONNECTION);
-		Operation createEdge = new Operation("Edge", EDGE_ID, Operation.Kind.CREATE_CONNECTION);
+		Operation createAutomatedTask = new Operation("Automated Task", AUTOMATED_TASK, Operation.Kind.CREATE_NODE);
+		Operation createManualTask = new Operation("Manual Task", MANUAL_TASK, Operation.Kind.CREATE_NODE);
+		Operation createDecisionNode = new Operation("Decision Node", DECISION_NODE, Operation.Kind.CREATE_NODE);
+		Operation createMergeNode = new Operation("Merge Node", MERGE_NODE, Operation.Kind.CREATE_NODE);
+		Operation createWeightedEdge = new Operation("Weighted Edge", WEIGHTED_EDGE, Operation.Kind.CREATE_CONNECTION);
+		Operation createEdge = new Operation("Edge", EDGE, Operation.Kind.CREATE_CONNECTION);
 
 		Operation[] operations = { createAutomatedTask, createManualTask, createDecisionNode, createMergeNode,
 				createWeightedEdge, createEdge };

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateAutomatedTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateAutomatedTaskHandler.java
@@ -10,21 +10,21 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.handler;
 
-import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
-import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
+import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
+import com.eclipsesource.glsp.example.workflow.schema.ModelTypes;
 
 public class CreateAutomatedTaskHandler extends CreateTaskHandler {
-	
+
 	public CreateAutomatedTaskHandler() {
-		super("automated", i -> "AutomatedTask" + i);
+		super(ModelTypes.AUTOMATED_TASK, "automated", i -> "AutomatedTask" + i);
 	}
 
 	@Override
 	public boolean handles(AbstractOperationAction execAction) {
 		if (execAction instanceof CreateNodeOperationAction) {
 			CreateNodeOperationAction action = (CreateNodeOperationAction) execAction;
-			return WorkflowOperationConfiguration.AUTOMATED_TASK_ID.equals(action.getElementTypeId());
+			return ModelTypes.AUTOMATED_TASK.equals(action.getElementTypeId());
 		}
 		return false;
 	}

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateDecisionNodeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateDecisionNodeHandler.java
@@ -15,11 +15,11 @@ import java.util.function.Function;
 import org.eclipse.sprotty.Point;
 import org.eclipse.sprotty.SModelElement;
 
-import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
+import com.eclipsesource.glsp.example.workflow.schema.ModelTypes;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
 
 public class CreateDecisionNodeHandler extends CreateNodeOperationHandler {
@@ -28,7 +28,7 @@ public class CreateDecisionNodeHandler extends CreateNodeOperationHandler {
 	public boolean handles(AbstractOperationAction execAction) {
 		if (execAction instanceof CreateNodeOperationAction) {
 			CreateNodeOperationAction action = (CreateNodeOperationAction) execAction;
-			return WorkflowOperationConfiguration.DECISION_NODE_ID.equals(action.getElementTypeId());
+			return ModelTypes.DECISION_NODE.equals(action.getElementTypeId());
 		}
 		return false;
 	}
@@ -37,6 +37,7 @@ public class CreateDecisionNodeHandler extends CreateNodeOperationHandler {
 	protected SModelElement createNode(Optional<Point> point, SModelIndex index) {
     	ActivityNode result = new ActivityNode();
     	result.setNodeType("decisionNode");
+    	result.setType(ModelTypes.DECISION_NODE);
     	point.ifPresent(result::setPosition);
     	
     	Function<Integer, String> idProvider = i -> "activityNode"+ i;

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateEdgeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateEdgeHandler.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.handler;
 
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.EDGE;
+
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
@@ -18,20 +20,19 @@ import org.eclipse.sprotty.SModelElement;
 import org.eclipse.sprotty.SModelRoot;
 import org.eclipse.sprotty.SNode;
 
-import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
-
+import com.eclipsesource.glsp.example.workflow.schema.ModelTypes;
 public class CreateEdgeHandler implements OperationHandler {
 	private static Logger log= Logger.getLogger(CreateEdgeHandler.class);
 	@Override
 	public boolean handles(AbstractOperationAction execAction) {
 		if (execAction instanceof CreateConnectionOperationAction) {
 			CreateConnectionOperationAction action = (CreateConnectionOperationAction) execAction;
-			return WorkflowOperationConfiguration.EDGE_ID.equals(action.getElementTypeId());
+			return ModelTypes.EDGE.equals(action.getElementTypeId());
 		}
 		return false;
 	}
@@ -71,13 +72,13 @@ public class CreateEdgeHandler implements OperationHandler {
 		SEdge edge = new SEdge();
 		edge.setSourceId(source.getId());
 		edge.setTargetId(target.getId());
-		String type = "edge";
-		edge.setType(type);
-		int newID = index.getTypeCount(type);
-		while (index.get(type + newID) != null) {
+	
+		edge.setType(EDGE);
+		int newID = index.getTypeCount(EDGE);
+		while (index.get(EDGE + newID) != null) {
 			newID++;
 		}
-		edge.setId(type + newID);
+		edge.setId(EDGE + newID);
 
 		currentModel.getChildren().add(edge);
 		index.addToIndex(edge, currentModel);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateManualTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateManualTaskHandler.java
@@ -10,21 +10,21 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.handler;
 
-import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
-import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
+import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
+import com.eclipsesource.glsp.example.workflow.schema.ModelTypes;
 
 public class CreateManualTaskHandler extends CreateTaskHandler {
 
 	public CreateManualTaskHandler() {
-		super("manual", i -> "ManualTask" + i);
+		super(ModelTypes.MANUAL_TASK, "manual", i -> "ManualTask" + i);
 	}
 
 	@Override
 	public boolean handles(AbstractOperationAction execAction) {
 		if (execAction instanceof CreateNodeOperationAction) {
 			CreateNodeOperationAction action = (CreateNodeOperationAction) execAction;
-			return WorkflowOperationConfiguration.MANUAL_TASK_ID.equals(action.getElementTypeId());
+			return ModelTypes.MANUAL_TASK.equals(action.getElementTypeId());
 		}
 		return false;
 	}

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateMergeNodeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateMergeNodeHandler.java
@@ -16,11 +16,11 @@ import java.util.function.Function;
 import org.eclipse.sprotty.Point;
 import org.eclipse.sprotty.SModelElement;
 
-import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
 import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
+import com.eclipsesource.glsp.example.workflow.schema.ModelTypes;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
 
 public class CreateMergeNodeHandler extends CreateNodeOperationHandler {
@@ -29,7 +29,7 @@ public class CreateMergeNodeHandler extends CreateNodeOperationHandler {
 	public boolean handles(AbstractOperationAction execAction) {
 		if (execAction instanceof CreateNodeOperationAction) {
 			CreateNodeOperationAction action = (CreateNodeOperationAction) execAction;
-			return WorkflowOperationConfiguration.MERGE_NODE_ID.equals(action.getElementTypeId());
+			return ModelTypes.MERGE_NODE.equals(action.getElementTypeId());
 		}
 		return false;
 	}
@@ -38,6 +38,7 @@ public class CreateMergeNodeHandler extends CreateNodeOperationHandler {
 	protected SModelElement createNode(Optional<Point> point, SModelIndex index) {
 		ActivityNode result = new ActivityNode();
 		result.setNodeType("mergeNode");
+		result.setType(ModelTypes.DECISION_NODE);
 		point.ifPresent(result::setPosition);
 
 		Function<Integer, String> idProvider = i -> "activityNode" + i;

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -10,6 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.handler;
 
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.COMP_HEADER;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.LABEL_HEADING;
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.LABEL_ICON;
+
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Function;
@@ -24,21 +28,22 @@ import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.schema.Icon;
 import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
-
 public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 
 	private String taskType;
 	private Function<Integer, String> labelProvider;
+	private String type;
 
-	public CreateTaskHandler(String taskType, Function<Integer, String> labelProvider) {
+	public CreateTaskHandler(String type,String taskType, Function<Integer, String> labelProvider) {
 		this.taskType = taskType;
+		this.type=type;
 		this.labelProvider = labelProvider;
 	}
 
 	@Override
 	protected SModelElement createNode(Optional<Point> point, SModelIndex index) {
 		TaskNode taskNode = new TaskNode();
-		String type = taskNode.getType();
+		taskNode.setType(type);
 		Function<Integer, String> idProvider = i -> "task" + i;
 		int nodeCounter = getCounter(index, type, idProvider);
 		taskNode.setId(idProvider.apply(nodeCounter));
@@ -55,7 +60,7 @@ public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 
 		SCompartment compHeader = new SCompartment();
 		compHeader.setId("task" + nodeCounter + "_header");
-		compHeader.setType("comp:header");
+		compHeader.setType(COMP_HEADER);
 		compHeader.setLayout("hbox");
 		compHeader.setChildren(new ArrayList<SModelElement>());
 		Icon icon = new Icon();
@@ -68,14 +73,14 @@ public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 		icon.setLayoutOptions(layoutOptions);
 		icon.setChildren(new ArrayList<SModelElement>());
 		SLabel iconLabel = new SLabel();
-		iconLabel.setType("label:icon");
+		iconLabel.setType(LABEL_ICON);
 		iconLabel.setId("task" + nodeCounter + "_ticon");
 		iconLabel.setText("" + taskNode.getTaskType().toUpperCase().charAt(0));
 		icon.getChildren().add(iconLabel);
 
 		SLabel heading = new SLabel();
 		heading.setId("task" + nodeCounter + "_classname");
-		heading.setType("label:heading");
+		heading.setType(LABEL_HEADING);
 		heading.setText(labelProvider.apply(nodeCounter));
 		compHeader.getChildren().add(icon);
 		compHeader.getChildren().add(heading);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -28,15 +28,16 @@ import com.eclipsesource.glsp.api.utils.SModelIndex;
 import com.eclipsesource.glsp.example.workflow.schema.Icon;
 import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
 import com.eclipsesource.glsp.server.operationhandler.CreateNodeOperationHandler;
+
 public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 
 	private String taskType;
 	private Function<Integer, String> labelProvider;
 	private String type;
 
-	public CreateTaskHandler(String type,String taskType, Function<Integer, String> labelProvider) {
+	public CreateTaskHandler(String type, String taskType, Function<Integer, String> labelProvider) {
 		this.taskType = taskType;
-		this.type=type;
+		this.type = type;
 		this.labelProvider = labelProvider;
 	}
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateWeightedEdgeHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateWeightedEdgeHandler.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.handler;
 
+import static com.eclipsesource.glsp.example.workflow.schema.ModelTypes.WEIGHTED_EDGE;
+
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
@@ -17,21 +19,22 @@ import org.eclipse.sprotty.SModelElement;
 import org.eclipse.sprotty.SModelRoot;
 import org.eclipse.sprotty.SNode;
 
-import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.utils.SModelIndex;
-import com.eclipsesource.glsp.example.workflow.WorkflowOperationConfiguration;
+import com.eclipsesource.glsp.example.workflow.schema.ModelTypes;
 import com.eclipsesource.glsp.example.workflow.schema.WeightedEdge;
 
 public class CreateWeightedEdgeHandler implements OperationHandler {
-	private static Logger log= Logger.getLogger(CreateWeightedEdgeHandler.class);
+	private static Logger log = Logger.getLogger(CreateWeightedEdgeHandler.class);
+
 	@Override
 	public boolean handles(AbstractOperationAction execAction) {
 		if (execAction instanceof CreateConnectionOperationAction) {
 			CreateConnectionOperationAction action = (CreateConnectionOperationAction) execAction;
-			return WorkflowOperationConfiguration.WEIGHTED_EDGE_ID.equals(action.getElementTypeId());
+			return ModelTypes.WEIGHTED_EDGE.equals(action.getElementTypeId());
 		}
 		return false;
 	}
@@ -71,9 +74,9 @@ public class CreateWeightedEdgeHandler implements OperationHandler {
 		WeightedEdge edge = new WeightedEdge();
 		edge.setSourceId(source.getId());
 		edge.setTargetId(target.getId());
-		edge.setType("edge:weighted");
-		int newID = index.getTypeCount("edge:weighted");
-		edge.setId("edge:weighted" + newID);
+		edge.setType(WEIGHTED_EDGE);
+		int newID = index.getTypeCount(WEIGHTED_EDGE);
+		edge.setId(WEIGHTED_EDGE + newID);
 		edge.setProbability("high");
 
 		currentModel.getChildren().add(edge);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ActivityNode.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ActivityNode.java
@@ -13,10 +13,10 @@ package com.eclipsesource.glsp.example.workflow.schema;
 import org.eclipse.sprotty.SNode;
 
 public class ActivityNode extends SNode {
-	public static final String TYPE = "node:activity";
-
+	public static final String BASE_TYPE = "activityNode";
+	
 	public ActivityNode() {
-		setType(ActivityNode.TYPE);
+		setType(ActivityNode.BASE_TYPE);
 	}
 
 	private String nodeType;
@@ -27,6 +27,7 @@ public class ActivityNode extends SNode {
 
 	public void setNodeType(String nodeType) {
 		this.nodeType = nodeType;
+		setType(BASE_TYPE+":"+nodeType);
 	}
 
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ModelTypes.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/ModelTypes.java
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.example.workflow.schema;
+
+public final class ModelTypes {
+	private ModelTypes() {
+	}
+
+	public static final String GRAPH = "graph";
+	public static final String LABEL_HEADING = "label:heading";
+	public static final String LABEL_TEXT = "label:text";
+	public static final String COMP_COMP = "comp";
+	public static final String COMP_HEADER = "comp:header";
+	public static final String LABEL_ICON = "label:icon";
+	public static final String EDGE = "edge";
+	public static final String WEIGHTED_EDGE = "edge:weighted";
+	public static final String HTML = "html";
+	public static final String PRE_RENDERED = "pre-rendered";
+	public static final String ICON = "icon";
+	public static final String DECISION_NODE = "activityNode:decision";
+	public static final String MERGE_NODE = "activityNode:merge";
+	public static final String MANUAL_TASK = "task:manual";
+	public static final String AUTOMATED_TASK = "task:automated";
+}

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/TaskNode.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/TaskNode.java
@@ -13,7 +13,6 @@ package com.eclipsesource.glsp.example.workflow.schema;
 import org.eclipse.sprotty.SNode;
 
 public class TaskNode extends SNode {
-	public static final String TYPE="node:task";
 	private String name;
 	private boolean expanded;
 	private int duration;
@@ -21,7 +20,6 @@ public class TaskNode extends SNode {
 	private String reference;
 
 	public TaskNode() {
-		setType(TaskNode.TYPE);
 	}
 
 	public boolean isExpanded() {
@@ -31,8 +29,6 @@ public class TaskNode extends SNode {
 	public void setExpanded(boolean expanded) {
 		this.expanded = expanded;
 	}
-
-
 
 	public String getName() {
 		return name;

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/WeightedEdge.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/schema/WeightedEdge.java
@@ -13,10 +13,9 @@ package com.eclipsesource.glsp.example.workflow.schema;
 import org.eclipse.sprotty.SEdge;
 
 public class WeightedEdge extends SEdge {
-	public static final String TYPE = "edge:weighted";
 
 	public WeightedEdge() {
-		setType(WeightedEdge.TYPE);
+		setType(ModelTypes.WEIGHTED_EDGE);
 	}
 
 	private String probability;


### PR DESCRIPTION
With this change it's always possible to match an operation to its corresponding elementType and vice versa
+ Use actual elementTypeId in operation declaration
+ Create ModelTypes constants class for the workflow example to improve maintainability
+ Refactor modelType IDs for task- & activity-nodes.
+ Ensure that each distinct model element has its own unique elementTypeId 

_Note: The header of newly introduced classes is already updated to conform to #142_ 


