### PR TITLE
Resolve #29: Implement EdgeReconnectTool as standard tool

### DIFF
--- a/client/packages/glsp-sprotty/css/glsp-sprotty.css
+++ b/client/packages/glsp-sprotty/css/glsp-sprotty.css
@@ -35,7 +35,8 @@
     cursor: copy;
 }
 
-.edge-creation-select-source-mode {
+.edge-creation-select-source-mode,
+.edge-reconnect-select-source-mode {
     cursor: pointer;
 }
 

--- a/client/packages/glsp-sprotty/src/features/reconnect/model.ts
+++ b/client/packages/glsp-sprotty/src/features/reconnect/model.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { createRoutingHandle, Routable, SModelElement, SParentElement, SRoutingHandle } from "sprotty/lib";
+
+const ROUTING_HANDLE_SOURCE_INDEX: number = -2;
+
+export function isRoutable<T extends SModelElement>(element: T): element is T & SParentElement & Routable {
+    return (element as any).routingPoints !== undefined
+        && typeof ((element as any).route) === 'function'
+        && element instanceof SParentElement;
+}
+
+export function isReconnectHandle(element: SModelElement | undefined): element is SRoutingHandle {
+    return element !== undefined && element instanceof SRoutingHandle;
+}
+
+export function addReconnectHandles(element: SParentElement & Routable) {
+    removeReconnectHandles(element);
+    element.add(createRoutingHandle('source', element.id, ROUTING_HANDLE_SOURCE_INDEX));
+    element.add(createRoutingHandle('target', element.id, element.routingPoints.length));
+}
+
+export function removeReconnectHandles(element: SParentElement & Routable) {
+    element.removeAll(child => child instanceof SRoutingHandle);
+}
+
+export function isSourceRoutingHandle(edge: Routable, routingHandle: SRoutingHandle) {
+    return routingHandle.pointIndex === ROUTING_HANDLE_SOURCE_INDEX;
+}
+
+export function isTargetRoutingHandle(edge: Routable, routingHandle: SRoutingHandle) {
+    return routingHandle.pointIndex === edge.routingPoints.length;
+}

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/change-bounds-tool-feedback.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/change-bounds-tool-feedback.ts
@@ -25,7 +25,7 @@ import { FeedbackCommand } from "./model";
 
 export class ShowChangeBoundsToolResizeFeedbackAction implements Action {
     kind = ShowChangeBoundsToolResizeFeedbackCommand.KIND;
-    constructor(readonly elementTypeId?: string) { }
+    constructor(readonly elementId?: string) { }
 }
 
 export class HideChangeBoundsToolResizeFeedbackAction implements Action {
@@ -45,8 +45,8 @@ export class ShowChangeBoundsToolResizeFeedbackCommand extends FeedbackCommand {
         const index = context.root.index;
         index.all().filter(isResizeable).forEach(removeResizeHandles);
 
-        if (isNotUndefined(this.action.elementTypeId)) {
-            const resizeElement = index.getById(this.action.elementTypeId);
+        if (isNotUndefined(this.action.elementId)) {
+            const resizeElement = index.getById(this.action.elementId);
             if (isNotUndefined(resizeElement) && isResizeable(resizeElement)) {
                 addResizeHandles(resizeElement);
             }

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/creation-tool-feedback.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/creation-tool-feedback.ts
@@ -138,11 +138,11 @@ export class FeedbackEdgeEndMovingMouseListener extends MouseListener {
     }
 }
 
-function feedbackEdgeId(root: SModelRoot): string {
+export function feedbackEdgeId(root: SModelRoot): string {
     return root.id + '_feedback_edge';
 }
 
-function feedbackEdgeEndId(root: SModelRoot): string {
+export function feedbackEdgeEndId(root: SModelRoot): string {
     return root.id + '_feedback_anchor';
 }
 

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
@@ -25,6 +25,10 @@ import {
     ShowNodeCreationToolFeedbackCommand
 } from "./creation-tool-feedback";
 import { FeedbackActionDispatcher } from "./feedback-action-dispatcher";
+import {
+    HideEdgeReconnectHandlesFeedbackCommand, HideEdgeReconnectToolFeedbackCommand, // 
+    ShowEdgeReconnectHandlesFeedbackCommand, ShowEdgeReconnectSelectSourceFeedbackCommand
+} from "./reconnect-tool-feedback";
 import { FeedbackEdgeEndView, SResizeHandleView } from "./view";
 
 const toolFeedbackModule = new ContainerModule((bind, _unbind, isBound) => {
@@ -46,6 +50,12 @@ const toolFeedbackModule = new ContainerModule((bind, _unbind, isBound) => {
     configureCommand({ bind, isBound }, ShowChangeBoundsToolResizeFeedbackCommand);
     configureCommand({ bind, isBound }, HideChangeBoundsToolResizeFeedbackCommand);
     configureView({ bind, isBound }, SResizeHandle.TYPE, SResizeHandleView);
+
+    // reconnect edge tool feedback
+    configureCommand({ bind, isBound }, ShowEdgeReconnectHandlesFeedbackCommand);
+    configureCommand({ bind, isBound }, HideEdgeReconnectHandlesFeedbackCommand);
+    configureCommand({ bind, isBound }, ShowEdgeReconnectSelectSourceFeedbackCommand);
+    configureCommand({ bind, isBound }, HideEdgeReconnectToolFeedbackCommand);
 
     bind(TYPES.IVNodeDecorator).to(LocationDecorator);
     bind(TYPES.HiddenVNodeDecorator).to(LocationDecorator);

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/reconnect-tool-feedback.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/reconnect-tool-feedback.ts
@@ -1,0 +1,205 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from "inversify";
+import {
+    Action, center, CommandExecutionContext, euclideanDistance, findChildrenAtPosition, findParentByFeature, isBoundsAware, //
+    isConnectable, MouseListener, MoveAction, SConnectableElement, SModelElement, SModelRoot, TYPES
+} from "sprotty/lib";
+import { isNotUndefined } from "../../utils/smodel-util";
+import { getAbsolutePosition } from "../../utils/viewpoint-util";
+import { addReconnectHandles, isRoutable, removeReconnectHandles } from "../reconnect/model";
+import {
+    FeedbackEdgeEnd, feedbackEdgeEndId, FeedbackEdgeEndMovingMouseListener, feedbackEdgeId, HideEdgeCreationToolFeedbackCommand, //
+    ShowEdgeCreationSelectTargetFeedbackAction, ShowEdgeCreationSelectTargetFeedbackCommand
+} from "./creation-tool-feedback";
+import { applyCssClassesToRoot, FeedbackCommand, unapplyCssClassesToRoot } from "./model";
+
+/**
+ * RECONNECT HANDLES FEEDBACK
+ */
+
+export class ShowEdgeReconnectHandlesFeedbackAction implements Action {
+    kind = ShowEdgeReconnectHandlesFeedbackCommand.KIND;
+    constructor(readonly elementId?: string) { }
+}
+
+export class HideEdgeReconnectHandlesFeedbackAction implements Action {
+    kind = HideEdgeReconnectHandlesFeedbackCommand.KIND;
+    constructor() { }
+}
+
+@injectable()
+export class ShowEdgeReconnectHandlesFeedbackCommand extends FeedbackCommand {
+    static readonly KIND = 'glsp.edge-reconnect-tool.handles.feedback.show';
+
+    constructor(@inject(TYPES.Action) protected action: ShowEdgeReconnectHandlesFeedbackAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): SModelRoot {
+        const index = context.root.index;
+        index.all().filter(isRoutable).forEach(removeReconnectHandles);
+
+        if (isNotUndefined(this.action.elementId)) {
+            const routableElement = index.getById(this.action.elementId);
+            if (isNotUndefined(routableElement) && isRoutable(routableElement)) {
+                addReconnectHandles(routableElement);
+            }
+        }
+
+        return context.root;
+    }
+}
+
+@injectable()
+export class HideEdgeReconnectHandlesFeedbackCommand extends FeedbackCommand {
+    static readonly KIND = 'glsp.edge-reconnect-tool.handles.feedback.hide';
+
+    constructor(@inject(TYPES.Action) protected action: HideEdgeReconnectHandlesFeedbackAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): SModelRoot {
+        const index = context.root.index;
+        index.all().filter(isRoutable).forEach(removeReconnectHandles);
+        return context.root;
+    }
+}
+
+/**
+ * SOURCE AND TARGET EDGE FEEDBACK
+ */
+
+export class ShowEdgeReconnectSelectSourceFeedbackAction implements Action {
+    kind = ShowEdgeReconnectSelectSourceFeedbackCommand.KIND;
+    constructor(readonly elementTypeId: string, readonly targetId: string) { }
+}
+
+
+export class ShowEdgeReconnectSelectTargetFeedbackAction extends ShowEdgeCreationSelectTargetFeedbackAction {
+    kind = ShowEdgeCreationSelectTargetFeedbackCommand.KIND; // re-use select target feedback from creation tool
+    constructor(readonly elementTypeId: string, readonly sourceId: string) {
+        super(elementTypeId, sourceId);
+    }
+}
+
+export class HideEdgeReconnectToolFeedbackAction implements Action {
+    kind = HideEdgeReconnectToolFeedbackCommand.KIND;
+    constructor() { }
+}
+
+const EDGE_RECONNECT_SOURCE_CSS_CLASS = 'edge-reconnect-select-source-mode';
+
+@injectable()
+export class ShowEdgeReconnectSelectSourceFeedbackCommand extends FeedbackCommand {
+    static readonly KIND = 'glsp.edge-reconnect-tool.selectsource.feedback.show';
+
+    constructor(@inject(TYPES.Action) protected action: ShowEdgeReconnectSelectSourceFeedbackAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): SModelRoot {
+        drawFeedbackEdgeSource(context, this.action.targetId, this.action.elementTypeId);
+        return applyCssClassesToRoot(context, [EDGE_RECONNECT_SOURCE_CSS_CLASS]);
+    }
+}
+
+@injectable()
+export class HideEdgeReconnectToolFeedbackCommand extends FeedbackCommand {
+    static readonly KIND = 'glsp.edge-reconnect-tool.selectsource.feedback.hide';
+    private hideCreationToolFeedbackCommand: HideEdgeCreationToolFeedbackCommand;
+
+    constructor() {
+        super();
+        this.hideCreationToolFeedbackCommand = new HideEdgeCreationToolFeedbackCommand();
+    }
+
+    execute(context: CommandExecutionContext): SModelRoot {
+        this.hideCreationToolFeedbackCommand.execute(context);
+        unapplyCssClassesToRoot(context, [EDGE_RECONNECT_SOURCE_CSS_CLASS])
+        return context.root;
+    }
+}
+
+/**
+ * SOURCE AND TARGET MOUSE MOVE LISTENER
+ */
+
+export class FeedbackEdgeTargetMovingMouseListener extends FeedbackEdgeEndMovingMouseListener {
+}
+
+export class FeedbackEdgeSourceMovingMouseListener extends MouseListener {
+    mouseMove(target: SModelElement, event: MouseEvent): Action[] {
+        const root = target.root;
+        const edgeEnd = root.index.getById(feedbackEdgeEndId(root));
+        if (!(edgeEnd instanceof FeedbackEdgeEnd) || !edgeEnd.feedbackEdge) {
+            return [];
+        }
+
+        const edge = edgeEnd.feedbackEdge;
+        const position = getAbsolutePosition(edgeEnd, event);
+        const endAtMousePosition = findChildrenAtPosition(target.root, position)
+            .find(e => isConnectable(e) && e.canConnect(edge, 'source'));
+
+        if (endAtMousePosition instanceof SConnectableElement && edge.target && isBoundsAware(edge.target)) {
+            const anchor = endAtMousePosition.getAnchor(center(edge.target.bounds));
+            if (euclideanDistance(anchor, edgeEnd.position) > 1) {
+                return [new MoveAction([{ elementId: edgeEnd.id, toPosition: anchor }], false)];
+            }
+        } else {
+            return [new MoveAction([{ elementId: edgeEnd.id, toPosition: position }], false)];
+        }
+
+        return [];
+    }
+}
+
+/**
+ * UTILITY FUNCTIONS
+ */
+
+function drawFeedbackEdgeSource(context: CommandExecutionContext, targetId: string, elementTypeId: string) {
+    const root = context.root;
+    const targetChild = root.index.getById(targetId);
+    if (!targetChild) {
+        return;
+    }
+
+    const target = findParentByFeature(targetChild, isConnectable);
+    if (!target || !isBoundsAware(target)) {
+        return;
+    }
+
+    const edgeEnd = new FeedbackEdgeEnd(target.id, elementTypeId);
+    edgeEnd.id = feedbackEdgeEndId(root);
+    edgeEnd.position = { x: target.bounds.x, y: target.bounds.y };
+
+    const feedbackEdgeSchema = {
+        type: 'edge',
+        id: feedbackEdgeId(root),
+        sourceId: edgeEnd.id,
+        targetId: target.id,
+        opacity: 0.3
+    };
+
+    const feedbackEdge = context.modelFactory.createElement(feedbackEdgeSchema);
+    if (isRoutable(feedbackEdge)) {
+        edgeEnd.feedbackEdge = feedbackEdge;
+        context.root.add(edgeEnd);
+        root.add(feedbackEdge);
+    }
+}

--- a/client/packages/glsp-sprotty/src/features/tools/default-tools.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/default-tools.ts
@@ -17,11 +17,13 @@ import { interfaces } from "inversify";
 import { ToolManager, TYPES } from "sprotty/lib";
 import { ChangeBoundsTool } from "./change-bounds-tool";
 import { DelKeyDeleteTool, MouseDeleteTool } from "./delete-tool";
+import { EdgeReconnectTool } from "./reconnect-tool";
 
 export function registerDefaultTools(container: interfaces.Container) {
     const toolManager: ToolManager = container.get(TYPES.IToolManager);
     toolManager.registerDefaultTools(
         container.resolve(ChangeBoundsTool),
+        container.resolve(EdgeReconnectTool),
         container.resolve(DelKeyDeleteTool));
     toolManager.registerTools(container.resolve(MouseDeleteTool));
     toolManager.enableDefaultTools();

--- a/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
@@ -152,12 +152,12 @@ class ReconnectEdgeListener extends SelectionTracker {
                 this.setEdgeSelected(edge);
             } else if (this.isReconnecting()) {
                 // PHASE 3: Select new connectable (target or source) for reconnecting the selected edge
+                // if no connectable was selected, do nothing, allow clicking on other elements and empty area during this phase
                 const connectable = findParentByFeature(target, isConnectable);
                 if (connectable) {
                     this.setNewConnectable(connectable);
                 }
-            }
-            if (!this.isEdgeSelected() && !this.isReconnecting()) {
+            } else {
                 this.reset();
             }
         }

--- a/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
@@ -1,0 +1,215 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable, optional } from "inversify";
+import {
+    Action, ButtonHandlerRegistry, Connectable, DeleteElementAction, findParentByFeature, isConnectable, isRoutable, MouseTool, Routable, //
+    SModelElement, SRoutingHandle, Tool
+} from "sprotty/lib";
+import { GLSP_TYPES } from "../../types";
+import { CreateConnectionOperationAction } from "../operation/operation-actions";
+import { isReconnectHandle, isSourceRoutingHandle, isTargetRoutingHandle } from "../reconnect/model";
+import { SelectionTracker } from "../select/selection-tracker";
+import { feedbackEdgeId } from "../tool-feedback/creation-tool-feedback";
+import { IFeedbackActionDispatcher } from "../tool-feedback/feedback-action-dispatcher";
+import {
+    FeedbackEdgeSourceMovingMouseListener, FeedbackEdgeTargetMovingMouseListener, HideEdgeReconnectHandlesFeedbackAction, HideEdgeReconnectToolFeedbackAction, //
+    ShowEdgeReconnectHandlesFeedbackAction, ShowEdgeReconnectSelectSourceFeedbackAction, ShowEdgeReconnectSelectTargetFeedbackAction
+} from "../tool-feedback/reconnect-tool-feedback";
+
+@injectable()
+export class EdgeReconnectTool implements Tool {
+    static ID = "glsp.edge-reconnect-tool";
+    readonly id = EdgeReconnectTool.ID;
+
+    protected feedbackEdgeSourceMovingListener: FeedbackEdgeSourceMovingMouseListener;
+    protected feedbackEdgeTargetMovingListener: FeedbackEdgeTargetMovingMouseListener;
+    protected reconnectEdgeListener: ReconnectEdgeListener;
+
+    constructor(@inject(MouseTool) protected mouseTool: MouseTool,
+        @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher,
+        @inject(ButtonHandlerRegistry) @optional() public buttonHandlerRegistry: ButtonHandlerRegistry) {
+    }
+
+    enable(): void {
+        this.reconnectEdgeListener = new ReconnectEdgeListener(this);
+        this.mouseTool.register(this.reconnectEdgeListener);
+
+        // install feedback move mouse listener for client-side move updates
+        this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener();
+        this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener();
+        this.mouseTool.register(this.feedbackEdgeSourceMovingListener);
+        this.mouseTool.register(this.feedbackEdgeTargetMovingListener);
+    }
+
+    disable(): void {
+        this.reconnectEdgeListener.reset();
+        this.mouseTool.deregister(this.feedbackEdgeSourceMovingListener);
+        this.mouseTool.deregister(this.feedbackEdgeTargetMovingListener);
+        this.mouseTool.deregister(this.reconnectEdgeListener);
+    }
+
+    dispatchFeedback(actions: Action[]) {
+        this.feedbackDispatcher.registerFeedback(this, actions);
+    }
+}
+
+class ReconnectEdgeListener extends SelectionTracker {
+    private isMouseDown: boolean;
+
+    // active edge data
+    private edgeId?: string;
+    private edgeTypeId?: string;
+    private edgeSourceId?: string;
+    private edgeTargetId?: string;
+
+    // active reconnect handle data
+    private reconnectMode?: 'NEW_SOURCE' | 'NEW_TARGET';
+
+    // new connectable (source or target) for edge
+    private newConnectable?: SModelElement & Connectable;
+
+    constructor(protected tool: EdgeReconnectTool) {
+        super(tool.buttonHandlerRegistry);
+    }
+
+    private isValidEdge(edge?: SModelElement & Routable): edge is SModelElement & Routable {
+        return edge !== undefined && edge.id !== feedbackEdgeId(edge.root);
+    }
+
+    private setEdgeSelected(edge: SModelElement & Routable) {
+        if (this.edgeId && this.edgeId !== edge.id) {
+            // reset from a previously selected edge
+            this.reset();
+        }
+
+        this.edgeId = edge.id;
+        this.edgeSourceId = edge.sourceId;
+        this.edgeTargetId = edge.targetId;
+        this.edgeTypeId = edge.type;
+        this.tool.dispatchFeedback([new ShowEdgeReconnectHandlesFeedbackAction(this.edgeId)]);
+    }
+
+    private isEdgeSelected(): boolean {
+        return this.edgeId !== undefined && this.edgeTypeId !== undefined;
+    }
+
+    private setReconnectHandleSelected(edge: SModelElement & Routable, reconnectHandle: SModelElement & SRoutingHandle) {
+        if (this.edgeTypeId && this.edgeSourceId && this.edgeTargetId) {
+            if (isSourceRoutingHandle(edge, reconnectHandle)) {
+                this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectSourceFeedbackAction(this.edgeTypeId, this.edgeTargetId)]);
+                this.reconnectMode = "NEW_SOURCE";
+            } else if (isTargetRoutingHandle(edge, reconnectHandle)) {
+                this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectTargetFeedbackAction(this.edgeTypeId, this.edgeSourceId)]);
+                this.reconnectMode = "NEW_TARGET";
+            }
+        }
+    }
+
+    private isReconnecting(): boolean {
+        return this.reconnectMode !== undefined;
+    }
+
+    private isReconnectingNewSource(): boolean {
+        return this.reconnectMode === "NEW_SOURCE";
+    }
+
+    private requiresReconnect(sourceId: string, targetId: string): boolean {
+        return this.edgeSourceId !== sourceId || this.edgeTargetId !== targetId;
+    }
+
+    private setNewConnectable(connectable?: SModelElement & Connectable) {
+        this.newConnectable = connectable;
+    }
+
+    private isReadyToReconnect() {
+        return this.isEdgeSelected() && this.isReconnecting() && this.newConnectable !== undefined;
+    }
+
+    mouseDown(target: SModelElement, event: MouseEvent): Action[] {
+        const result: Action[] = [];
+        this.isMouseDown = true;
+        if (event.button === 0) {
+            const reconnectHandle = findParentByFeature(target, isReconnectHandle);
+            const edge = findParentByFeature(target, isRoutable);
+            if (this.isEdgeSelected() && edge && reconnectHandle) {
+                // PHASE 2: Select reconnect handle on selected edge
+                this.setReconnectHandleSelected(edge, reconnectHandle);
+            } else if (this.isValidEdge(edge)) {
+                // PHASE 1: Select edge
+                this.setEdgeSelected(edge);
+            } else if (this.isReconnecting()) {
+                // PHASE 3: Select new connectable (target or source) for reconnecting the selected edge
+                const connectable = findParentByFeature(target, isConnectable);
+                if (connectable) {
+                    this.setNewConnectable(connectable);
+                }
+            }
+            if (!this.isEdgeSelected() && !this.isReconnecting()) {
+                this.reset();
+            }
+        }
+        return result;
+    }
+
+    mouseMove(target: SModelElement, event: MouseEvent): Action[] {
+        if (this.isMouseDown) {
+            // reset any selected connectables when we are dragging, maybe the user is just panning
+            this.setNewConnectable(undefined);
+        }
+        return [];
+    }
+
+    mouseUp(target: SModelElement, event: MouseEvent): Action[] {
+        this.isMouseDown = false;
+        if (!this.isReadyToReconnect()) {
+            return [];
+        }
+
+        const result: Action[] = [];
+        if (this.newConnectable) {
+            const id = this.edgeId;
+            const type = this.edgeTypeId;
+            const sourceId = this.isReconnectingNewSource() ? this.newConnectable.id : this.edgeSourceId;
+            const targetId = this.isReconnectingNewSource() ? this.edgeTargetId : this.newConnectable.id;
+            if (id && type && sourceId && targetId && this.requiresReconnect(sourceId, targetId)) {
+                result.push(new DeleteElementAction([id]));
+                result.push(new CreateConnectionOperationAction(type, sourceId, targetId));
+            }
+        }
+        this.reset();
+        return result;
+    }
+
+    public reset() {
+        this.resetData();
+        this.resetFeedback();
+    }
+
+    private resetData() {
+        this.isMouseDown = false;
+        this.edgeId = undefined;
+        this.edgeSourceId = undefined;
+        this.edgeTargetId = undefined;
+        this.edgeTypeId = undefined;
+        this.reconnectMode = undefined;
+        this.newConnectable = undefined;
+    }
+
+    private resetFeedback() {
+        this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction()]);
+        this.tool.dispatchFeedback([new HideEdgeReconnectToolFeedbackAction()]);
+    }
+}


### PR DESCRIPTION
- Provide tool to reconnect source or target of an existing edge
- Implement source selection feedback for reconnection
- Reuse target selection feedback from edge creation tool
- Register reconnect tool as standard tool
- Fix typo in change bounds tool feedback (elementTypeId -> elementId)