### PR TITLE
Support dragging while node and edge creation (#167, #168)

### DIFF
--- a/client/packages/glsp-sprotty/src/features/tools/creation-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/creation-tool.ts
@@ -138,7 +138,6 @@ export class EdgeCreationToolMouseListener extends MouseListener {
             // In that case, we're dragging something, and shouldn't create
             // a connection
             this.isMouseMove = true;
-            this.reinitialize();
         }
         return [];
     }
@@ -146,10 +145,12 @@ export class EdgeCreationToolMouseListener extends MouseListener {
     private reinitialize() {
         this.source = undefined;
         this.target = undefined;
-        this.tool.dispatchFeedback([new ShowEdgeCreationSelectSourceFeedbackAction(this.elementTypeId)]);
+        this.tool.dispatchFeedback([
+            new HideEdgeCreationToolFeedbackAction(this.elementTypeId),
+            new ShowEdgeCreationSelectSourceFeedbackAction(this.elementTypeId)]);
     }
 
-    mouseUp(target: SModelElement, event: MouseEvent): Action[] {
+    mouseUp(element: SModelElement, event: MouseEvent): Action[] {
         this.isMouseDown = false;
         if (this.isMouseMove) {
             this.isMouseMove = false;
@@ -158,16 +159,13 @@ export class EdgeCreationToolMouseListener extends MouseListener {
 
         const result: Action[] = [];
 
-        if (this.source == null) {
-            this.source = target.id;
+        if (this.source === undefined) {
+            this.source = element.id;
             this.tool.dispatchFeedback([new ShowEdgeCreationSelectTargetFeedbackAction(this.elementTypeId, this.source)]);
         } else {
-            this.target = target.id;
-            if (this.source != null && this.target != null) {
+            this.target = element.id;
+            if (this.source !== undefined && this.target !== undefined) {
                 result.push(new CreateConnectionOperationAction(this.elementTypeId, this.source, this.target));
-                this.source = undefined;
-                this.target = undefined;
-
                 if (!isCtrlOrCmd(event)) {
                     result.push(new EnableDefaultToolsAction());
                 } else {

--- a/client/packages/glsp-sprotty/src/features/tools/drag-aware-mouse-listener.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/drag-aware-mouse-listener.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Action, MouseListener, SModelElement } from "sprotty/lib";
+
+/**
+ * A mouse listener that is aware of prior mouse dragging.
+ *
+ * Therefore, this listener distinguishes between mouse up events after dragging and
+ * mouse up events without prior dragging. Subclasses may override the methods 
+ * `draggingMouseUp` and/or `nonDraggingMouseUp` to react to only these specific kinds
+ * of mouse up events.
+ */
+export class DragAwareMouseListener extends MouseListener {
+
+    private isMouseDown: boolean = false;
+    private isMouseDrag: boolean = false;
+
+    mouseDown(target: SModelElement, event: MouseEvent): Action[] {
+        this.isMouseDown = true;
+        return [];
+    }
+
+    mouseMove(target: SModelElement, event: MouseEvent): Action[] {
+        if (this.isMouseDown) {
+            this.isMouseDrag = true;
+        }
+        return [];
+    }
+
+    mouseUp(element: SModelElement, event: MouseEvent): Action[] {
+        this.isMouseDown = false;
+        if (this.isMouseDrag) {
+            this.isMouseDrag = false;
+            return this.draggingMouseUp(element, event);
+        }
+
+        return this.nonDraggingMouseUp(element, event);
+    }
+
+    nonDraggingMouseUp(element: SModelElement, event: MouseEvent): Action[] {
+        return [];
+    }
+
+    draggingMouseUp(element: SModelElement, event: MouseEvent): Action[] {
+        return [];
+    }
+
+}


### PR DESCRIPTION
Fix #168 by making the edge creation tool more resilient to mouse dragging operations during the operation.

This change also introduces `DragAwareMouseListener` to make it easier for mouse listeners based tools to react only to mouse up events without prior dragging or with prior dragging.
The node creation tool as well as the edge creation tool now only react to non-dragging mouse up events, so that the user can drag in the diagram without changing the state of the node or edge creation tools. This fixes #167.