### PR TITLE
Extract generic API from CommandPalette

### DIFF
--- a/client/packages/glsp-sprotty/src/base/di.config.ts
+++ b/client/packages/glsp-sprotty/src/base/di.config.ts
@@ -12,6 +12,7 @@ import { ContainerModule } from "inversify";
 import { TYPES } from "sprotty/lib";
 import { GLSP_TYPES } from "../types";
 import { GLSPCommandStack, IReadonlyModelAccess } from "./command-stack";
+import { DiagramUIExtensionRegistry } from "./diagram-ui-extension/diagram-ui-extension-registry";
 
 const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     if (isBound(TYPES.ICommandStack)) {
@@ -27,6 +28,9 @@ const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) =>
             });
         };
     });
+
+    bind(DiagramUIExtensionRegistry).toSelf().inSingletonScope();
+    bind(TYPES.IActionHandlerInitializer).toService(DiagramUIExtensionRegistry)
 })
 
 export default defaultGLSPModule;

--- a/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension-registry.ts
+++ b/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension-registry.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable, multiInject, optional } from "inversify";
+import {
+    Action, ActionHandlerRegistry, CommandExecutionContext, CommandResult, IActionHandler, IActionHandlerInitializer, ICommand, //
+    InstanceRegistry, SystemCommand
+} from "sprotty/lib";
+import { toArray } from "sprotty/lib/utils/iterable";
+import { GLSP_TYPES } from "../../types";
+import { IDiagramUIExtension } from "./diagram-ui-extension";
+
+/**
+ * Action requesting to show the diagram UI extension with specified id.
+ */
+export class ShowDiagramUIExtensionAction implements Action {
+    static KIND = "showDiagramUIExtension";
+    readonly kind = ShowDiagramUIExtensionAction.KIND;
+    constructor(public readonly extensionId: string, public readonly selectedElementIds: string[]) { }
+}
+
+/**
+ * Action requesting to hide the diagram UI extension with specified id.
+ */
+export class HideDiagramUIExtensionAction implements Action {
+    static KIND = "hideDiagramUIExtension";
+    readonly kind = HideDiagramUIExtensionAction.KIND;
+    constructor(public readonly extensionId: string) { }
+}
+
+/**
+ * The diagram UI extension registry maintains all available diagram UI extensions and makes them retrievable via ID
+ */
+@injectable()
+export class DiagramUIExtensionRegistry extends InstanceRegistry<IDiagramUIExtension> implements IActionHandlerInitializer, IActionHandler {
+
+    constructor(@multiInject(GLSP_TYPES.IDiagramUIExtension) @optional() extensions: (IDiagramUIExtension)[] = []) {
+        super();
+        extensions.forEach(
+            extension => this.register(extension.id, extension)
+        );
+    }
+
+    initialize(registry: ActionHandlerRegistry): void {
+        registry.register(ShowDiagramUIExtensionAction.KIND, this)
+        registry.register(HideDiagramUIExtensionAction.KIND, this)
+    }
+
+    handle(action: Action): void | ICommand | Action {
+        if (action instanceof ShowDiagramUIExtensionAction) {
+            return new DiagramUIExtensionActionCommand((context) => {
+                const index = context.root.index;
+                const selectedElements = toArray(index.all()
+                    .filter(e => action.selectedElementIds.indexOf(e.id) >= 0))
+                const extension = this.get(action.extensionId)
+                if (extension) {
+                    extension.show(selectedElements)
+                }
+            });
+        } else if (action instanceof HideDiagramUIExtensionAction) {
+            return new DiagramUIExtensionActionCommand((context) => {
+                const extension = this.get(action.extensionId)
+                if (extension) {
+                    extension.hide()
+                }
+            });
+        }
+    }
+}
+
+export type CommandEffect = (context: CommandExecutionContext) => void;
+
+/**
+ * A system command that doesn't change the model but just performs a specified `effect`.
+ */
+export class DiagramUIExtensionActionCommand extends SystemCommand {
+
+    constructor(readonly effect: CommandEffect) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandResult {
+        this.effect(context);
+        context.root.index
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+}

--- a/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension.ts
+++ b/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension.ts
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable } from "inversify";
+import { Action, IActionDispatcherProvider, ILogger, SModelElement, TYPES, ViewerOptions } from "sprotty/lib";
+
+/** A toggable extension  that can display additional (UI) information
+ *  on top of a sprotty diagram
+ */
+export interface IDiagramUIExtension {
+    readonly id: string
+    show(selectedElements: SModelElement[]): void
+    hide(): void
+}
+
+/** An abstract Diagram UI extension that can serve as a common base for different
+ * subtypes of diagram UI extensions
+ */
+@injectable()
+export abstract class BaseDiagramUIExtension implements IDiagramUIExtension {
+    abstract readonly id: string
+    protected containerElement: HTMLDivElement;
+    constructor(
+        @inject(TYPES.ViewerOptions) protected options: ViewerOptions,
+        @inject(TYPES.IActionDispatcherProvider) protected actionDispatcherProvider: IActionDispatcherProvider,
+        @inject(TYPES.ILogger) protected logger: ILogger) { }
+
+    show(selectedElements: SModelElement[]) {
+        if (!this.containerElement) {
+            this.createUiElements();
+        }
+        this.updatePosition(selectedElements);
+        this.containerElement.style.visibility = 'visible';
+        this.containerElement.style.opacity = '1';
+    }
+
+    /** Subtypes can override this method to modfiy the position
+     * of selection-aware extensions
+     */
+    protected updatePosition(selectedElements: SModelElement[]) {
+        // default: do nothing
+    }
+    hide(): void {
+        if (this.containerElement) {
+            this.containerElement.style.visibility = 'hidden';
+            this.containerElement.style.opacity = '0';
+        }
+
+        // restore focus of sprotty's svg element
+        // _sprotty: svg container id as specified in DiagramManagerImpl
+        const sprottyDiv = document.getElementById(this.options.baseDiv + "_sprotty");
+        if (sprottyDiv) {
+            sprottyDiv.focus();
+        }
+    }
+
+    protected abstract createUiElements(): void
+
+    protected executeDiagramUIExtensionAction(item: LabeledAction) {
+        this.actionDispatcherProvider()
+            .then((actionDispatcher) => actionDispatcher.dispatchAll(item.actions))
+            .catch((reason) => this.logger.error(this, 'No action dispatcher available to execute diagram ui extension  action', reason));
+        this.hide();
+    }
+}
+
+/**
+ * Action with a label. This is used to represent the available actions in the command palettes.
+ */
+export class LabeledAction {
+    constructor(readonly label: string, readonly actions: Action[]) { }
+}

