### PR TITLE
Improve EditConfig API

### DIFF
--- a/client/packages/glsp-sprotty/src/base/edit-config/edit-config.ts
+++ b/client/packages/glsp-sprotty/src/base/edit-config/edit-config.ts
@@ -9,7 +9,7 @@
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
 
-import { SEdge, SModelElement, SNode } from "sprotty/lib";
+import { SEdge, SModelElement, SModelElementSchema, SNode } from "sprotty/lib";
 
 export const edgeEditConfig = Symbol.for("edgeEditConfiguration")
 export const nodeEditConfig = Symbol.for("nodeEditConfiguration")
@@ -25,21 +25,34 @@ export function isConfigurableNode(element: SModelElement): element is SNode & N
     return element instanceof SNode && isConfigurableElement(element) && element.configType === nodeEditConfig
 }
 
+export function isEdgeEditConfig(editConfig: EditConfig): editConfig is EdgeEditConfig {
+    return editConfig.configType === edgeEditConfig
+}
+
+export function isNodeEditConfig(editConfig: EditConfig): editConfig is NodeEditConfig {
+    return editConfig.configType === nodeEditConfig
+}
+
 export interface EditConfig {
     deletable: boolean
     repositionable: boolean
-    configType?:symbol
+    configType: symbol
+    elementTypeId?: string
 }
 
 export interface NodeEditConfig extends EditConfig {
     resizable: boolean
     isContainer(): boolean
-    isContainableElement(element: SModelElement): boolean
+    isContainableElement(input: SModelElement | SModelElementSchema | string): boolean
 }
 
 export interface EdgeEditConfig extends EditConfig {
     routable: boolean
-    isAllowedSource(element: SModelElement): boolean
-    isAllowedTarget(element: SModelElement): boolean
+    isAllowedSource(input: SModelElement | SModelElementSchema | string): boolean
+    isAllowedTarget(input: SModelElement | SModelElementSchema | string): boolean
+}
+
+export interface IEditConfigProvider {
+    getEditConfig(input: SModelElement | SModelElementSchema | string): EditConfig | undefined
 }
 

--- a/client/packages/glsp-sprotty/src/features/command-palette/command-palette.ts
+++ b/client/packages/glsp-sprotty/src/features/command-palette/command-palette.ts
@@ -62,6 +62,7 @@ export class LabeledAction {
     constructor(readonly label: string, readonly actions: Action[]) { }
 }
 
+
 @injectable()
 export class CommandPalette {
 

--- a/client/packages/glsp-sprotty/src/features/hints/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/hints/di.config.ts
@@ -17,6 +17,7 @@ const modelHintsModule = new ContainerModule(bind => {
     bind(TypeHintsActionIntializer).toSelf().inSingletonScope()
     bind(TYPES.IActionHandlerInitializer).toService(TypeHintsActionIntializer)
     bind(GLSP_TYPES.IModelUpdateObserver).toService(TypeHintsActionIntializer)
+    bind(GLSP_TYPES.IEditConfigProvider).toService(TypeHintsActionIntializer)
 })
 
 export default modelHintsModule;

--- a/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
+++ b/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
@@ -9,15 +9,18 @@
  * 	Tobias Ortmayr - initial API and implementation
  ******************************************************************************/
 import { injectable } from "inversify";
-import { Action, ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer, ICommand, SModelRoot } from "sprotty/lib";
+import { Action, ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer, ICommand, SModelElement, SModelElementSchema, SModelRoot } from "sprotty/lib";
 import { IModelUpdateObserver } from "../../base/command-stack";
-import { EdgeEditConfig, edgeEditConfig, EditConfig, NodeEditConfig, nodeEditConfig } from "../../base/edit-config/edit-config";
+import {
+    EdgeEditConfig, edgeEditConfig, EditConfig, IEditConfigProvider, isEdgeEditConfig, //
+    isNodeEditConfig, NodeEditConfig, nodeEditConfig
+} from "../../base/edit-config/edit-config";
 import { contains } from "../../utils/array-utils";
 import { EdgeTypeHint, isSetTypeHintsAction, NodeTypeHint, SetTypeHintsAction } from "./action-definition";
 
 
 @injectable()
-export class TypeHintsActionIntializer implements IActionHandlerInitializer, IActionHandler, IModelUpdateObserver {
+export class TypeHintsActionIntializer implements IActionHandlerInitializer, IActionHandler, IModelUpdateObserver, IEditConfigProvider {
 
     protected editConfigs: Map<string, EditConfig> = new Map
     handle(action: Action): ICommand | Action | void {
@@ -43,27 +46,61 @@ export class TypeHintsActionIntializer implements IActionHandlerInitializer, IAc
             }
         })
     }
