### PR TITLE
Starting migration to new commands API in Sprotty (#174)

### DIFF
--- a/client/packages/glsp-sprotty/src/base/di.config.ts
+++ b/client/packages/glsp-sprotty/src/base/di.config.ts
@@ -14,11 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ContainerModule } from "inversify";
-import { Tool, TYPES } from "sprotty/lib";
+import { configureCommand, Tool, TYPES } from "sprotty/lib";
 import "../../css/glsp-sprotty.css";
 import { GLSP_TYPES } from "../types";
 import { GLSPCommandStack, IReadonlyModelAccess } from "./command-stack";
-import { DiagramUIExtensionActionHandlerInitializer, DiagramUIExtensionRegistry } from "./diagram-ui-extension/diagram-ui-extension-registry";
+import { DiagramUIExtensionRegistry, HideDiagramUIExtensionCommand, ShowDiagramUIExtensionCommand } from "./diagram-ui-extension/diagram-ui-extension-registry";
 import { ModelUpdateActionInitializer, ModelUpdateObserverRegistry } from "./model/model-update-observer-registry";
 import { createToolFactory, ToolManagerActionHandler } from "./tool-manager/tool-manager-action-handler";
 
@@ -39,7 +39,8 @@ const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) =>
 
     // DiagramUIExtension registry initialization ------------------------------------
     bind(GLSP_TYPES.DiagramUIExtensionRegistry).to(DiagramUIExtensionRegistry).inSingletonScope();
-    bind(TYPES.IActionHandlerInitializer).to(DiagramUIExtensionActionHandlerInitializer)
+    configureCommand({ bind, isBound }, ShowDiagramUIExtensionCommand);
+    configureCommand({ bind, isBound }, HideDiagramUIExtensionCommand);
 
     // Tool manager initialization ------------------------------------
 

--- a/client/packages/glsp-sprotty/src/base/di.config.ts
+++ b/client/packages/glsp-sprotty/src/base/di.config.ts
@@ -20,7 +20,7 @@ import { GLSP_TYPES } from "../types";
 import { GLSPCommandStack, IReadonlyModelAccess } from "./command-stack";
 import { DiagramUIExtensionRegistry, HideDiagramUIExtensionCommand, ShowDiagramUIExtensionCommand } from "./diagram-ui-extension/diagram-ui-extension-registry";
 import { ModelUpdateActionInitializer, ModelUpdateObserverRegistry } from "./model/model-update-observer-registry";
-import { createToolFactory, ToolManagerActionHandler } from "./tool-manager/tool-manager-action-handler";
+import { createToolFactory, SetOperationsActionInToolManagerCommand } from "./tool-manager/tool-manager-initialization";
 
 const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     // GLSP Commandstack  initialization ------------------------------------
@@ -43,8 +43,7 @@ const defaultGLSPModule = new ContainerModule((bind, unbind, isBound, rebind) =>
     configureCommand({ bind, isBound }, HideDiagramUIExtensionCommand);
 
     // Tool manager initialization ------------------------------------
-
-    bind(TYPES.IActionHandlerInitializer).to(ToolManagerActionHandler);
+    configureCommand({ bind, isBound }, SetOperationsActionInToolManagerCommand);
     bind(GLSP_TYPES.IToolFactory).toFactory<Tool>((createToolFactory()));
 
     // Model update initialization ------------------------------------

--- a/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension-registry.ts
+++ b/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension-registry.ts
@@ -14,8 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable, multiInject, optional } from "inversify";
-import { Action, CommandExecutionContext, CommandResult, InstanceRegistry, SystemCommand, TYPES } from "sprotty/lib";
+import { Action, CommandExecutionContext, InstanceRegistry, TYPES } from "sprotty/lib";
 import { toArray } from "sprotty/lib/utils/iterable";
+import { ControlCommand } from "../../lib/commands";
 import { GLSP_TYPES } from "../../types";
 import { IDiagramUIExtension } from "./diagram-ui-extension";
 
@@ -48,22 +49,8 @@ export class HideDiagramUIExtensionAction implements Action {
     constructor(public readonly extensionId: string) { }
 }
 
-abstract class DiagramUiExtensionCommand extends SystemCommand {
-    execute(context: CommandExecutionContext): CommandResult {
-        this.doExecute(context);
-        return context.root;
-    }
-    undo(context: CommandExecutionContext): CommandResult {
-        return context.root;
-    }
-    redo(context: CommandExecutionContext): CommandResult {
-        return context.root;
-    }
-    abstract doExecute(context: CommandExecutionContext): void;
-}
-
 @injectable()