--- a/client/packages/glsp-sprotty/src/features/command-palette/action-provider.ts
+++ b/client/packages/glsp-sprotty/src/features/command-palette/action-provider.ts
@@ -13,9 +13,9 @@ import { inject, injectable, multiInject, optional } from "inversify";
 import { CenterAction, ILogger, SelectAction, SModelElement, SModelRoot, TYPES } from "sprotty/lib";
 import { toArray } from "sprotty/lib/utils/iterable";
 import { IReadonlyModelAccessProvider } from "../../base/command-stack";
+import { LabeledAction } from "../../base/diagram-ui-extension/diagram-ui-extension";
 import { GLSP_TYPES } from "../../types";
 import { isNameable, name } from "../nameable/model";
-import { LabeledAction } from "./command-palette";
 
 export interface ICommandPaletteActionProvider {
     getActions(selectedElements: SModelElement[]): Promise<LabeledAction[]>;

--- a/client/packages/glsp-sprotty/src/features/command-palette/command-palette.ts
+++ b/client/packages/glsp-sprotty/src/features/command-palette/command-palette.ts
@@ -12,12 +12,13 @@
 import { AutocompleteResult, AutocompleteSettings } from "autocompleter";
 import { inject, injectable } from "inversify";
 import {
-    Action, ActionHandlerRegistry, CommandExecutionContext, CommandResult, findParentByFeature, IActionDispatcherProvider, //
-    IActionHandler, IActionHandlerInitializer, ICommand, ILogger, isBoundsAware, isSelectable, isViewport, KeyListener, //
-    SModelElement, SystemCommand, TYPES, ViewerOptions
+    Action, findParentByFeature, IActionDispatcherProvider, ILogger, isBoundsAware, isSelectable, isViewport, KeyListener, //
+    SModelElement, TYPES, ViewerOptions
 } from "sprotty/lib";
 import { toArray } from "sprotty/lib/utils/iterable";
 import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
+import { BaseDiagramUIExtension, LabeledAction } from "../../base/diagram-ui-extension/diagram-ui-extension";
+import { HideDiagramUIExtensionAction, ShowDiagramUIExtensionAction } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
 import { GLSP_TYPES } from "../../types";
 import { ICommandPaletteActionProviderRegistry } from "./action-provider";
 
@@ -29,42 +30,19 @@ const configureAutocomplete: (settings: AutocompleteSettings<LabeledAction>) => 
 export class CommandPaletteKeyListener extends KeyListener {
     keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Escape')) {
-            return [new HideCommandPaletteAction()];
+            return [new HideDiagramUIExtensionAction(CommandPalette.ID)];
         } else if (matchesKeystroke(event, 'Space', 'ctrl')) {
             const selected = toArray(element.root.index.all().filter(e => isSelectable(e) && e.selected)).map(e => e.id);
-            return [new ShowCommandPaletteAction(selected)];
+            return [new ShowDiagramUIExtensionAction(CommandPalette.ID, selected)];
         }
         return [];
     }
 }
 