+
+    getEditConfig(input: SModelElement | SModelElementSchema | string): EditConfig | undefined {
+        return this.editConfigs.get(getElementTypeId(input))
+    }
+
+    getAllEdgeEditConfigs(): EdgeEditConfig[] {
+        const configs: EdgeEditConfig[] = []
+        this.editConfigs.forEach((value, key) => {
+            if (isEdgeEditConfig(value)) {
+                configs.push(value)
+            }
+        })
+        return configs
+    }
+
+    getAllNodeEditConfigs(): NodeEditConfig[] {
+        const configs: NodeEditConfig[] = []
+        this.editConfigs.forEach((value, key) => {
+            if (isNodeEditConfig(value)) {
+                configs.push(value)
+            }
+        })
+        return configs
+    }
 }
 
 export function createNodeEditConfig(hint: NodeTypeHint): NodeEditConfig {
     return <NodeEditConfig>{
+        elementTypeId: hint.elementTypeId,
         deletable: hint.deletable,
         repositionable: hint.repositionable,
         resizable: hint.resizable,
         configType: nodeEditConfig,
-        isContainableElement: (element) => { return hint.containableElementTypeIds?  contains(hint.containableElementTypeIds, element.type):false},
-        isContainer: () => { return hint.containableElementTypeIds? hint.containableElementTypeIds.length > 0 :false}
+        isContainableElement: (element) => { return hint.containableElementTypeIds ? contains(hint.containableElementTypeIds, getElementTypeId(element)) : false },
+        isContainer: () => { return hint.containableElementTypeIds ? hint.containableElementTypeIds.length > 0 : false }
     }
 }
 
 
 export function createEdgeEditConfig(hint: EdgeTypeHint): EdgeEditConfig {
     return <EdgeEditConfig>{
+        elementTypeId: hint.elementTypeId,
         deletable: hint.deletable,
         repositionable: hint.repositionable,
         routable: hint.routable,
         configType: edgeEditConfig,
-        isAllowedSource: (source) => { return contains(hint.sourceElementTypeIds, source.type) },
-        isAllowedTarget: (target) => { return contains(hint.targetElementTypeIds, target.type) }
+        isAllowedSource: (source) => { return contains(hint.sourceElementTypeIds, getElementTypeId(source)) },
+        isAllowedTarget: (target) => { return contains(hint.targetElementTypeIds, getElementTypeId(target)) }
+    }
+}
+
+function getElementTypeId(input: SModelElement | SModelElementSchema | string) {
+    if (typeof (input) === 'string') {
+        return <string>input
+    } else {
+        return <string>(<any>input)["type"]
     }
 }

--- a/client/packages/glsp-sprotty/src/types.ts
+++ b/client/packages/glsp-sprotty/src/types.ts
@@ -17,5 +17,6 @@ export const GLSP_TYPES = {
     ToolFactory: Symbol.for("Factory<Tool>"),
     IModelUpdateNotifier: Symbol.for("IModelUpdateNotifier"),
     IModelUpdateObserver: Symbol.for("IModelUpdateObserver"),
-    IReadonlyModelAccessProvider: Symbol.for("IReadonlyModelAccessProvider")
+    IReadonlyModelAccessProvider: Symbol.for("IReadonlyModelAccessProvider"),
+    IEditConfigProvider: Symbol.for("IEditConfigProvider")
 }

--- a/client/packages/glsp-sprotty/src/utils/array-utils.ts
+++ b/client/packages/glsp-sprotty/src/utils/array-utils.ts
@@ -11,6 +11,7 @@
  ******************************************************************************/
 
 export function contains<T>(array: T[], value: T): boolean {
+    if (value === undefined) return false
     return array.indexOf(value) >= 0
 }
 


### PR DESCRIPTION
This change further improves and polishes the EditConfig API introduced with #141 
+ Make EditType.configType non-optional
+ Add optional EditType.elementTypeId  property
+ Make use of multi-typed parameters (SModelElement, SModelElementSchema, string) for input arguments
+ Introduce EditConfigProvider to enable obtaining the corresponding EditConfig when working on schema basis or with simple type strings.