-export class ShowDiagramUIExtensionCommand extends DiagramUiExtensionCommand {
+export class ShowDiagramUIExtensionCommand extends ControlCommand {
 
     static KIND = "showDiagramUIExtension";
 
@@ -84,7 +71,7 @@ export class ShowDiagramUIExtensionCommand extends DiagramUiExtensionCommand {
 }
 
 @injectable()
-export class HideDiagramUIExtensionCommand extends DiagramUiExtensionCommand {
+export class HideDiagramUIExtensionCommand extends ControlCommand {
 
     static KIND = "hideDiagramUIExtension";
 

--- a/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension.ts
+++ b/client/packages/glsp-sprotty/src/base/diagram-ui-extension/diagram-ui-extension.ts
@@ -17,7 +17,7 @@ import { inject, injectable } from "inversify";
 import { Action, IActionDispatcherProvider, ILogger, SModelElement, TYPES, ViewerOptions } from "sprotty/lib";
 
 /**
- * An extension with togglable visbility  that can display additional (UI) information on top of a sprotty diagram
+ * An extension with togglable visbility that can display additional (UI) information on top of a sprotty diagram.
  */
 export interface IDiagramUIExtension {
     readonly id: string

--- a/client/packages/glsp-sprotty/src/base/model/model-update-observer-registry.ts
+++ b/client/packages/glsp-sprotty/src/base/model/model-update-observer-registry.ts
@@ -17,7 +17,7 @@ import { inject, injectable, multiInject, optional } from "inversify";
 import { Action, ICommand, IModelFactory, SetModelAction, SetModelCommand, SModelRoot, TYPES, UpdateModelAction, UpdateModelCommand } from "sprotty/lib";
 import { GLSP_TYPES } from "../../types";
 import { distinctAdd, remove } from "../../utils/array-utils";
-import { SelfInitializingActionHandler } from "../diagram-ui-extension/diagram-ui-extension-registry";
+import { SelfInitializingActionHandler } from "../self-initializing-action-handler";
 
 export interface IModelUpdateObserver {
     /*Is called before an update model request from the server is applied*/

--- a/client/packages/glsp-sprotty/src/base/self-initializing-action-handler.ts
+++ b/client/packages/glsp-sprotty/src/base/self-initializing-action-handler.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from "inversify";
+import { Action, ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer, ICommand } from "sprotty/lib";
+
+/**
+* Convinience class for classes that implement both `IActionHandler` and `IActionHandlerInitializer`
+*/
+@injectable()
+export abstract class SelfInitializingActionHandler implements IActionHandler, IActionHandlerInitializer {
+
+    initialize(registry: ActionHandlerRegistry) {
+        this.handledActionKinds.forEach(kind => registry.register(kind, this))
+    }
+
+    abstract handle(action: Action): ICommand | Action | void
+    abstract handledActionKinds: string[]
+}

--- a/client/packages/glsp-sprotty/src/base/tool-manager/tool-manager-action-handler.ts
+++ b/client/packages/glsp-sprotty/src/base/tool-manager/tool-manager-action-handler.ts
@@ -19,11 +19,13 @@ import { isSetOperationsAction, OperationKind, SetOperationsAction } from "../..
 import { EdgeCreationTool, NodeCreationTool } from "../../features/tools/creation-tool";
 import { MouseDeleteTool } from "../../features/tools/delete-tool";
 import { GLSP_TYPES } from "../../types";
-import { SelfInitializingActionHandler } from "../diagram-ui-extension/diagram-ui-extension-registry";
+import { SelfInitializingActionHandler } from "../self-initializing-action-handler";
 
+const UNDEFINED_TOOL_ID = "undefined-tool"
 
 @injectable()
 export class ToolManagerActionHandler extends SelfInitializingActionHandler {
+
     @inject(GLSP_TYPES.IToolFactory) readonly toolFactory: (operationKind: string) => Tool
     @inject(TYPES.IToolManager) readonly toolManager: ToolManager
 
@@ -34,6 +36,7 @@ export class ToolManagerActionHandler extends SelfInitializingActionHandler {
             this.configure(action)
         }
     }
+
     configure(action: SetOperationsAction): any {
         const configuredTools = action.operations.map(op => {
             const tool = this.toolFactory(op.operationKind)
@@ -43,7 +46,6 @@ export class ToolManagerActionHandler extends SelfInitializingActionHandler {
 
             return tool;
         }).filter(tool => tool.id !== UNDEFINED_TOOL_ID)
-
         this.toolManager.registerTools(...configuredTools)
     }
 }
@@ -55,7 +57,7 @@ export function isTypeAware(tool: Tool): tool is Tool & TypeAware {
 export interface TypeAware {
     elementTypeId: string;
 }
-const UNDEFINED_TOOL_ID = "undefined-tool"
+
 export function createToolFactory(): interfaces.FactoryCreator<Tool> {
     return (context: interfaces.Context) => {
         return (operationKind: string) => {

--- a/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
+++ b/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
@@ -15,12 +15,12 @@
  ********************************************************************************/
 import { injectable } from "inversify";
 import { Action, Command, ICommand, SModelElement, SModelElementSchema, SModelRoot } from "sprotty/lib";
-import { SelfInitializingActionHandler } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
 import {
     EdgeEditConfig, edgeEditConfig, EditConfig, IEditConfigProvider, isEdgeEditConfig, //
     isNodeEditConfig, NodeEditConfig, nodeEditConfig
 } from "../../base/edit-config/edit-config";
 import { IModelUpdateObserver } from "../../base/model/model-update-observer-registry";
+import { SelfInitializingActionHandler } from "../../base/self-initializing-action-handler";
 import { contains } from "../../utils/array-utils";
 import { EdgeTypeHint, isSetTypeHintsAction, NodeTypeHint, SetTypeHintsAction } from "./action-definition";
 

--- a/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
+++ b/client/packages/glsp-sprotty/src/features/hints/type-hints-action-initializer.ts
@@ -95,7 +95,6 @@ export function createNodeEditConfig(hint: NodeTypeHint): NodeEditConfig {
     }
 }
 
-
 export function createEdgeEditConfig(hint: EdgeTypeHint): EdgeEditConfig {
     return <EdgeEditConfig>{
         elementTypeId: hint.elementTypeId,

--- a/client/packages/glsp-sprotty/src/features/tool-palette/tool-palette.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-palette/tool-palette.ts
@@ -19,7 +19,8 @@ import {
     TYPES, ViewerOptions
 } from "sprotty/lib";
 import { BaseDiagramUIExtension } from "../../base/diagram-ui-extension/diagram-ui-extension";
-import { SelfInitializingActionHandler, ShowDiagramUIExtensionAction } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
+import { ShowDiagramUIExtensionAction } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
+import { SelfInitializingActionHandler } from "../../base/self-initializing-action-handler";
 import { isSetOperationsAction, Operation, OperationKind, SetOperationsAction } from "../operation/set-operations";
 import { deriveToolId } from "../tools/creation-tool";
 import { MouseDeleteTool } from "../tools/delete-tool";

--- a/client/packages/glsp-sprotty/src/features/tools/creation-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/creation-tool.ts
@@ -19,7 +19,7 @@ import {
     Action, EnableDefaultToolsAction, isCtrlOrCmd, MouseListener, //
     MouseTool, SModelElement, SModelRoot, Tool
 } from "sprotty/lib";
-import { TypeAware } from "../../base/tool-manager/tool-manager-action-handler";
+import { TypeAware } from "../../base/tool-manager/tool-manager-initialization";
 import { GLSP_TYPES } from "../../types";
 import { getAbsolutePosition } from "../../utils/viewpoint-util";
 import { CreateConnectionOperationAction, CreateNodeOperationAction } from "../operation/operation-actions";

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -40,6 +40,7 @@ export * from './features/tools/change-bounds-tool';
 export * from './features/tools/creation-tool';
 export * from './features/tools/default-tools';
 export * from './features/tools/delete-tool';
+export * from './lib/commands';
 export * from './lib/model';
 export * from './types';
 export * from './utils/array-utils';

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -19,7 +19,7 @@ export * from './base/diagram-ui-extension/diagram-ui-extension';
 export * from './base/edit-config/edit-config';
 export * from './base/model/model-update-observer-registry';
 export * from './base/self-initializing-action-handler';
-export * from './base/tool-manager/tool-manager-action-handler';
+export * from './base/tool-manager/tool-manager-initialization';
 export * from './features/change-bounds/model';
 export * from './features/change-bounds/resize';
 export * from './features/command-palette/action-provider';

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -18,6 +18,7 @@ export * from './base/command-stack';
 export * from './base/diagram-ui-extension/diagram-ui-extension';
 export * from './base/edit-config/edit-config';
 export * from './base/model/model-update-observer-registry';
+export * from './base/self-initializing-action-handler';
 export * from './base/tool-manager/tool-manager-action-handler';
 export * from './features/change-bounds/model';
 export * from './features/change-bounds/resize';

--- a/client/packages/glsp-sprotty/src/lib/commands.ts
+++ b/client/packages/glsp-sprotty/src/lib/commands.ts
@@ -13,17 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ContainerModule } from "inversify";
-import { configureCommand } from "sprotty/lib";
-import "../../../css/tool-palette.css";
-import { GLSP_TYPES } from "../../types";
-import { EnableDefaultToolsInToolPaletteCommand, SetOperationsInToolPaletteCommand, ToolPalette } from "./tool-palette";
+import { CommandExecutionContext, CommandResult, SystemCommand } from "sprotty/lib";
 
-const toolPaletteModule = new ContainerModule((bind, unbind, isBound) => {
-    bind(ToolPalette).toSelf().inSingletonScope();
-    bind(GLSP_TYPES.IDiagramUIExtension).toService(ToolPalette)
-    configureCommand({ bind, isBound }, SetOperationsInToolPaletteCommand);
-    configureCommand({ bind, isBound }, EnableDefaultToolsInToolPaletteCommand);
-});
-
-export default toolPaletteModule;
+/**
+ * A system command for controlling side effects without affecting the model.
+ */
+export abstract class ControlCommand extends SystemCommand {
+    execute(context: CommandExecutionContext): CommandResult {
+        this.doExecute(context);
+        return context.root;
+    }
+    undo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+    redo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+    abstract doExecute(context: CommandExecutionContext): void;
+}


### PR DESCRIPTION
Migrates the following parts to the new command API in sprotty (#174):
- [X] Diagram UI extension
- [X] Tool palette
- [X] Tool manager action handler