-/**
- * Action requesting to show the command palette.
- */
-export class ShowCommandPaletteAction implements Action {
-    static KIND = "show-command-palette";
-    readonly kind = ShowCommandPaletteAction.KIND;
-    constructor(public readonly selectedElementIds: string[]) { }
-}
-
-/**
- * Action requesting to hide the command palette.
- */
-export class HideCommandPaletteAction implements Action {
-    static KIND = "hide-command-palette";
-    readonly kind = HideCommandPaletteAction.KIND;
-}
-
-/**
- * Action with a label. This is used to represent the available actions in the command palettes.
- */
-export class LabeledAction {
-    constructor(readonly label: string, readonly actions: Action[]) { }
-}
-
 @injectable()
-export class CommandPalette {
-
+export class CommandPalette extends BaseDiagramUIExtension {
+    static readonly ID = "glsp-command-palette"
+    readonly id = CommandPalette.ID
     readonly xOffset = 20;
     readonly yOffset = 30;
     readonly defaultWidth = 400;
@@ -77,15 +55,12 @@ export class CommandPalette {
         @inject(TYPES.ViewerOptions) protected options: ViewerOptions,
         @inject(TYPES.IActionDispatcherProvider) protected actionDispatcherProvider: IActionDispatcherProvider,
         @inject(GLSP_TYPES.ICommandPaletteActionProviderRegistry) protected actionProvider: ICommandPaletteActionProviderRegistry,
-        @inject(TYPES.ILogger) protected logger: ILogger) { }
+        @inject(TYPES.ILogger) protected logger: ILogger) {
+        super(options, actionDispatcherProvider, logger);
+    }
 
     show(selectedElements: SModelElement[]) {
-        if (!this.containerElement) {
-            this.createUiElements();
-        }
-        this.updatePosition(selectedElements);
-        this.containerElement.style.visibility = 'visible';
-        this.containerElement.style.opacity = '1';
+        super.show(selectedElements)
         if (this.inputElement.value) {
             this.inputElement.setSelectionRange(0, this.inputElement.value.length);
         }
@@ -148,7 +123,7 @@ export class CommandPalette {
                     .catch((reason) => this.logger.error(this, "Failed to obtain actions from command palette action providers", reason));
             },
             onSelect: (item: LabeledAction) => {
-                this.executeCommandPaletteAction(item);
+                this.executeDiagramUIExtensionAction(item);
             },
             customize: (input: HTMLInputElement, inputRect: ClientRect | DOMRect, container: HTMLDivElement, maxHeight: number) => {
                 // move container into our command palette container as this is already positioned correctly
@@ -167,79 +142,11 @@ export class CommandPalette {
         }));
     }
 
-    protected executeCommandPaletteAction(item: LabeledAction) {
-        this.actionDispatcherProvider()
-            .then((actionDispatcher) => actionDispatcher.dispatchAll(item.actions))
-            .catch((reason) => this.logger.error(this, 'No action dispatcher available to execute command palette action', reason));
-        this.hide();
-    }
 
     hide() {
-        if (this.containerElement) {
-            this.containerElement.style.visibility = 'hidden';
-            this.containerElement.style.opacity = '0';
-        }
         if (this.autoCompleteResult) {
             this.autoCompleteResult.destroy();
         }
-        // restore focus of sprotty's svg element
-        // _sprotty: svg container id as specified in DiagramManagerImpl
-        const sprottyDiv = document.getElementById(this.options.baseDiv + "_sprotty");
-        if (sprottyDiv) {
-            sprottyDiv.focus();
-        }
-    }
-}
-
-@injectable()
-export class CommandPaletteActionHandlerInitializer implements IActionHandlerInitializer, IActionHandler {
-
-    @inject(CommandPalette)
-    readonly commandPalette: CommandPalette;
-
-    initialize(registry: ActionHandlerRegistry): void {
-        registry.register(ShowCommandPaletteAction.KIND, this);
-        registry.register(HideCommandPaletteAction.KIND, this);
-    }
-
-    handle(action: Action): void | ICommand | Action {
-        if (action instanceof ShowCommandPaletteAction) {
-            return new CommandPaletteActionCommand((context) => {
-                const index = context.root.index;
-                const selectedElements = toArray(index.all()
-                    .filter(e => action.selectedElementIds.indexOf(e.id) >= 0));
-                this.commandPalette.show(selectedElements)
-            });
-        } else if (action instanceof HideCommandPaletteAction) {
-            return new CommandPaletteActionCommand((context) => {
-                this.commandPalette.hide();
-            });
-        }
-    }
-}
-
-export type CommandEffect = (context: CommandExecutionContext) => void;
-
-/**
- * A system command that doesn't change the model but just performs a specified `effect`.
- */
-export class CommandPaletteActionCommand extends SystemCommand {
-
-    constructor(readonly effect: CommandEffect) {
-        super();
-    }
-
-    execute(context: CommandExecutionContext): CommandResult {
-        this.effect(context);
-        context.root.index
-        return context.root;
-    }
-
-    undo(context: CommandExecutionContext): CommandResult {
-        return context.root;
-    }
-
-    redo(context: CommandExecutionContext): CommandResult {
-        return context.root;
+        super.hide()
     }
 }

