### PR TITLE
#111 Refactor ModelUpdateObserver implementation

### DIFF
--- a/client/packages/glsp-sprotty/src/base/command-stack.ts
+++ b/client/packages/glsp-sprotty/src/base/command-stack.ts
@@ -13,23 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, multiInject, optional } from "inversify";
-import {
-    AnimationFrameSyncer, CommandExecutionContext, CommandResult, CommandStack, CommandStackOptions, //
-    ICommand, ILogger, IModelFactory, IViewerProvider, SetModelCommand, SModelRoot, TYPES, UpdateModelCommand
-} from "sprotty/lib";
-import { GLSP_TYPES } from "../types";
-import { distinctAdd, remove } from "../utils/array-utils";
-
-export interface IModelUpdateObserver {
-    /*Is called before an update model request from the server is applied*/
-    beforeServerUpdate(model: SModelRoot): void
-}
-
-export interface IModelUpdateNotifier {
-    registerObserver(observer: IModelUpdateObserver): boolean | void;
-    deregisterObserver(observer: IModelUpdateObserver): boolean | void;
-}
+import { inject, injectable } from "inversify";
+import { AnimationFrameSyncer, CommandStack, CommandStackOptions, ILogger, IModelFactory, IViewerProvider, SModelRoot, TYPES } from "sprotty/lib";
 
 /**
  * Provides access to the current `SModelRoot` instance.
@@ -55,57 +40,19 @@ export interface IReadonlyModelAccess {
 export type IReadonlyModelAccessProvider = () => Promise<IReadonlyModelAccess>;
 
 @injectable()
-export class GLSPCommandStack extends CommandStack implements IReadonlyModelAccess, IModelUpdateNotifier {
-
-    private notifyObservers = false;
-    public serverSideUpdate: boolean = false;
+export class GLSPCommandStack extends CommandStack implements IReadonlyModelAccess {
 
     constructor(@inject(TYPES.IModelFactory) protected modelFactory: IModelFactory,
         @inject(TYPES.IViewerProvider) protected viewerProvider: IViewerProvider,
         @inject(TYPES.ILogger) protected logger: ILogger,
         @inject(TYPES.AnimationFrameSyncer) protected syncer: AnimationFrameSyncer,
-        @inject(TYPES.CommandStackOptions) protected options: CommandStackOptions,
-        @multiInject(GLSP_TYPES.IModelUpdateObserver) @optional() protected observers: IModelUpdateObserver[] = []) {
+        @inject(TYPES.CommandStackOptions) protected options: CommandStackOptions) {
         super(modelFactory, viewerProvider, logger, syncer, options);
     }
-
-    registerObserver(observer: IModelUpdateObserver): boolean | void {
-        return distinctAdd(this.observers, observer);
-    }
-
-    deregisterObserver(observer: IModelUpdateObserver): boolean | void {
-        return remove(this.observers, observer);
-    }
-
-    async update(model: SModelRoot): Promise<void> {
-        if (this.viewer === undefined)
-            this.viewer = await this.viewerProvider();
-        if (this.notifyObservers && this.serverSideUpdate) {
-            this.observers.forEach(obs => obs.beforeServerUpdate(model));
-            this.notifyObservers = false;
-            this.serverSideUpdate = false;
-        }
-        this.viewer.update(model);
-    }
-
-    protected handleCommand(command: ICommand,
-        operation: (context: CommandExecutionContext) => CommandResult,
-        beforeResolve: (command: ICommand, context: CommandExecutionContext) => void) {
-
-        if (isObservedCommand) {
-            this.notifyObservers = true;
-        }
-        super.handleCommand(command, operation, beforeResolve);
-    }
-
     get model(): Promise<SModelRoot> {
         return this.currentPromise.then(
             state => this.modelFactory.createRoot(state.root)
         );
     }
-
 }
 
-function isObservedCommand(command: ICommand) {
-    return (command instanceof SetModelCommand || command instanceof UpdateModelCommand);
-}

--- a/client/packages/glsp-sprotty/src/base/di.config.ts
+++ b/client/packages/glsp-sprotty/src/base/di.config.ts
@@ -19,17 +19,17 @@ import "../../css/glsp-sprotty.css";
 import { GLSP_TYPES } from "../types";
 import { GLSPCommandStack, IReadonlyModelAccess } from "./command-stack";
 import { DiagramUIExtensionActionHandlerInitializer, DiagramUIExtensionRegistry } from "./diagram-ui-extension/diagram-ui-extension-registry";
+import { ModelUpdateActionInitializer, ModelUpdateObserverRegistry } from "./model/model-update-observer-registry";
 import { Tool } from "./tool-manager/tool";
 import { createToolFactory, DefaultToolsEnablingKeyListener, GLSPToolManagerActionHandlerInitializer, ToolManager } from "./tool-manager/tool-manager";
 
 const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    // GLSP Commandstack  initialization ------------------------------------
     if (isBound(TYPES.ICommandStack)) {
         unbind(TYPES.ICommandStack);
     }
-    // GLSP Commandstack  initialization ------------------------------------
     bind(GLSPCommandStack).toSelf().inSingletonScope();
     bind(TYPES.ICommandStack).toService(GLSPCommandStack);
-    bind(GLSP_TYPES.IModelUpdateNotifier).toService(GLSPCommandStack);
     bind(GLSP_TYPES.IReadonlyModelAccessProvider).toProvider<IReadonlyModelAccess>((context) => {
         return () => {
             return new Promise<IReadonlyModelAccess>((resolve) => {
@@ -39,7 +39,7 @@ const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) =>
     });
 
     // DiagramUIExtension registry initialization ------------------------------------
-    bind(DiagramUIExtensionRegistry).toSelf().inSingletonScope();
+    bind(GLSP_TYPES.DiagramUIExtensionRegistry).to(DiagramUIExtensionRegistry).inSingletonScope();
     bind(TYPES.IActionHandlerInitializer).to(DiagramUIExtensionActionHandlerInitializer)
 
     // Tool manager initialization ------------------------------------
@@ -47,6 +47,10 @@ const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) =>
     bind(TYPES.KeyListener).to(DefaultToolsEnablingKeyListener);
     bind(TYPES.IActionHandlerInitializer).to(GLSPToolManagerActionHandlerInitializer);
     bind(GLSP_TYPES.IToolFactory).toFactory<Tool>((createToolFactory()));
+
+    // Model update initialization ------------------------------------
+    bind(GLSP_TYPES.ModelUpdateObserverRegistry).to(ModelUpdateObserverRegistry).inSingletonScope();
+    bind(TYPES.IActionHandlerInitializer).to(ModelUpdateActionInitializer)
 })
 
 export default defaultGLSPModule;

--- a/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension-registry.ts
+++ b/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension-registry.ts
@@ -23,6 +23,20 @@ import { GLSP_TYPES } from "../../types";
 import { IDiagramUIExtension } from "./diagram-ui-extension";
 
 /**
+ * Convinience class for classes that implement both `IActionHandler` and `IActionHandlerInitializer`
+ */
+@injectable()
+export abstract class SelfInitializingActionHandler implements IActionHandler, IActionHandlerInitializer {
+
+    initialize(registry: ActionHandlerRegistry) {
+        this.handledActionKinds.forEach(kind => registry.register(kind, this))
+    }
+
+    abstract handle(action: Action): ICommand | Action | void
+    abstract handledActionKinds: string[]
+
+}
+/**
  * Action requesting to show the diagram UI extension with specified id.
  */
 export class ShowDiagramUIExtensionAction implements Action {
@@ -57,13 +71,10 @@ export class DiagramUIExtensionRegistry extends InstanceRegistry<IDiagramUIExten
  * Initalizer and handler for DiagramUIExension actions.
  */
 @injectable()
-export class DiagramUIExtensionActionHandlerInitializer implements IActionHandlerInitializer, IActionHandler {
-    @inject(DiagramUIExtensionRegistry) protected readonly registry: DiagramUIExtensionRegistry
+export class DiagramUIExtensionActionHandlerInitializer extends SelfInitializingActionHandler {
+    @inject(GLSP_TYPES.DiagramUIExtensionRegistry) protected readonly registry: DiagramUIExtensionRegistry
 
-    initialize(registry: ActionHandlerRegistry): void {
-        registry.register(ShowDiagramUIExtensionAction.KIND, this)
-        registry.register(HideDiagramUIExtensionAction.KIND, this)
-    }
+    readonly handledActionKinds = [ShowDiagramUIExtensionAction.KIND, HideDiagramUIExtensionAction.KIND]
 
     handle(action: Action): void | ICommand | Action {
         if (action instanceof ShowDiagramUIExtensionAction) {

--- a/client/packages/glsp-sprotty/src/base/model/model-update-observer-registry.ts
+++ b/client/packages/glsp-sprotty/src/base/model/model-update-observer-registry.ts
@@ -1,0 +1,87 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable, multiInject, optional } from "inversify";
+import { Action, ICommand, IModelFactory, SetModelAction, SetModelCommand, SModelRoot, TYPES, UpdateModelAction, UpdateModelCommand } from "sprotty/lib";
+import { GLSP_TYPES } from "../../types";
+import { distinctAdd, remove } from "../../utils/array-utils";
+import { SelfInitializingActionHandler } from "../diagram-ui-extension/diagram-ui-extension-registry";
+
+export interface IModelUpdateObserver {
+    /*Is called before an update model request from the server is applied*/
+    beforeServerUpdate(model: SModelRoot): void
+}
+
+/**
+ * Injectable registry for `IModelUpdateObservers` that will notifiy all registered observers before a server update is processed
+ */
+@injectable()
+export class ModelUpdateObserverRegistry implements IModelUpdateObserver {
+
+    constructor(@multiInject(GLSP_TYPES.IModelUpdateObserver) @optional() protected observers: IModelUpdateObserver[] = []) {
+        observers.forEach(observer => this.register(observer))
+    }
+
+    register(observer: IModelUpdateObserver) {
+        distinctAdd(this.observers, observer)
+    }
+
+    beforeServerUpdate(model: SModelRoot): void {
+        this.observers.forEach(observer => observer.beforeServerUpdate(model))
+    }
+
+    deregister(observer: IModelUpdateObserver) {
+        remove(this.observers, observer)
+    }
+}
+/**
+ * Actionhandler that replaces the default action handler for `SetModelAction` and `UpdateModelAction`
+ * and allows registered `IModelUpdateObservers` to process and modify the model before the actual update is executed
+ */
+@injectable()
+export class ModelUpdateActionInitializer extends SelfInitializingActionHandler {
+    @inject(GLSP_TYPES.ModelUpdateObserverRegistry) protected readonly observerRegistry: ModelUpdateObserverRegistry
+    @inject(TYPES.IModelFactory) protected readonly modelFactory: IModelFactory
+
+    readonly handledActionKinds = [SetModelCommand.KIND, UpdateModelCommand.KIND]
+
+    handle(action: Action): ICommand | Action | void {
+        if (isSetModelAction(action) || isUpdateModelAction(action)) {
+            if (action.newRoot) {
+                const model = this.modelFactory.createRoot(action.newRoot)
+                this.observerRegistry.beforeServerUpdate(model)
+                // Transform the model back into the corresponding schema after
+                // all observers have applied their modifications
+                const updatedSchema = this.modelFactory.createSchema(model)
+
+                if (action.kind === (SetModelCommand.KIND)) {
+                    return new SetModelCommand(new SetModelAction(updatedSchema))
+                } else {
+                    return new UpdateModelCommand(new UpdateModelAction(updatedSchema, true))
+                }
+            }
+        }
+    }
+}
+
+export function isSetModelAction(action: Action): action is SetModelAction {
+    return action.kind === SetModelCommand.KIND && (<any>action)["newRoot"] !== undefined
+}
+
+export function isUpdateModelAction(action: Action): action is UpdateModelAction {
+    return action.kind === UpdateModelCommand.KIND &&
+        ((<any>action)["newRoot"] !== undefined || (<any>action)["matches"] !== undefined)
+        && (<any>action)["animate"] !== undefined
+}

--- a/client/packages/glsp-sprotty/src/features/hints/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/hints/di.config.ts
@@ -16,13 +16,13 @@
 import { ContainerModule } from "inversify";
 import { TYPES } from "sprotty/lib";
 import { GLSP_TYPES } from "../../types";
-import { TypeHintsActionIntializer } from "./type-hints-action-initializer";
+import { TypeHintsActionHandler } from "./type-hints-action-initializer";
 
 const modelHintsModule = new ContainerModule(bind => {
-    bind(TypeHintsActionIntializer).toSelf().inSingletonScope()
-    bind(TYPES.IActionHandlerInitializer).toService(TypeHintsActionIntializer)
-    bind(GLSP_TYPES.IModelUpdateObserver).toService(TypeHintsActionIntializer)
-    bind(GLSP_TYPES.IEditConfigProvider).toService(TypeHintsActionIntializer)
+    bind(TypeHintsActionHandler).toSelf().inSingletonScope()
+    bind(TYPES.IActionHandlerInitializer).toService(TypeHintsActionHandler)
+    bind(GLSP_TYPES.IModelUpdateObserver).toService(TypeHintsActionHandler)
+    bind(GLSP_TYPES.IEditConfigProvider).toService(TypeHintsActionHandler)
 })
 
 export default modelHintsModule;

--- a/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
+++ b/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
@@ -14,29 +14,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { injectable } from "inversify";
-import { Action, ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer, ICommand, SModelElement, SModelElementSchema, SModelRoot } from "sprotty/lib";
-import { IModelUpdateObserver } from "../../base/command-stack";
+import { Action, ICommand, SModelElement, SModelElementSchema, SModelRoot } from "sprotty/lib";
+import { SelfInitializingActionHandler } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
 import {
     EdgeEditConfig, edgeEditConfig, EditConfig, IEditConfigProvider, isEdgeEditConfig, //
     isNodeEditConfig, NodeEditConfig, nodeEditConfig
 } from "../../base/edit-config/edit-config";
+import { IModelUpdateObserver } from "../../base/model/model-update-observer-registry";
 import { contains } from "../../utils/array-utils";
 import { EdgeTypeHint, isSetTypeHintsAction, NodeTypeHint, SetTypeHintsAction } from "./action-definition";
 
 
 @injectable()
-export class TypeHintsActionIntializer implements IActionHandlerInitializer, IActionHandler, IModelUpdateObserver, IEditConfigProvider {
-
+export class TypeHintsActionHandler extends SelfInitializingActionHandler implements IModelUpdateObserver, IEditConfigProvider {
     protected editConfigs: Map<string, EditConfig> = new Map
+    readonly handledActionKinds = [SetTypeHintsAction.KIND]
+
     handle(action: Action): ICommand | Action | void {
         if (isSetTypeHintsAction(action)) {
             action.nodeHints.forEach(hint => this.editConfigs.set(hint.elementTypeId, createNodeEditConfig(hint)))
             action.edgeHints.forEach(hint => this.editConfigs.set(hint.elementTypeId, createEdgeEditConfig(hint)))
         }
-    }
-
-    initialize(registry: ActionHandlerRegistry): void {
-        registry.register(SetTypeHintsAction.KIND, this)
     }
 
     beforeServerUpdate(model: SModelRoot) {

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
@@ -27,6 +27,7 @@ import { FeedbackEdgeEndView } from "./view";
 
 const toolFeedbackModule = new ContainerModule(bind => {
     bind(GLSP_TYPES.IFeedbackActionDispatcher).to(FeedbackActionDispatcher).inSingletonScope();
+    bind(GLSP_TYPES.IModelUpdateObserver).toService(GLSP_TYPES.IFeedbackActionDispatcher)
 
     // create node and edge tool feedback
     bind(TYPES.ICommand).toConstructor(ShowNodeCreationToolFeedbackCommand);

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/feedback-action-dispatcher.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/feedback-action-dispatcher.ts
@@ -15,8 +15,7 @@
  ********************************************************************************/
 import { inject, injectable } from "inversify";
 import { Action, IActionDispatcher, ILogger, SModelRoot, TYPES } from "sprotty/lib";
-import { IModelUpdateNotifier, IModelUpdateObserver } from "../../base/command-stack";
-import { GLSP_TYPES } from "../../types";
+import { IModelUpdateObserver } from "../../base/model/model-update-observer-registry";
 
 export interface IFeedbackEmitter { }
 
@@ -52,10 +51,8 @@ export class FeedbackActionDispatcher implements IFeedbackActionDispatcher, IMod
     protected feedbackEmitters: Map<IFeedbackEmitter, Action[]> = new Map;
 
     constructor(
-        @inject(GLSP_TYPES.IModelUpdateNotifier) protected modelUpdateNotifier: IModelUpdateNotifier,
         @inject(TYPES.IActionDispatcherProvider) protected actionDispatcher: () => Promise<IActionDispatcher>,
         @inject(TYPES.ILogger) protected logger: ILogger) {
-        this.modelUpdateNotifier.registerObserver(this);
     }
 
     registerFeedback(feedbackEmitter: IFeedbackEmitter, actions: Action[]): void {

--- a/client/packages/glsp-sprotty/src/features/tool-palette/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-palette/di.config.ts
@@ -17,12 +17,12 @@ import { ContainerModule } from "inversify";
 import { TYPES } from "sprotty/lib";
 import "../../../css/tool-palette.css";
 import { GLSP_TYPES } from "../../types";
-import { ToolPalette, ToolPaletteActionInitializer } from "./tool-palette";
+import { ToolPalette, ToolPaletteActionHandler } from "./tool-palette";
 
 const toolPaletteModule = new ContainerModule((bind) => {
     bind(ToolPalette).toSelf().inSingletonScope();
     bind(GLSP_TYPES.IDiagramUIExtension).toService(ToolPalette)
-    bind(TYPES.IActionHandlerInitializer).to(ToolPaletteActionInitializer)
+    bind(TYPES.IActionHandlerInitializer).to(ToolPaletteActionHandler)
 });
 
 export default toolPaletteModule;

--- a/client/packages/glsp-sprotty/src/features/tool-palette/tool-palette.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-palette/tool-palette.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 import { inject, injectable } from "inversify";
 import {
-    Action, ActionHandlerRegistry, IActionDispatcherProvider, IActionHandler, IActionHandlerInitializer, ICommand, ILogger, //
+    Action, IActionDispatcherProvider, ICommand, ILogger, //
     TYPES, ViewerOptions
 } from "sprotty/lib";
 import { BaseDiagramUIExtension } from "../../base/diagram-ui-extension/diagram-ui-extension";
-import { ShowDiagramUIExtensionAction } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
+import { SelfInitializingActionHandler, ShowDiagramUIExtensionAction } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
 import { EnableDefaultToolsAction, EnableToolsAction } from "../../base/tool-manager/tool";
 import { isSetOperationsAction, Operation, OperationKind, SetOperationsAction } from "../operation/set-operations";
 import { deriveToolId } from "../tools/creation-tool";
@@ -159,13 +159,10 @@ function createToolGroup(label: string, groupId: string): HTMLElement {
 }
 
 @injectable()
-export class ToolPaletteActionInitializer implements IActionHandler, IActionHandlerInitializer {
+export class ToolPaletteActionHandler extends SelfInitializingActionHandler {
     @inject(ToolPalette) protected readonly toolPalette: ToolPalette
 
-    initialize(registry: ActionHandlerRegistry): void {
-        registry.register(SetOperationsAction.KIND, this)
-        registry.register(EnableDefaultToolsAction.KIND, this)
-    }
+    readonly handledActionKinds = [SetOperationsAction.KIND, EnableDefaultToolsAction.KIND]
 
     handle(action: Action): ICommand | Action | void {
         if (isSetOperationsAction(action)) {

--- a/client/packages/glsp-sprotty/src/features/tools/change-bounds-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/change-bounds-tool.ts
@@ -18,7 +18,7 @@ import {
     Action, Bounds, BoundsAware, ButtonHandlerRegistry, ElementAndBounds, findParentByFeature, isViewport, KeyTool, MouseTool, Point, //
     SetBoundsAction, SModelElement, SModelRoot, SParentElement
 } from "sprotty/lib";
-import { IModelUpdateNotifier, IModelUpdateObserver } from "../../base/command-stack";
+import { IModelUpdateObserver, ModelUpdateObserverRegistry } from "../../base/model/model-update-observer-registry";
 import { Tool } from "../../base/tool-manager/tool";
 import { GLSP_TYPES } from "../../types";
 import { forEachElement, getIndex, isSelectedBoundsAware } from "../../utils/smodel-util";
@@ -52,7 +52,7 @@ export class ChangeBoundsTool implements Tool {
 
     constructor(@inject(MouseTool) protected mouseTool: MouseTool,
         @inject(KeyTool) protected keyTool: KeyTool,
-        @inject(GLSP_TYPES.IModelUpdateNotifier) protected modelUpdateNotifier: IModelUpdateNotifier,
+        @inject(GLSP_TYPES.ModelUpdateObserverRegistry) protected modelUpdateObserverRegistry: ModelUpdateObserverRegistry,
         @inject(ButtonHandlerRegistry) @optional() protected buttonHandlerRegistry: ButtonHandlerRegistry) { }
 
     enable() {
@@ -63,13 +63,13 @@ export class ChangeBoundsTool implements Tool {
         // instlal change bounds listener for client-side resize updates and server-side updates
         this.changeBoundsListener = new ChangeBoundsListener(this.buttonHandlerRegistry);
         this.mouseTool.register(this.changeBoundsListener);
-        this.modelUpdateNotifier.registerObserver(this.changeBoundsListener);
+        this.modelUpdateObserverRegistry.register(this.changeBoundsListener);
         this.keyTool.register(this.changeBoundsListener);
     }
 
     disable() {
         this.mouseTool.deregister(this.changeBoundsListener);
-        this.modelUpdateNotifier.deregisterObserver(this.changeBoundsListener);
+        this.modelUpdateObserverRegistry.deregister(this.changeBoundsListener);
         this.keyTool.deregister(this.changeBoundsListener);
         this.mouseTool.deregister(this.feedbackMoveMouseListener);
     }

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -17,6 +17,7 @@ export * from 'sprotty/lib';
 export * from './base/command-stack';
 export * from './base/diagram-ui-extension/diagram-ui-extension';
 export * from './base/edit-config/edit-config';
+export * from './base/model/model-update-observer-registry';
 export * from './base/tool-manager/tool';
 export * from './base/tool-manager/tool-manager';
 export * from './features/change-bounds/model';

--- a/client/packages/glsp-sprotty/src/types.ts
+++ b/client/packages/glsp-sprotty/src/types.ts
@@ -19,9 +19,10 @@ export const GLSP_TYPES = {
     ICommandPaletteActionProviderRegistry: Symbol.for("ICommandPaletteActionProviderRegistry"),
     IFeedbackActionDispatcher: Symbol.for("IFeedbackActionDispatcher"),
     IToolFactory: Symbol.for("Factory<Tool>"),
-    IModelUpdateNotifier: Symbol.for("IModelUpdateNotifier"),
     IModelUpdateObserver: Symbol.for("IModelUpdateObserver"),
+    ModelUpdateObserverRegistry: Symbol.for("ModelUpdateObserverRegistry"),
     IReadonlyModelAccessProvider: Symbol.for("IReadonlyModelAccessProvider"),
-    IDiagramUIExtension: Symbol.for("DiagramUIExtension"),
+    IDiagramUIExtension: Symbol.for("IDiagramUIExtension"),
+    DiagramUIExtensionRegistry: Symbol.for("DiagramUIExtensionRegistry"),
     IEditConfigProvider: Symbol.for("IEditConfigProvider")
 }


### PR DESCRIPTION
The initial implementation was sort of a hacky approach that was tinkered into the GLSPCommandStack. In addition, it required a direct dependency between diagram server and commandstack for the sole purpose of setting a boolean flag to true 

I propose another more stable approach replacing the original handlers for Set- and UpdateActions with a custom handler that is observer-aware and delegates the model to each observer before the corresponding command is created.

This PR also contains the following minor changes:
- Introduce a common base class for classes that are both action handler and initializer
- Update GLSP_TYPES to also contain Symbols for non interface-derived types (e.g. DiagramUIExtensionRegistry)