--- a/client/packages/glsp-sprotty/src/features/command-palette/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/command-palette/di.config.ts
@@ -13,11 +13,11 @@ import { ContainerModule } from "inversify";
 import { TYPES } from "sprotty/lib";
 import { GLSP_TYPES } from "../../types";
 import { CommandPaletteActionProviderRegistry, ICommandPaletteActionProvider, NavigationCommandPaletteActionProvider } from "./action-provider";
-import { CommandPalette, CommandPaletteActionHandlerInitializer, CommandPaletteKeyListener } from "./command-palette";
+import { CommandPalette, CommandPaletteKeyListener } from "./command-palette";
 
 const commandPaletteModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(CommandPalette).toSelf().inSingletonScope();
-    bind(TYPES.IActionHandlerInitializer).to(CommandPaletteActionHandlerInitializer);
+    bind(GLSP_TYPES.IDiagramUIExtension).toService(CommandPalette)
     bind(TYPES.KeyListener).to(CommandPaletteKeyListener);
     bind(CommandPaletteActionProviderRegistry).toSelf().inSingletonScope();
     bind(GLSP_TYPES.ICommandPaletteActionProviderRegistry).toProvider<ICommandPaletteActionProvider>((context) => {

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -10,6 +10,7 @@
  ******************************************************************************/
 export * from 'sprotty/lib';
 export * from './base/command-stack';
+export * from './base/diagram-ui-extension/diagram-ui-extension';
 export * from './base/edit-config/edit-config';
 export * from './features/change-bounds/model';
 export * from './features/change-bounds/resize';
@@ -39,7 +40,6 @@ export * from './utils/smodel-util';
 export * from './utils/viewpoint-util';
 export { saveModule, toolManagerModule, executeModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, changeBoundsCommandModule, commandPaletteModule };
 
-
 import defaultGLSPModule from './base/di.config';
 import changeBoundsCommandModule from './features/change-bounds/di.config';
 import commandPaletteModule from './features/command-palette/di.config';
@@ -48,5 +48,7 @@ import modelHintsModule from './features/hints/di.config';
 import saveModule from './features/save/di.config';
 import toolFeedbackModule from './features/tool-feedback/di.config';
 import toolManagerModule from './features/tool-manager/di.config';
+
+
 
 

--- a/client/packages/glsp-sprotty/src/types.ts
+++ b/client/packages/glsp-sprotty/src/types.ts
@@ -17,5 +17,6 @@ export const GLSP_TYPES = {
     ToolFactory: Symbol.for("Factory<Tool>"),
     IModelUpdateNotifier: Symbol.for("IModelUpdateNotifier"),
     IModelUpdateObserver: Symbol.for("IModelUpdateObserver"),
-    IReadonlyModelAccessProvider: Symbol.for("IReadonlyModelAccessProvider")
+    IReadonlyModelAccessProvider: Symbol.for("IReadonlyModelAccessProvider"),
+    IDiagramUIExtension: Symbol.for("DiagramUIExtension")
 }


### PR DESCRIPTION
Based on the implementation of the command palette (#124) this change introduces a common API for `DiagramUIExtensions`. A `DiagramUIExtension` is  an additional UI element for sprotty diagrams that can be activated/deactivated at runtime. Possible features that can be implemented as a `DiagramUIExtension` (apart from the command palette) are e.g. a tool palette (#80) or papyrus-like context-aware diagram assistants.

