### PR TITLE
Fix #186: Migrate to new sprotty Routing API

### DIFF
--- a/client/examples/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/examples/workflow/workflow-sprotty/src/di.config.ts
@@ -18,7 +18,7 @@ import {
     boundsModule, buttonModule, commandPaletteModule, configureModelElement, ConsoleLogger, defaultGLSPModule, defaultModule, //
     DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelHintsModule, //
     modelSourceModule, openModule, overrideViewerOptions, paletteModule, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, requestResponseModule, //
-    saveModule, SButton, SCompartment, SCompartmentView, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, //
+    routingModule, saveModule, SButton, SCompartment, SCompartmentView, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, //
     toolFeedbackModule, TYPES, viewportModule
 } from "glsp-sprotty/lib";
 import executeCommandModule from "glsp-sprotty/lib/features/execute/di.config";
@@ -60,7 +60,7 @@ export default function createContainer(widgetId: string): Container {
     container.load(defaultModule, defaultGLSPModule, selectModule, boundsModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
         workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule,
-        commandPaletteModule, paletteModule, requestResponseModule);
+        commandPaletteModule, paletteModule, requestResponseModule, routingModule);
 
     overrideViewerOptions(container, {
         needsClientLayout: true,

--- a/client/examples/workflow/workflow-sprotty/src/workflow-views.tsx
+++ b/client/examples/workflow/workflow-sprotty/src/workflow-views.tsx
@@ -62,7 +62,8 @@ export class WorkflowEdgeView extends PolylineEdgeView {
 @injectable()
 export class WeightedEdgeView extends WorkflowEdgeView {
     render(edge: Readonly<WeightedEdge>, context: RenderingContext): VNode {
-        const route = edge.route();
+        const router = this.edgeRouterRegistry.get(edge.routerKind);
+        const route = router.route(edge);
         if (route.length === 0)
             return this.renderDanglingEdge("Cannot compute route", edge, context);
 

--- a/client/packages/glsp-sprotty/src/base/command-stack.ts
+++ b/client/packages/glsp-sprotty/src/base/command-stack.ts
@@ -13,8 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from "inversify";
-import { AnimationFrameSyncer, CommandStack, CommandStackOptions, ILogger, IModelFactory, IViewerProvider, SModelRoot, TYPES } from "sprotty/lib";
+import { injectable } from "inversify";
+import { CommandStack, SModelRoot } from "sprotty/lib";
 
 /**
  * Provides access to the current `SModelRoot` instance.
@@ -42,13 +42,6 @@ export type IReadonlyModelAccessProvider = () => Promise<IReadonlyModelAccess>;
 @injectable()
 export class GLSPCommandStack extends CommandStack implements IReadonlyModelAccess {
 
-    constructor(@inject(TYPES.IModelFactory) protected modelFactory: IModelFactory,
-        @inject(TYPES.IViewerProvider) protected viewerProvider: IViewerProvider,
-        @inject(TYPES.ILogger) protected logger: ILogger,
-        @inject(TYPES.AnimationFrameSyncer) protected syncer: AnimationFrameSyncer,
-        @inject(TYPES.CommandStackOptions) protected options: CommandStackOptions) {
-        super(modelFactory, viewerProvider, logger, syncer, options);
-    }
     get model(): Promise<SModelRoot> {
         return this.currentPromise.then(
             state => this.modelFactory.createRoot(state.root)

--- a/client/packages/glsp-sprotty/src/features/command-palette/action-provider.ts
+++ b/client/packages/glsp-sprotty/src/features/command-palette/action-provider.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable, multiInject, optional } from "inversify";
-import { Action, ActionHandlerRegistry, CenterAction, ILogger, SelectAction, SModelElement, SModelRoot, TYPES } from "sprotty/lib";
+import { Action, CenterAction, ILogger, SelectAction, SModelElement, SModelRoot, TYPES } from "sprotty/lib";
 import { toArray } from "sprotty/lib/utils/iterable";
 import { IReadonlyModelAccessProvider } from "../../base/command-stack";
 import { LabeledAction } from "../../base/diagram-ui-extension/diagram-ui-extension";
@@ -71,8 +71,7 @@ export class NavigationCommandPaletteActionProvider implements ICommandPaletteAc
 
 @injectable()
 export class ServerCommandPaletteActionProvider implements ICommandPaletteActionProvider {
-    constructor(@inject(GLSP_TYPES.RequestResponseSupport) protected requestResponseSupport: RequestResponseSupport,
-        @inject(TYPES.ActionHandlerRegistry) protected registry: ActionHandlerRegistry) {
+    constructor(@inject(GLSP_TYPES.RequestResponseSupport) protected requestResponseSupport: RequestResponseSupport) {
     }
 
     getActions(selectedElements: SModelElement[]): Promise<LabeledAction[]> {

--- a/client/packages/glsp-sprotty/src/features/reconnect/model.ts
+++ b/client/packages/glsp-sprotty/src/features/reconnect/model.ts
@@ -13,34 +13,44 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { createRoutingHandle, Routable, SModelElement, SParentElement, SRoutingHandle } from "sprotty/lib";
+import { edgeInProgressID, edgeInProgressTargetHandleID, RoutingHandleKind, SModelElement, SRoutableElement, SRoutingHandle } from "sprotty/lib";
 
 const ROUTING_HANDLE_SOURCE_INDEX: number = -2;
 
-export function isRoutable<T extends SModelElement>(element: T): element is T & SParentElement & Routable {
-    return (element as any).routingPoints !== undefined
-        && typeof ((element as any).route) === 'function'
-        && element instanceof SParentElement;
+export function isRoutable<T extends SModelElement>(element: T): element is T & SRoutableElement {
+    return element instanceof SRoutableElement && (element as any).routingPoints !== undefined;
 }
 
 export function isReconnectHandle(element: SModelElement | undefined): element is SRoutingHandle {
     return element !== undefined && element instanceof SRoutingHandle;
 }
 
-export function addReconnectHandles(element: SParentElement & Routable) {
+export function addReconnectHandles(element: SRoutableElement) {
     removeReconnectHandles(element);
-    element.add(createRoutingHandle('source', element.id, ROUTING_HANDLE_SOURCE_INDEX));
-    element.add(createRoutingHandle('target', element.id, element.routingPoints.length));
+    createReconnectHandle(element, 'source', ROUTING_HANDLE_SOURCE_INDEX);
+    createReconnectHandle(element, 'target', element.routingPoints.length);
 }
 
-export function removeReconnectHandles(element: SParentElement & Routable) {
+export function removeReconnectHandles(element: SRoutableElement) {
     element.removeAll(child => child instanceof SRoutingHandle);
 }
 
-export function isSourceRoutingHandle(edge: Routable, routingHandle: SRoutingHandle) {
+export function isSourceRoutingHandle(edge: SRoutableElement, routingHandle: SRoutingHandle) {
     return routingHandle.pointIndex === ROUTING_HANDLE_SOURCE_INDEX;
 }
 
-export function isTargetRoutingHandle(edge: Routable, routingHandle: SRoutingHandle) {
+export function isTargetRoutingHandle(edge: SRoutableElement, routingHandle: SRoutingHandle) {
     return routingHandle.pointIndex === edge.routingPoints.length;
+}
+
+export function createReconnectHandle(edge: SRoutableElement, kind: RoutingHandleKind, routingPointIndex: number): SRoutingHandle {
+    const handle = new SRoutingHandle();
+    handle.kind = kind;
+    handle.pointIndex = routingPointIndex;
+    handle.type = 'routing-point';
+    if (kind === 'target' && edge.id === edgeInProgressID) {
+        handle.id = edgeInProgressTargetHandleID;
+    }
+    edge.add(handle);
+    return handle;
 }

--- a/client/packages/glsp-sprotty/src/features/request-response/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/request-response/di.config.ts
@@ -21,8 +21,8 @@ import { RequestResponseSupport } from "./support";
 
 const requestResponseModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(RequestResponseSupport).toSelf().inSingletonScope();
-    bind(GLSP_TYPES.RequestResponseSupport).to(RequestResponseSupport).inSingletonScope();
-    bind(TYPES.IActionHandlerInitializer).to(RequestResponseSupport);
+    bind(GLSP_TYPES.RequestResponseSupport).toService(RequestResponseSupport);
+    bind(TYPES.IActionHandlerInitializer).toService(RequestResponseSupport);
 });
 
 export default requestResponseModule;

--- a/client/packages/glsp-sprotty/src/features/request-response/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/request-response/di.config.ts
@@ -15,12 +15,14 @@
  ********************************************************************************/
 
 import { ContainerModule } from "inversify";
+import { TYPES } from "sprotty";
 import { GLSP_TYPES } from "../../types";
 import { RequestResponseSupport } from "./support";
 
 const requestResponseModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(RequestResponseSupport).toSelf().inSingletonScope();
     bind(GLSP_TYPES.RequestResponseSupport).to(RequestResponseSupport).inSingletonScope();
+    bind(TYPES.IActionHandlerInitializer).to(RequestResponseSupport);
 });
 
 export default requestResponseModule;

--- a/client/packages/glsp-sprotty/src/features/request-response/support.ts
+++ b/client/packages/glsp-sprotty/src/features/request-response/support.ts
@@ -15,17 +15,19 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action, ActionHandlerRegistry, IActionDispatcher, ILogger, TYPES } from "sprotty/lib";
+import { Action, ActionHandlerRegistry, IActionDispatcher, IActionHandlerInitializer, ILogger, TYPES } from "sprotty/lib";
 import { v4 as uuid } from 'uuid';
 import { IdentifiableRequestAction, IdentifiableResponseAction, isIdentifiableResponseAction } from "./action-definitions";
 
 @injectable()
-export class RequestResponseSupport {
+export class RequestResponseSupport implements IActionHandlerInitializer {
     private requestedResponses = new Map<string, Action | undefined>();
 
-    constructor(@inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher,
-        @inject(TYPES.ActionHandlerRegistry) protected registry: ActionHandlerRegistry,
-        @inject(TYPES.ILogger) protected logger: ILogger) {
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
+    @inject(TYPES.ActionHandlerRegistryProvider) protected registry: ActionHandlerRegistry;
+    @inject(TYPES.ILogger) protected logger: ILogger;
+
+    initialize(registry: ActionHandlerRegistry): void {
         registry.register(IdentifiableResponseAction.KIND, this);
     }
 

--- a/client/packages/glsp-sprotty/src/features/select/selection-tracker.ts
+++ b/client/packages/glsp-sprotty/src/features/select/selection-tracker.ts
@@ -13,8 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, optional } from "inversify";
-import { Action, ButtonHandlerRegistry, KeyListener, MouseListener, SelectAction, SelectKeyboardListener, SelectMouseListener, SModelElement } from "sprotty/lib";
+import { Action, KeyListener, MouseListener, SelectAction, SelectKeyboardListener, SelectMouseListener, SModelElement } from "sprotty/lib";
 
 /**
  * A mouse and key listener that tracks the currently selected elements in an accessible manner by extending the selection implementation of Sprotty.
@@ -24,9 +23,9 @@ export class SelectionTracker extends MouseListener implements KeyListener {
     private selectKeyboardListener: SelectKeyboardListener;
     private selectedElementIDs: Set<string> = new Set();
 
-    constructor(@inject(ButtonHandlerRegistry) @optional() protected buttonHandlerRegistry: ButtonHandlerRegistry) {
+    constructor() {
         super();
-        this.selectMouseListener = new SelectMouseListener(buttonHandlerRegistry);
+        this.selectMouseListener = new SelectMouseListener();
         this.selectKeyboardListener = new SelectKeyboardListener();
     }
 

--- a/client/packages/glsp-sprotty/src/features/tools/change-bounds-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/change-bounds-tool.ts
@@ -13,9 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, optional } from "inversify";
+import { inject, injectable } from "inversify";
 import {
-    Action, Bounds, BoundsAware, ButtonHandlerRegistry, ElementAndBounds, findParentByFeature, isViewport, KeyTool, MouseTool, Point, //
+    Action, Bounds, BoundsAware, ElementAndBounds, findParentByFeature, isViewport, KeyTool, MouseTool, Point, //
     SetBoundsAction, SModelElement, SParentElement, Tool
 } from "sprotty/lib";
 import { GLSP_TYPES } from "../../types";
@@ -50,7 +50,6 @@ export class ChangeBoundsTool implements Tool {
 
     constructor(@inject(MouseTool) protected mouseTool: MouseTool,
         @inject(KeyTool) protected keyTool: KeyTool,
-        @inject(ButtonHandlerRegistry) @optional() protected buttonHandlerRegistry: ButtonHandlerRegistry,
         @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher) { }
 
     enable() {
@@ -59,7 +58,7 @@ export class ChangeBoundsTool implements Tool {
         this.mouseTool.register(this.feedbackMoveMouseListener);
 
         // instlal change bounds listener for client-side resize updates and server-side updates
-        this.changeBoundsListener = new ChangeBoundsListener(this.buttonHandlerRegistry, this);
+        this.changeBoundsListener = new ChangeBoundsListener(this);
         this.mouseTool.register(this.changeBoundsListener);
         this.keyTool.register(this.changeBoundsListener);
         this.feedbackDispatcher.registerFeedback(this, [new ShowChangeBoundsToolResizeFeedbackAction])
@@ -86,8 +85,8 @@ class ChangeBoundsListener extends SelectionTracker {
     private activeResizeElementId: string | undefined = undefined;
     private activeResizeHandle: SResizeHandle | undefined = undefined;
 
-    constructor(buttonHandlerRegistry: ButtonHandlerRegistry, protected tool: ChangeBoundsTool) {
-        super(buttonHandlerRegistry);
+    constructor(protected tool: ChangeBoundsTool) {
+        super();
     }
 
     mouseDown(target: SModelElement, event: MouseEvent): Action[] {

--- a/client/packages/glsp-sprotty/src/features/tools/creation-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/creation-tool.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from "inversify";
 import {
-    Action, EnableDefaultToolsAction, isCtrlOrCmd, //
+    Action, AnchorComputerRegistry, EnableDefaultToolsAction, isCtrlOrCmd, //
     MouseTool, SModelElement, SModelRoot, Tool
 } from "sprotty/lib";
 import { TypeAware } from "../../base/tool-manager/tool-manager-action-handler";
@@ -91,7 +91,8 @@ export class EdgeCreationTool implements Tool, TypeAware {
     protected feedbackEndMovingMouseListener: FeedbackEdgeEndMovingMouseListener;
 
     constructor(@inject(MouseTool) protected mouseTool: MouseTool,
-        @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher) { }
+        @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher,
+        @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry) { }
 
     get id() {
         return deriveToolId(OperationKind.CREATE_CONNECTION, this.elementTypeId)
@@ -100,7 +101,7 @@ export class EdgeCreationTool implements Tool, TypeAware {
     enable() {
         this.creationToolMouseListener = new EdgeCreationToolMouseListener(this.elementTypeId, this);
         this.mouseTool.register(this.creationToolMouseListener);
-        this.feedbackEndMovingMouseListener = new FeedbackEdgeEndMovingMouseListener();
+        this.feedbackEndMovingMouseListener = new FeedbackEdgeEndMovingMouseListener(this.anchorRegistry);
         this.mouseTool.register(this.feedbackEndMovingMouseListener);
         this.dispatchFeedback([new ShowEdgeCreationSelectSourceFeedbackAction(this.elementTypeId)]);
     }

--- a/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
@@ -48,8 +48,8 @@ export class EdgeReconnectTool implements Tool {
         this.mouseTool.register(this.reconnectEdgeListener);
 
         // install feedback move mouse listener for client-side move updates
-        this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener(anchorRegistry);
-        this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener(anchorRegistry);
+        this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener(this.anchorRegistry);
+        this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener(this.anchorRegistry);
         this.mouseTool.register(this.feedbackEdgeSourceMovingListener);
         this.mouseTool.register(this.feedbackEdgeTargetMovingListener);
     }

--- a/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/reconnect-tool.ts
@@ -13,14 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, optional } from "inversify";
+import { inject, injectable } from "inversify";
 import {
-    Action, ButtonHandlerRegistry, Connectable, DeleteElementAction, findParentByFeature, isConnectable, isRoutable, MouseTool, Routable, //
-    SModelElement, SRoutingHandle, Tool
+    Action, AnchorComputerRegistry, Connectable, DeleteElementAction, findParentByFeature, isConnectable, MouseTool, //
+    SModelElement, SRoutableElement, SRoutingHandle, Tool
 } from "sprotty/lib";
 import { GLSP_TYPES } from "../../types";
 import { CreateConnectionOperationAction } from "../operation/operation-actions";
-import { isReconnectHandle, isSourceRoutingHandle, isTargetRoutingHandle } from "../reconnect/model";
+import { isReconnectHandle, isRoutable, isSourceRoutingHandle, isTargetRoutingHandle } from "../reconnect/model";
 import { SelectionTracker } from "../select/selection-tracker";
 import { feedbackEdgeId } from "../tool-feedback/creation-tool-feedback";
 import { IFeedbackActionDispatcher } from "../tool-feedback/feedback-action-dispatcher";
@@ -40,7 +40,7 @@ export class EdgeReconnectTool implements Tool {
 
     constructor(@inject(MouseTool) protected mouseTool: MouseTool,
         @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher,
-        @inject(ButtonHandlerRegistry) @optional() public buttonHandlerRegistry: ButtonHandlerRegistry) {
+        @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry) {
     }
 
     enable(): void {
@@ -48,8 +48,8 @@ export class EdgeReconnectTool implements Tool {
         this.mouseTool.register(this.reconnectEdgeListener);
 
         // install feedback move mouse listener for client-side move updates
-        this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener();
-        this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener();
+        this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener(anchorRegistry);
+        this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener(anchorRegistry);
         this.mouseTool.register(this.feedbackEdgeSourceMovingListener);
         this.mouseTool.register(this.feedbackEdgeTargetMovingListener);
     }
@@ -82,14 +82,14 @@ class ReconnectEdgeListener extends SelectionTracker {
     private newConnectable?: SModelElement & Connectable;
 
     constructor(protected tool: EdgeReconnectTool) {
-        super(tool.buttonHandlerRegistry);
+        super();
     }
 
-    private isValidEdge(edge?: SModelElement & Routable): edge is SModelElement & Routable {
+    private isValidEdge(edge?: SRoutableElement): edge is SRoutableElement {
         return edge !== undefined && edge.id !== feedbackEdgeId(edge.root);
     }
 
-    private setEdgeSelected(edge: SModelElement & Routable) {
+    private setEdgeSelected(edge: SRoutableElement) {
         if (this.edgeId && this.edgeId !== edge.id) {
             // reset from a previously selected edge
             this.reset();
@@ -106,7 +106,7 @@ class ReconnectEdgeListener extends SelectionTracker {
         return this.edgeId !== undefined && this.edgeTypeId !== undefined;
     }
 
-    private setReconnectHandleSelected(edge: SModelElement & Routable, reconnectHandle: SModelElement & SRoutingHandle) {
+    private setReconnectHandleSelected(edge: SRoutableElement, reconnectHandle: SRoutingHandle) {
         if (this.edgeTypeId && this.edgeSourceId && this.edgeTargetId) {
             if (isSourceRoutingHandle(edge, reconnectHandle)) {
                 this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectSourceFeedbackAction(this.edgeTypeId, this.edgeTargetId)]);

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -15,26 +15,17 @@
  ********************************************************************************/
 import { Emitter, Event } from "@theia/core/lib/common";
 import {
-    Action, ActionHandlerRegistry, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, ExecuteServerCommandAction, ExportSvgAction, IActionDispatcher, ICommand, IdentifiableRequestAction, ILogger, IModelFactory, //
+    Action, ActionHandlerRegistry, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, ExecuteServerCommandAction, ExportSvgAction, IdentifiableRequestAction, //
     ModelSource, OpenAction, OperationKind, RequestBoundsCommand, RequestCommandPaletteActions, RequestModelAction, RequestOperationsAction, RequestPopupModelAction, //
     RequestTypeHintsAction, SaveModelAction, ServerStatusAction, //
-    SetTypeHintsAction, SModelStorage, SwitchEditModeCommand, TYPES, ViewerOptions
+    SetTypeHintsAction, SwitchEditModeCommand
 } from "glsp-sprotty/lib";
-import { inject, injectable } from "inversify";
+import { injectable } from "inversify";
 import { TheiaDiagramServer } from "sprotty-theia/lib";
 
 @injectable()
 export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements NotifyingModelSource {
     readonly handledActionEventEmitter: Emitter<Action> = new Emitter<Action>();
-
-    constructor(@inject(TYPES.IActionDispatcher) public actionDispatcher: IActionDispatcher,
-        @inject(TYPES.ActionHandlerRegistry) actionHandlerRegistry: ActionHandlerRegistry,
-        @inject(TYPES.ViewerOptions) viewerOptions: ViewerOptions,
-        @inject(TYPES.SModelStorage) storage: SModelStorage,
-        @inject(TYPES.ILogger) logger: ILogger,
-        @inject(TYPES.IModelFactory) protected modelFactory: IModelFactory) {
-        super(actionDispatcher, actionHandlerRegistry, viewerOptions, storage, logger)
-    }
 
     initialize(registry: ActionHandlerRegistry): void {
         registry.register(RequestOperationsAction.KIND, this)
@@ -73,7 +64,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         return this.handledActionEventEmitter.event;
     }
 
-    handle(action: Action): void | ICommand {
+    handle(action: Action) {
         this.handledActionEventEmitter.fire(action);
         return super.handle(action)
     }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -137,12 +137,12 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@theia/application-manager@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.4.0-next.d9385eda.tgz#124daceb17179dec129ce4f2373533d07447d7bf"
-  integrity sha512-b7ecd+kRn6xEIqCYjZnN6XvgtaZvr8eQtEachoiR+/OHEWvVFw1+AN4k+LAM2Q5lB9vGlq3Zx6py4v+awr6HSg==
+"@theia/application-manager@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.4.0-next.ba717c52.tgz#fcd6f7eaeb7b66a0d3484bd7a3074a20acadec59"
+  integrity sha512-0N9jzonUPtN6mBCHLESk0G7OivdqG3+7P089ov1+4ovqPqH2eaLnzi8OG9mht74TVq2VnOmZ0UwkoNwGxsjSsQ==
   dependencies:
-    "@theia/application-package" "0.4.0-next.d9385eda"
+    "@theia/application-package" "0.4.0-next.ba717c52"
     "@types/fs-extra" "^4.0.2"
     bunyan "^1.8.10"
     circular-dependency-plugin "^5.0.0"
@@ -164,10 +164,10 @@
     webpack-cli "2.0.12"
     worker-loader "^1.1.1"
 
-"@theia/application-package@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.d9385eda.tgz#86a179ac5719925478304d59e31ba141af331601"
-  integrity sha512-U5JQboH9BR8OkluU9gY5SSk0mKfZ+dUvzFKMjW2GL05d4cz5MAza1yOx1qrbwQdy0fGpVCi1KekVBvNNkrNNEA==
+"@theia/application-package@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.ba717c52.tgz#00b2007b89223fd8c0122a477db37cfb53e2a936"
+  integrity sha512-nLsYehptIpnUjartn5i0ONwwBh4k/uVZc95CYVQs6hF2G9hcVba4uSYEp80APKLHNphHjhh2pcsZZirQcOvMgA==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -180,31 +180,31 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/callhierarchy@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.4.0-next.d9385eda.tgz#73319805996bf742746e2564de35dfe8384d06ba"
-  integrity sha512-Rz3MRgPRk1MJbk70ku5PLmpNhyQPsTs+ZGglILdjksC0KRWK/rpx9aWY3DqMzaNfwavJCYl06SkY3hRv1DUTFQ==
+"@theia/callhierarchy@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.4.0-next.ba717c52.tgz#0a7d1199a550a20d43ddaaae3a96239af023065d"
+  integrity sha512-4sf9gwSEHaJUNmGNSLa3UQ+a8Ek/HFTBjSioc3iHJSqrWBvxr9VAicQewmZrREIyb8jyE9R5TlEvM5eYsJJPyQ==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/editor" "0.4.0-next.d9385eda"
-    "@theia/languages" "0.4.0-next.d9385eda"
-    "@theia/monaco" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/editor" "0.4.0-next.ba717c52"
+    "@theia/languages" "0.4.0-next.ba717c52"
+    "@theia/monaco" "0.4.0-next.ba717c52"
     ts-md5 "^1.2.2"
 
 "@theia/cli@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.4.0-next.d9385eda.tgz#cf51a8ea709cc5ef33e758bd4da99a138dcca741"
-  integrity sha512-Qy6NVed50IQu6OS3Jdtk/BeQsDlDPB1ce3c18hsYnfgIHZRTp15HL5+/zlgbcu6hw0ECkmABhmgZypc9hDbdiQ==
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.4.0-next.ba717c52.tgz#ae2306f5fd3018e7cad5909079c46f01ca613900"
+  integrity sha512-Ki+i3qYNwW6Ap0ISHOAT4ipP+F6Js/1OtxXQDzQ++B+fSamRXjraraoNwB09N98FITnZ4kFgoCuRR4HlN1Defw==
   dependencies:
-    "@theia/application-manager" "0.4.0-next.d9385eda"
+    "@theia/application-manager" "0.4.0-next.ba717c52"
 
-"@theia/core@0.4.0-next.d9385eda", "@theia/core@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.d9385eda.tgz#1e6d7aaa8f5c32ac6331f34035403ddca4771cf8"
-  integrity sha512-x8l9q0fTFRC2S8hzSVnPBlDAym/G9DWOdg1aLeMRKmkDE4rwDj6bZnFwnX2EYWLcAY/QCgyPIvg+19TpbIcIWg==
+"@theia/core@0.4.0-next.ba717c52", "@theia/core@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.ba717c52.tgz#6e33ef034eebe3e10d6b1cd315fed03787e82800"
+  integrity sha512-JQTf1F5+Wu22b9RnwYMmCPJJ+zxb+Q79Dtk0loPL59r2DisSWbIK4s2rf3/Sb+C5onuxQ8mgJZ40khthA7fQjw==
   dependencies:
     "@phosphor/widgets" "^1.5.0"
-    "@theia/application-package" "0.4.0-next.d9385eda"
+    "@theia/application-package" "0.4.0-next.ba717c52"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -219,6 +219,7 @@
     ajv "^6.5.3"
     body-parser "^1.17.2"
     electron "^2.0.14"
+    electron-store "^2.0.0"
     es6-promise "^4.2.4"
     express "^4.16.3"
     file-icons-js "^1.0.3"
@@ -242,23 +243,23 @@
     ws "^5.2.2"
     yargs "^11.1.0"
 
-"@theia/editor@0.4.0-next.d9385eda", "@theia/editor@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.d9385eda.tgz#1fb90fa5bb98b3daa183b05c0707a6f3fc458269"
-  integrity sha512-k2FkrUtQGeDEIASM2ilx3yLclZa60KAH6rFjqpujRpHHyYhDvDETiJ5UpDBArjbtVWa8NPxzilr1PEOr6QHrag==
+"@theia/editor@0.4.0-next.ba717c52", "@theia/editor@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.ba717c52.tgz#1549880ad9b8942adb4fa1e2f20312e3dd9f154b"
+  integrity sha512-uw+qCHRACU046cxDEXTJAsAycr+qzmbAFIRD1ylPFcziXInIOPhS61GAApGnPaYpHnKE+friJ6rgQW/4qmt89Q==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/languages" "0.4.0-next.d9385eda"
-    "@theia/variable-resolver" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/languages" "0.4.0-next.ba717c52"
+    "@theia/variable-resolver" "0.4.0-next.ba717c52"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
-"@theia/filesystem@0.4.0-next.d9385eda", "@theia/filesystem@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.4.0-next.d9385eda.tgz#cec47e65bacf4ec49315dfbc1de77e8daed37945"
-  integrity sha512-SXxmNlmytquR1x7YjBOkPvQDT+fX7oJrlK6EV1Ne0mv83DOgAhVSPIWO0EAin1VruMJcgr7gU/gvoOcvcj87mg==
+"@theia/filesystem@0.4.0-next.ba717c52", "@theia/filesystem@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.4.0-next.ba717c52.tgz#d585750ac703da9d0b95707efec089cd2f9cb118"
+  integrity sha512-f0IIGiraeoDkL9SbZUlETlyprAdOqR+B/cgJBhYU4oRYJXRVtPkEzZsd5fr0oLCIk+DUUq5dGrPH1XX02Q1Bcw==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
     "@types/base64-js" "^1.2.5"
     "@types/body-parser" "^1.17.0"
     "@types/fs-extra" "^4.0.2"
@@ -282,59 +283,59 @@
     uuid "^3.2.1"
     zip-dir "^1.0.2"
 
-"@theia/json@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.4.0-next.d9385eda.tgz#53be9d50143deef90fd2c34e35f24f5ecc510654"
-  integrity sha512-NfO+9t4PV75nZ1Oxs0IFhSp478VmjvNUpkmU7VkwjTWKUVef0KsolZGqKFG7iFaD4g8STzhyNMOiVpHPdF1uWA==
+"@theia/json@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.4.0-next.ba717c52.tgz#aacb94316ae1ed6f76ece42d8e5231a81d0a8ffa"
+  integrity sha512-fBb2l8Ntl+fYa/oNpEz0enNEuTnrbz7JK4F3waGP3zzYib66SzxVdVtlQZRSVF475cA+Vt9q+8Lz1hqBCp1y0Q==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/languages" "0.4.0-next.d9385eda"
-    "@theia/monaco" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/languages" "0.4.0-next.ba717c52"
+    "@theia/monaco" "0.4.0-next.ba717c52"
     vscode-json-languageserver "^1.0.1"
 
-"@theia/languages@0.4.0-next.d9385eda", "@theia/languages@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.4.0-next.d9385eda.tgz#c4a2a4f2cf6bd61d1dd22d0c2435d4da980d9059"
-  integrity sha512-iB7WkB3UBR5qFPbGpeEWe+hpcrOlZdipgkfvDmC/0/Dqo9OzFpmVastMu0SS/3+NH77TsZNNhWRlB1eEX7j19w==
+"@theia/languages@0.4.0-next.ba717c52", "@theia/languages@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.4.0-next.ba717c52.tgz#df6eac02e89f67f395a9b06771c0b24ba298b4fe"
+  integrity sha512-LYeBeCOWmD875P6kMHeSoW5JY2fg/eBPbyvm0OrCiRYPPN/CS1usLS5k/O7UOAVXbUaBBa7/c3Cj/W8LSp7CCw==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/output" "0.4.0-next.d9385eda"
-    "@theia/process" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/output" "0.4.0-next.ba717c52"
+    "@theia/process" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
     "@typefox/monaco-editor-core" "^0.14.6"
     "@types/uuid" "^3.4.3"
     monaco-languageclient "^0.9.0"
     uuid "^3.2.1"
 
-"@theia/markers@0.4.0-next.d9385eda", "@theia/markers@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.d9385eda.tgz#dff590d87805b18180b70b30a9963c1651632d52"
-  integrity sha512-838K+0ySJKWlzwrA82zN+BHShbgU+tXFHZQfa8oX/cGcwEzIH7D9tYW2lhfkGWst5+uMhvoHlqJpymMKsUgq/A==
+"@theia/markers@0.4.0-next.ba717c52", "@theia/markers@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.ba717c52.tgz#8c03a37ceecf7ce14c97c8ee8fffa8d759b5764b"
+  integrity sha512-oY31c+MagkYVZyPP/W7i5W6S8o4E98edDNrSHx5nB6dxW/IK9pFPq+HfkO+7Vi9LljEMAItuV3A4MhtOKffJzQ==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/navigator" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/navigator" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
 
 "@theia/messages@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.4.0-next.d9385eda.tgz#ee568cff529c265b75090849c782aee7d3de9bb2"
-  integrity sha512-8fD3p9Gm2q6KODKr0yS9V/cnjfMKw9vzMPmX2lp5icIfVJznsCKSdecDTgzwqJ5gPWvkHvIGp87cYRA4HV9lDg==
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.4.0-next.ba717c52.tgz#daba36cbb97814f341a853e2159806265d465c01"
+  integrity sha512-njDdyisndrgiyiNrDhiYaHfHK713H+CAmrCerPn74utVcdPpdJTSva0ol7RH4JPEjrRUSYCOK+eHLVvky5ptMg==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
 
-"@theia/monaco@0.4.0-next.d9385eda", "@theia/monaco@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.4.0-next.d9385eda.tgz#2f4d6227c481264e5c196a6040dc432ca60a26ac"
-  integrity sha512-FkqC/yk7I1eEbApHZBoJUFseRfZQ3r9nKunw2Kb3YJ8PavywHvUrfRue4eBxqEV0VgT7uwfN/NE2r4NiyvNDqw==
+"@theia/monaco@0.4.0-next.ba717c52", "@theia/monaco@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.4.0-next.ba717c52.tgz#f376b5f386a2129239dba3d2adf8bf4d1783c23e"
+  integrity sha512-XptxaZsDHb+9u7d0AgLjlMQULKjhNj54QNMVk0fElmIl+WTzzF36XoDpUI+1qnJH5qErdlSACV1SJjJKN0c03w==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/editor" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/languages" "0.4.0-next.d9385eda"
-    "@theia/markers" "0.4.0-next.d9385eda"
-    "@theia/outline-view" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/editor" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/languages" "0.4.0-next.ba717c52"
+    "@theia/markers" "0.4.0-next.ba717c52"
+    "@theia/outline-view" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
     deepmerge "2.0.1"
     jsonc-parser "^2.0.2"
     monaco-css "^2.0.1"
@@ -342,106 +343,114 @@
     onigasm "^2.1.0"
     vscode-textmate "^4.0.1"
 
-"@theia/navigator@0.4.0-next.d9385eda", "@theia/navigator@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.d9385eda.tgz#ae421fa02d00d041ae900919a332f40c68877ae1"
-  integrity sha512-ic4UmmEuLulX/BZBA5Vz3N5XbIRXy/6RhTF10x/kEAhxa4Tv8jmFDddE+5YJIRo2WS/LosPGD6S00XEfWUyZXQ==
+"@theia/navigator@0.4.0-next.ba717c52", "@theia/navigator@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.ba717c52.tgz#709a465c6a44def95eaec8120d7ca7aecbb96740"
+  integrity sha512-BaOAerBCOU9HptOmhT8QIC6Txnf5/StVF9E28tq/PE5DaTsOqnpgYvNS8E+pottLYRfReBx4c1b7U2B9n4+/TA==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
-"@theia/outline-view@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.4.0-next.d9385eda.tgz#ade86b2692b79def74b02edc5f1ffdc06e1ea4fa"
-  integrity sha512-J+d9Yxvoc5GPrh9nrIN8wlgaFShoN8wQT7W8C1rv5D5J716D6O3XEaUmJJIG1hHMItrAqm76ypA/MVwsWeiOUg==
+"@theia/node-pty@0.7.8-theia004":
+  version "0.7.8-theia004"
+  resolved "https://registry.yarnpkg.com/@theia/node-pty/-/node-pty-0.7.8-theia004.tgz#0fe31b958df9315352d5fbeea7075047cf69c935"
+  integrity sha512-GetaD2p1qVPq/xbNCHCwKYjIr9IWjksf9V2iiv/hV6f885cJ+ie0Osr4+C159PrwzGRYW2jQVUtXghBJoyOCLg==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
+    nan "2.10.0"
 
-"@theia/output@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.d9385eda.tgz#0c8697a80a4429d0ffaf04819555c58fc39fd080"
-  integrity sha512-mau+zBuyLCyOsAV3TpRvfWnaH9YqfjbJpKGYFkqW87xHJYcX0QSSJcd20IxgWS8qdVH2sZ575ESdP/tfy3U0qA==
+"@theia/outline-view@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.4.0-next.ba717c52.tgz#18e4efb028486fa2ab8988c2c31c3d8099c935c3"
+  integrity sha512-07qZFHlNoJs8d2xJxN5+4HLcl3+3YCEmV5yIdHyHYtkxwKv6wqdUzIMFSszMTyojzhiSXx/5+6WHYguOMDTZAQ==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+
+"@theia/output@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.ba717c52.tgz#4de3eb26652b345898e5ce80c6245cc14aadb044"
+  integrity sha512-NXwMvsiuY0mxYkHIbCe6JqGYxSU90u+yjAOlbjS/E48Farx0wBym3UdTa3YeP46YtdcWC1PSWLaDEKtBsFsXUA==
+  dependencies:
+    "@theia/core" "0.4.0-next.ba717c52"
 
 "@theia/preferences@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.4.0-next.d9385eda.tgz#003749eaf4cba9e1e201d9241e74572025d5f4ea"
-  integrity sha512-8y++OdsZl6M7DcKXtFo0v0AxjAEahiS1uzdRBHKXgDy7Nm/qv/gV9+qohKHM6WpwWybdPv8fTyZN/PKb2oKs2w==
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.4.0-next.ba717c52.tgz#5a070fa29457a8348d3b4bc84380527445d11e4b"
+  integrity sha512-dCcqyXHdGCQ5LkncFVlUFzurffr/Ucyhr2B0OWOn0nqewF70Xomk4VmbonhbQsu5wjgtjwjZ44U3htxgomM51w==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/editor" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/json" "0.4.0-next.d9385eda"
-    "@theia/monaco" "0.4.0-next.d9385eda"
-    "@theia/userstorage" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/editor" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/json" "0.4.0-next.ba717c52"
+    "@theia/monaco" "0.4.0-next.ba717c52"
+    "@theia/userstorage" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
     "@types/fs-extra" "^4.0.2"
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
 
-"@theia/process@0.4.0-next.d9385eda", "@theia/process@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.d9385eda.tgz#1ed22eb79c667ec7bf07ebec006dd8d3c7115585"
-  integrity sha512-/3JtEPbBL0r6QEiBwCFIkR2e2C7x7Wnhu53g0Ne/fXEA5YQCjSXPMMOp6ng/DU1KpPtNXaXKxR8dyciN8/8plA==
+"@theia/process@0.4.0-next.ba717c52", "@theia/process@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.ba717c52.tgz#6f6b56182012ef7caf45cdcb045c3cde4402487e"
+  integrity sha512-1dJwIPWiiaFVWCJ9lOHGSVkXl2sqqFgq6O37sNBdpiqJhWeO3RSxpGvCc7Ep6yPNoFlv5vTADTbt5yX8Dt5ThA==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    node-pty "0.7.6"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/node-pty" "0.7.8-theia004"
     string-argv "^0.1.1"
 
 "@theia/terminal@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.4.0-next.d9385eda.tgz#d1b179107d7d00d3d29a1b6de55194fa59ebcd65"
-  integrity sha512-3SuPOz6+QR//6ILwHomJhm4LPwKOJQG812RYVvHoiaq0M8FtWj/YqUX3bpdx6DvzqKM4gRcnKohh+RyX/UrbZA==
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.4.0-next.ba717c52.tgz#dda4cd8f74bafe57dc1524a3c014eca2b859fa48"
+  integrity sha512-uRsdDxBVFQovA0Wip+Gd7TnB8mVDAPQdzsscKNyzwStEa0urd4e1K+fqa1NwC0TO6m1gdeVog5kLUz28cDVy6Q==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/process" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/editor" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/process" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
     xterm "3.9.2"
 
 "@theia/typescript@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.4.0-next.d9385eda.tgz#107810f9167b9403e19386ddd3b014bd9f20ba04"
-  integrity sha512-gis/SQhJjc9RO7JX7oN+PNJNkXBnyYWD8x29ulEXQparlLpeQvD1OJXdmG7W0Bwv90Binkh91rDxbK5Vh2c3WA==
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.4.0-next.ba717c52.tgz#a58717cb0206994c816b88190e51e770f45732a8"
+  integrity sha512-p9IK0o23k7/PgJgP+Lg1GRwkpW/VEf+7YIPBStlkCJK0epo+h/SyPLyooxajM3I4ZWmJo/aJA6wjNoW7f7Q7lw==
   dependencies:
-    "@theia/application-package" "0.4.0-next.d9385eda"
-    "@theia/callhierarchy" "0.4.0-next.d9385eda"
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/editor" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/languages" "0.4.0-next.d9385eda"
-    "@theia/monaco" "0.4.0-next.d9385eda"
-    "@theia/workspace" "0.4.0-next.d9385eda"
+    "@theia/application-package" "0.4.0-next.ba717c52"
+    "@theia/callhierarchy" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/editor" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/languages" "0.4.0-next.ba717c52"
+    "@theia/monaco" "0.4.0-next.ba717c52"
+    "@theia/workspace" "0.4.0-next.ba717c52"
     command-exists "^1.2.8"
     typescript-language-server "^0.3.7"
 
-"@theia/userstorage@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.d9385eda.tgz#2fa6960bad9083ee5d6282888507ef7e93a003e3"
-  integrity sha512-wYGu3QQ8JCbEXR0CZHDa6Ffs10cxkahyRhaYOOXTY8LdawVkHIWFBz0TwNMKpwBpCjDq6VJU0HH8L6QmvlEuPA==
+"@theia/userstorage@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.ba717c52.tgz#99f2ea011d872f9e14ca6bd91ae319752e7cde3c"
+  integrity sha512-fTrn0kjOPbRVtlStUFnm22gmi13HKTLpjDlJgUdZhmRgXh009Zv7SBAIbOdIQqNq74gJW1Mkw2dFgJmscStBTw==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
 
-"@theia/variable-resolver@0.4.0-next.d9385eda":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.d9385eda.tgz#340cffc25943e455dc8587bb6dce63cab95391d6"
-  integrity sha512-L5QKqJFiMxreOrmM8LvJYKmnlbE1LdVx+xywnuGuf2mGand/MXTPIaxA4gy4QrV7M3v8WXjlapDYEnBcsvLktw==
+"@theia/variable-resolver@0.4.0-next.ba717c52":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.ba717c52.tgz#6bc2d4f5d485acfbc658051b7235bfae6c1bc344"
+  integrity sha512-Pm9pxauxgJ7QQn4pLkisilTJsrvrwkfz+g3blM9+U8VyUXiANHllOzdPNlatFLK3E0Go6I0ikDUoeEDGPXjeeQ==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
 
-"@theia/workspace@0.4.0-next.d9385eda", "@theia/workspace@next":
-  version "0.4.0-next.d9385eda"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.4.0-next.d9385eda.tgz#09e349eefa893688e55de202d05cc59641ff05c0"
-  integrity sha512-2NRpZYSLUv6gO5a69keAY5UVfum19GrU/jnOTOKKKkrzGvjQAJJVLZOuWjrucQrSN+n/rk1tNAF6hb0ee0QzMQ==
+"@theia/workspace@0.4.0-next.ba717c52", "@theia/workspace@next":
+  version "0.4.0-next.ba717c52"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.4.0-next.ba717c52.tgz#5633b163dc1fb8aff28816ee9e45b03005ddf9d2"
+  integrity sha512-zxpqA7DzGus188DrtRx+Jwph2P1UpRHZIHOzYZZMm9GXkCxyPZuD4JO47eBEDxUJFxwPg5lA602mXyG5yPmKMA==
   dependencies:
-    "@theia/core" "0.4.0-next.d9385eda"
-    "@theia/filesystem" "0.4.0-next.d9385eda"
-    "@theia/variable-resolver" "0.4.0-next.d9385eda"
+    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/variable-resolver" "0.4.0-next.ba717c52"
     "@types/fs-extra" "^4.0.2"
     ajv "^6.5.3"
     fs-extra "^4.0.2"
@@ -544,16 +553,16 @@
     "@types/lodash" "*"
 
 "@types/lodash.throttle@^4.1.3":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.4.tgz#db210627eb05ef68af99344669818c5baad24039"
-  integrity sha512-ZniM2KbesKU9Qyv+mxbp1/3xAzJyrrXcfdYdOpuO8VFIG04E2VGqzXUKjNiqOKTBpNXR3r0F9yukldLBX4z5HA==
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.5.tgz#6f00b1d9edff5d1b9265c7035e2883db8bb27aeb"
+  integrity sha512-zm7RQP1z3JSaxKF5mwJH1pysZ0pQS7+J3IRWG2GBcNx+i/9uDedlB8Gfe/8SN3zNXSVdMOwv2cxmMbj/HIuAOQ==
   dependencies:
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.120"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.120.tgz#cf265d06f6c7a710db087ed07523ab8c1a24047b"
-  integrity sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==
+  version "4.14.121"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.121.tgz#9327e20d49b95fc2bf983fc2f045b2c6effc80b9"
+  integrity sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==
 
 "@types/mime-types@^2.1.0":
   version "2.1.0"
@@ -571,9 +580,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "10.12.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.24.tgz#b13564af612a22a20b5d95ca40f1bffb3af315cf"
-  integrity sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ==
+  version "11.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.4.tgz#ceb0048a546db453f6248f2d1d95e937a6f00a14"
+  integrity sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==
 
 "@types/node@^8.0.14", "@types/node@^8.0.24":
   version "8.10.40"
@@ -581,9 +590,9 @@
   integrity sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ==
 
 "@types/prop-types@*":
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
-  integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
+  version "15.5.9"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.9.tgz#f2d14df87b0739041bc53a7d75e3d77d726a3ec0"
+  integrity sha512-Nha5b+jmBI271jdTMwrHiNXM+DvThjHOfyZtMX9kj/c/LUj2xiLHsG/1L3tJ8DjAoQN48cHwUwtqBotjyXaSdQ==
 
 "@types/range-parser@*":
   version "1.2.3"
@@ -591,9 +600,9 @@
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/react-dom@^16.0.6":
-  version "16.8.0"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.0.tgz#c565f43f9d2ec911f9e0b8f3b74e25e67879aa3f"
-  integrity sha512-Jp4ufcEEjVJEB0OHq2MCZcE1u3KYUKO6WnSuiU/tZeYeiZxUoQavfa/TZeiIT+1XoN6l0lQVNM30VINZFDeolQ==
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.2.tgz#9bd7d33f908b243ff0692846ef36c81d4941ad12"
+  integrity sha512-MX7n1wq3G/De15RGAAqnmidzhr2Y9O/ClxPxyqaNg96pGyeXUYPSvujgzEVpLo9oIP4Wn1UETl+rxTN02KEpBw==
   dependencies:
     "@types/react" "*"
 
@@ -606,9 +615,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.4.1":
-  version "16.8.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
-  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
+  integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -632,9 +641,9 @@
     "@types/node" "*"
 
 "@types/route-parser@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@types/route-parser/-/route-parser-0.1.1.tgz#24b69588c68249f695122c230e547d3d6c8be095"
-  integrity sha512-VF2jxpkSGehlHBcfnVbVuvAp9/EdGr9Gi0C9qOZk4IKMGuYwFkF6AmsRNhN4V1WeLX+FpaXXa7PwYjQNQeVJiA==
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/route-parser/-/route-parser-0.1.2.tgz#41cf1844f0acfd90eaba01881bb567649eaf0bd0"
+  integrity sha512-fdOCj8qPC6vGrq00eDU/F7WZmXjdOUEFVfygrm6Rf8v/yxElYGmO2/v8acQ2HGNJUOcn0EsmadwV/lMI4ufhQw==
 
 "@types/semver@^5.4.0":
   version "5.5.0"
@@ -691,158 +700,161 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-11.1.2.tgz#fd4b676846fe731a5de5c6d2e5ef6a377262fc30"
   integrity sha512-zG61PAp2OcoIBjRV44wftJj6AJgzJrOc32LCYOBqk9bdgcdzK5DCJHV9QZJ60+Fu+fOn79g8Ks3Gixm4CfkZ+w==
 
-"@webassemblyjs/ast@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
-  integrity sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==
+"@webassemblyjs/ast@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.3.tgz#63a741bd715a6b6783f2ea5c6ab707516aa215eb"
+  integrity sha512-xy3m06+Iu4D32+6soz6zLnwznigXJRuFNTovBX2M4GqVqLb0dnyWLbPnpcXvUSdEN+9DVyDeaq2jyH1eIL2LZQ==
   dependencies:
-    "@webassemblyjs/helper-module-context" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/wast-parser" "1.7.11"
+    "@webassemblyjs/helper-module-context" "1.8.3"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.3"
+    "@webassemblyjs/wast-parser" "1.8.3"
 
-"@webassemblyjs/floating-point-hex-parser@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz#a69f0af6502eb9a3c045555b1a6129d3d3f2e313"
-  integrity sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==
+"@webassemblyjs/floating-point-hex-parser@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.3.tgz#f198a2d203b3c50846a064f5addd6a133ef9bc0e"
+  integrity sha512-vq1TISG4sts4f0lDwMUM0f3kpe0on+G3YyV5P0IySHFeaLKRYZ++n2fCFfG4TcCMYkqFeTUYFxm75L3ddlk2xA==
 
-"@webassemblyjs/helper-api-error@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz#c7b6bb8105f84039511a2b39ce494f193818a32a"
-  integrity sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==
+"@webassemblyjs/helper-api-error@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.3.tgz#3b708f6926accd64dcbaa7ba5b63db5660ff4f66"
+  integrity sha512-BmWEynI4FnZbjk8CaYZXwcv9a6gIiu+rllRRouQUo73hglanXD3AGFJE7Q4JZCoVE0p5/jeX6kf5eKa3D4JxwQ==
 
-"@webassemblyjs/helper-buffer@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz#3122d48dcc6c9456ed982debe16c8f37101df39b"
-  integrity sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==
+"@webassemblyjs/helper-buffer@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.3.tgz#f3150a23ffaba68621e1f094c8a14bebfd53dd48"
+  integrity sha512-iVIMhWnNHoFB94+/2l7LpswfCsXeMRnWfExKtqsZ/E2NxZyUx9nTeKK/MEMKTQNEpyfznIUX06OchBHQ+VKi/Q==
 
-"@webassemblyjs/helper-code-frame@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz#cf8f106e746662a0da29bdef635fcd3d1248364b"
-  integrity sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==
+"@webassemblyjs/helper-code-frame@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.3.tgz#f43ac605789b519d95784ef350fd2968aebdd3ef"
+  integrity sha512-K1UxoJML7GKr1QXR+BG7eXqQkvu+eEeTjlSl5wUFQ6W6vaOc5OwSxTcb3oE9x/3+w4NHhrIKD4JXXCZmLdL2cg==
   dependencies:
-    "@webassemblyjs/wast-printer" "1.7.11"
+    "@webassemblyjs/wast-printer" "1.8.3"
 
-"@webassemblyjs/helper-fsm@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz#df38882a624080d03f7503f93e3f17ac5ac01181"
-  integrity sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==
+"@webassemblyjs/helper-fsm@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.3.tgz#46aaa03f41082a916850ebcb97e9fc198ef36a9c"
+  integrity sha512-387zipfrGyO77/qm7/SDUiZBjQ5KGk4qkrVIyuoubmRNIiqn3g+6ijY8BhnlGqsCCQX5bYKOnttJobT5xoyviA==
 
-"@webassemblyjs/helper-module-context@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz#d874d722e51e62ac202476935d649c802fa0e209"
-  integrity sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==
-
-"@webassemblyjs/helper-wasm-bytecode@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz#dd9a1e817f1c2eb105b4cf1013093cb9f3c9cb06"
-  integrity sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==
-
-"@webassemblyjs/helper-wasm-section@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz#9c9ac41ecf9fbcfffc96f6d2675e2de33811e68a"
-  integrity sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==
+"@webassemblyjs/helper-module-context@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.3.tgz#150da405d90c8ea81ae0b0e1965b7b64e585634f"
+  integrity sha512-lPLFdQfaRssfnGEJit5Sk785kbBPPPK4ZS6rR5W/8hlUO/5v3F+rN8XuUcMj/Ny9iZiyKhhuinWGTUuYL4VKeQ==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-buffer" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/wasm-gen" "1.7.11"
+    "@webassemblyjs/ast" "1.8.3"
+    mamacro "^0.0.3"
 
-"@webassemblyjs/ieee754@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz#c95839eb63757a31880aaec7b6512d4191ac640b"
-  integrity sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==
+"@webassemblyjs/helper-wasm-bytecode@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.3.tgz#12f55bbafbbc7ddf9d8059a072cb7b0c17987901"
+  integrity sha512-R1nJW7bjyJLjsJQR5t3K/9LJ0QWuZezl8fGa49DZq4IVaejgvkbNlKEQxLYTC579zgT4IIIVHb5JA59uBPHXyw==
+
+"@webassemblyjs/helper-wasm-section@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.3.tgz#9e79456d9719e116f4f8998ee62ab54ba69a6cf3"
+  integrity sha512-P6F7D61SJY73Yz+fs49Q3+OzlYAZP86OfSpaSY448KzUy65NdfzDmo2NPVte+Rw4562MxEAacvq/mnDuvRWOcg==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/helper-buffer" "1.8.3"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.3"
+    "@webassemblyjs/wasm-gen" "1.8.3"
+
+"@webassemblyjs/ieee754@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.8.3.tgz#0a89355b1f6c9d08d0605c2acbc2a6fe3141f5b4"
+  integrity sha512-UD4HuLU99hjIvWz1pD68b52qsepWQlYCxDYVFJQfHh3BHyeAyAlBJ+QzLR1nnS5J6hAzjki3I3AoJeobNNSZlg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
-"@webassemblyjs/leb128@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.7.11.tgz#d7267a1ee9c4594fd3f7e37298818ec65687db63"
-  integrity sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==
+"@webassemblyjs/leb128@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.8.3.tgz#b7fd9d7c039e34e375c4473bd4dc89ce8228b920"
+  integrity sha512-XXd3s1BmkC1gpGABuCRLqCGOD6D2L+Ma2BpwpjrQEHeQATKWAQtxAyU9Z14/z8Ryx6IG+L4/NDkIGHrccEhRUg==
   dependencies:
-    "@xtuc/long" "4.2.1"
+    "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/utf8@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.7.11.tgz#06d7218ea9fdc94a6793aa92208160db3d26ee82"
-  integrity sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==
+"@webassemblyjs/utf8@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.8.3.tgz#75712db52cfdda868731569ddfe11046f1f1e7a2"
+  integrity sha512-Wv/WH9Zo5h5ZMyfCNpUrjFsLZ3X1amdfEuwdb7MLdG3cPAjRS6yc6ElULlpjLiiBTuzvmLhr3ENsuGyJ3wyCgg==
 
-"@webassemblyjs/wasm-edit@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz#8c74ca474d4f951d01dbae9bd70814ee22a82005"
-  integrity sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==
+"@webassemblyjs/wasm-edit@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.3.tgz#23c3c6206b096f9f6aa49623a5310a102ef0fb87"
+  integrity sha512-nB19eUx3Yhi1Vvv3yev5r+bqQixZprMtaoCs1brg9Efyl8Hto3tGaUoZ0Yb4Umn/gQCyoEGFfUxPLp1/8+Jvnw==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-buffer" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/helper-wasm-section" "1.7.11"
-    "@webassemblyjs/wasm-gen" "1.7.11"
-    "@webassemblyjs/wasm-opt" "1.7.11"
-    "@webassemblyjs/wasm-parser" "1.7.11"
-    "@webassemblyjs/wast-printer" "1.7.11"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/helper-buffer" "1.8.3"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.3"
+    "@webassemblyjs/helper-wasm-section" "1.8.3"
+    "@webassemblyjs/wasm-gen" "1.8.3"
+    "@webassemblyjs/wasm-opt" "1.8.3"
+    "@webassemblyjs/wasm-parser" "1.8.3"
+    "@webassemblyjs/wast-printer" "1.8.3"
 
-"@webassemblyjs/wasm-gen@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz#9bbba942f22375686a6fb759afcd7ac9c45da1a8"
-  integrity sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==
+"@webassemblyjs/wasm-gen@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.3.tgz#1a433b8ab97e074e6ac2e25fcbc8cb6125400813"
+  integrity sha512-sDNmu2nLBJZ/huSzlJvd9IK8B1EjCsOl7VeMV9VJPmxKYgTJ47lbkSP+KAXMgZWGcArxmcrznqm7FrAPQ7vVGg==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/ieee754" "1.7.11"
-    "@webassemblyjs/leb128" "1.7.11"
-    "@webassemblyjs/utf8" "1.7.11"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.3"
+    "@webassemblyjs/ieee754" "1.8.3"
+    "@webassemblyjs/leb128" "1.8.3"
+    "@webassemblyjs/utf8" "1.8.3"
 
-"@webassemblyjs/wasm-opt@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz#b331e8e7cef8f8e2f007d42c3a36a0580a7d6ca7"
-  integrity sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==
+"@webassemblyjs/wasm-opt@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.3.tgz#54754bcf88f88e92b909416a91125301cc81419c"
+  integrity sha512-j8lmQVFR+FR4/645VNgV4R/Jz8i50eaPAj93GZyd3EIJondVshE/D9pivpSDIXyaZt+IkCodlzOoZUE4LnQbeA==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-buffer" "1.7.11"
-    "@webassemblyjs/wasm-gen" "1.7.11"
-    "@webassemblyjs/wasm-parser" "1.7.11"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/helper-buffer" "1.8.3"
+    "@webassemblyjs/wasm-gen" "1.8.3"
+    "@webassemblyjs/wasm-parser" "1.8.3"
 
-"@webassemblyjs/wasm-parser@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz#6e3d20fa6a3519f6b084ef9391ad58211efb0a1a"
-  integrity sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==
+"@webassemblyjs/wasm-parser@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.3.tgz#d12ed19d1b8e8667a7bee040d2245aaaf215340b"
+  integrity sha512-NBI3SNNtRoy4T/KBsRZCAWUzE9lI94RH2nneLwa1KKIrt/2zzcTavWg6oY05ArCbb/PZDk3OUi63CD1RYtN65w==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-api-error" "1.7.11"
-    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
-    "@webassemblyjs/ieee754" "1.7.11"
-    "@webassemblyjs/leb128" "1.7.11"
-    "@webassemblyjs/utf8" "1.7.11"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/helper-api-error" "1.8.3"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.3"
+    "@webassemblyjs/ieee754" "1.8.3"
+    "@webassemblyjs/leb128" "1.8.3"
+    "@webassemblyjs/utf8" "1.8.3"
 
-"@webassemblyjs/wast-parser@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz#25bd117562ca8c002720ff8116ef9072d9ca869c"
-  integrity sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==
+"@webassemblyjs/wast-parser@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.8.3.tgz#44aa123e145503e995045dc3e5e2770069da117b"
+  integrity sha512-gZPst4CNcmGtKC1eYQmgCx6gwQvxk4h/nPjfPBbRoD+Raw3Hs+BS3yhrfgyRKtlYP+BJ8LcY9iFODEQofl2qbg==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/floating-point-hex-parser" "1.7.11"
-    "@webassemblyjs/helper-api-error" "1.7.11"
-    "@webassemblyjs/helper-code-frame" "1.7.11"
-    "@webassemblyjs/helper-fsm" "1.7.11"
-    "@xtuc/long" "4.2.1"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/floating-point-hex-parser" "1.8.3"
+    "@webassemblyjs/helper-api-error" "1.8.3"
+    "@webassemblyjs/helper-code-frame" "1.8.3"
+    "@webassemblyjs/helper-fsm" "1.8.3"
+    "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/wast-printer@1.7.11":
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz#c4245b6de242cb50a2cc950174fdbf65c78d7813"
-  integrity sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==
+"@webassemblyjs/wast-printer@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.8.3.tgz#b1177780b266b1305f2eeba87c4d6aa732352060"
+  integrity sha512-DTA6kpXuHK4PHu16yAD9QVuT1WZQRT7079oIFFmFSjqjLWGXS909I/7kiLTn931mcj7wGsaUNungjwNQ2lGQ3Q==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/wast-parser" "1.7.11"
-    "@xtuc/long" "4.2.1"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/wast-parser" "1.8.3"
+    "@xtuc/long" "4.2.2"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
   integrity sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
 
-"@xtuc/long@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
-  integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
+"@xtuc/long@4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
+  integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -893,9 +905,9 @@ ajv-errors@^1.0.0:
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
 ajv-keywords@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.3.0.tgz#cb6499da9b83177af8bc1732b2f0a1a1a3aacf8c"
-  integrity sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
+  integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -1192,11 +1204,11 @@ async@^1.5.0, async@^1.5.2:
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.5.0, async@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2324,9 +2336,9 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000935"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000935.tgz#0b4210ae207013c76bc1a2e0e903b15bec742a08"
-  integrity sha512-HFqvW9MZZcWD02F3J2GV2ggQyIXiDr7DRPlOWSKVIihu8J1dtsYFqtMjmFqiYamfOmY4NHyn7xFaWAHBtFWgjQ==
+  version "1.0.30000938"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000938.tgz#dc37923823ddf88e6bb0a82a7fb913a11e5cf681"
+  integrity sha512-1lbcoAGPQFUYOdY7sxpsl8ZDBfn5cyn80XuYnZwk7N4Qp7Behw7uxZCH5jjH2qWTV2WM6hgjvDVpP/uV3M/l9g==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2344,7 +2356,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2383,9 +2395,9 @@ chardet@^0.7.0:
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chokidar@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.0.tgz#5fcb70d0b28ebe0867eb0f09d5f6a08f29a1efa0"
-  integrity sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -2472,7 +2484,7 @@ cli-spinners@^0.1.2:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
   integrity sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=
 
-cli-spinners@^1.1.0:
+cli-spinners@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
   integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
@@ -2729,6 +2741,17 @@ concat-stream@1.6.2, concat-stream@^1.4.10, concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+conf@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-2.2.0.tgz#ee282efafc1450b61e205372041ad7d866802d9a"
+  integrity sha512-93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==
+  dependencies:
+    dot-prop "^4.1.0"
+    env-paths "^1.0.0"
+    make-dir "^1.0.0"
+    pkg-up "^2.0.0"
+    write-file-atomic "^2.3.0"
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -2972,9 +2995,9 @@ copy-webpack-plugin@^4.5.0:
     serialize-javascript "^1.4.0"
 
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
-  integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3460,6 +3483,13 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
+  dependencies:
+    is-obj "^1.0.0"
+
 drivelist@^6.4.3:
   version "6.4.6"
   resolved "https://registry.yarnpkg.com/drivelist/-/drivelist-6.4.6.tgz#3d092dd8b771fbcfda170784ba0d72db58c7554a"
@@ -3554,6 +3584,13 @@ electron-rebuild@^1.5.11:
     spawn-rx "^3.0.0"
     yargs "^12.0.5"
 
+electron-store@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-2.0.0.tgz#1035cca2a95409d1f54c7466606345852450d64a"
+  integrity sha512-1WCFYHsYvZBqDsoaS0Relnz0rd81ZkBAI0Fgx7Nq2UWU77rSNs1qxm4S6uH7TCZ0bV3LQpJFk7id/is/ZgoOPA==
+  dependencies:
+    conf "^2.0.0"
+
 electron-to-chromium@^1.2.7:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
@@ -3612,6 +3649,11 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
+env-paths@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
+  integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
+
 errlop@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/errlop/-/errlop-1.1.1.tgz#d9ae4c76c3e64956c5d79e6e035d6343bfd62250"
@@ -3642,9 +3684,9 @@ error@^7.0.2:
     xtend "~4.0.0"
 
 es6-promise@^4.0.3, es6-promise@^4.0.5, es6-promise@^4.2.4:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
-  integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
+  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
 
 es6-promisify@^5.0.0:
   version "5.0.0"
@@ -4187,9 +4229,9 @@ flatten@^1.0.2:
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
 flow-parser@^0.*:
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.92.1.tgz#c81fb52b202c7b1195f253bb01ac6dd2f5c15dfc"
-  integrity sha512-l6rlAGgMTTRYPOj5XUzbCeZB2bsK2cimPcoQD06YtQC2BI2wu9AhMQH+FkKV2Kd1Aa9EMNxVyF05QzNaiYdObQ==
+  version "0.93.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.93.0.tgz#85f7f1b975b47613043bbad48585a70e91e5b240"
+  integrity sha512-gJzVXpCWSYRFG6d1iH4RqUneX1vlcCYWwLCs8iU95fqaM1mAHLOn/ur+gsOTmBF9w+v/rX8u55MLpSvts4ZWzw==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"
@@ -4948,9 +4990,9 @@ home-path@^1.0.1:
   integrity sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==
 
 homedir-polyfill@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
-  integrity sha1-TCu8inWJmP7r9e1oWA921GdotLw=
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   dependencies:
     parse-passwd "^1.0.0"
 
@@ -6151,7 +6193,7 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6197,6 +6239,11 @@ make-dir@^1.0.0, make-dir@^1.1.0:
   integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
   dependencies:
     pify "^3.0.0"
+
+mamacro@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
+  integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -6403,17 +6450,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
-  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
+mime-db@~1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
 
 mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.18, mime-types@~2.1.19, mime-types@~2.1.7:
-  version "2.1.21"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
-  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
+  version "2.1.22"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
+  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
   dependencies:
-    mime-db "~1.37.0"
+    mime-db "~1.38.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -6705,9 +6752,9 @@ nice-try@^1.0.4:
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-abi@^2.2.0, node-abi@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.7.0.tgz#e2f814088ab97c85504ae2bacb8f93d5d77cbc2b"
-  integrity sha512-egTtvNoZLMjwxkL/5iiJKYKZgn2im0zP+G+PncMxICYGiD3aZtXUvEsDmu0pF8gpASvLZyD8v53qi1/ELaRZpg==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.7.1.tgz#a8997ae91176a5fbaa455b194976e32683cda643"
+  integrity sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==
   dependencies:
     semver "^5.4.1"
 
@@ -6778,13 +6825,6 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-node-pty@0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.6.tgz#bff6148c9c5836ca7e73c7aaaec067dcbdac2f7b"
-  integrity sha512-ECzKUB7KkAFZ0cjyjMXp5WLJ+7YIZ1xnNmiiegOI6WdDaKABUNV5NbB1Dw9MXD4KrZipWII0wQ7RGZ6StU/7jA==
-  dependencies:
-    nan "2.10.0"
 
 node.extend@^1.1.2:
   version "1.1.8"
@@ -6888,9 +6928,9 @@ npm-bundled@^1.0.1:
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
 npm-packlist@^1.1.6:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.3.0.tgz#7f01e8e44408341379ca98cfd756e7b29bd2626c"
-  integrity sha512-qPBc6CnxEzpOcc4bjoIBJbYdy0D/LFFPUdxvfwor4/w3vxeE0h6TiOVurCEPpQ6trjN77u/ShyfeJGsbAfB3dA==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
+  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -6967,9 +7007,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-keys@^1.0.11, object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
-  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-keys@~0.4.0:
   version "0.4.0"
@@ -7067,15 +7107,15 @@ ora@^0.2.3:
     object-assign "^4.0.1"
 
 ora@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
-  integrity sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.1.0.tgz#dbedd8c03b5d017fb67083e87ee52f5ec89823ed"
+  integrity sha512-vRBPaNCclUi8pUxRF/G8+5qEQkc6EgzKK1G2ZNJUIGu088Un5qIxFXeDgymvPRM9nmrcUOGzQgS1Vmtz+NtlMw==
   dependencies:
-    chalk "^2.3.1"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
-    cli-spinners "^1.1.0"
+    cli-spinners "^1.3.1"
     log-symbols "^2.2.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.0.0"
     wcwidth "^1.0.1"
 
 ordered-read-streams@^1.0.0:
@@ -7250,9 +7290,9 @@ parallel-transform@^1.1.0:
     readable-stream "^2.1.5"
 
 parse-asn1@^5.0.0:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.3.tgz#1600c6cc0727365d68b97f3aa78939e735a75204"
-  integrity sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.4.tgz#37f6628f823fbdeb2273b4d540434a22f3ef1fcc"
+  integrity sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -7456,6 +7496,13 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
+  dependencies:
+    find-up "^2.1.0"
 
 plugin-error@^0.1.2:
   version "0.1.2"
@@ -7842,12 +7889,13 @@ promise@^7.1.1:
     asap "~2.0.3"
 
 prop-types@^15.6.0, prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
     object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proxy-addr@~2.0.4:
   version "2.0.4"
@@ -8001,9 +8049,9 @@ randomatic@^3.0.0:
     math-random "^1.0.1"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80"
-  integrity sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
@@ -8041,14 +8089,19 @@ rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^16.4.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.1.tgz#ec860f98853d09d39bafd3a6f1e12389d283dbb4"
-  integrity sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.3.tgz#ae236029e66210783ac81999d3015dfc475b9c32"
+  integrity sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.1"
+    scheduler "^0.13.3"
+
+react-is@^16.8.1:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -8068,14 +8121,14 @@ react-virtualized@^9.20.0:
     react-lifecycles-compat "^3.0.4"
 
 react@^16.4.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"
-  integrity sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
+  integrity sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.1"
+    scheduler "^0.13.3"
 
 read-chunk@^2.1.0:
   version "2.1.0"
@@ -8634,10 +8687,10 @@ sax@^1.2.4, sax@~1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.1.tgz#1a217df1bfaabaf4f1b92a9127d5d732d85a9591"
-  integrity sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==
+scheduler@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
+  integrity sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -9032,9 +9085,9 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sprotty-theia@next:
-  version "0.3.0-next.d0f80d1"
-  resolved "https://registry.yarnpkg.com/sprotty-theia/-/sprotty-theia-0.3.0-next.d0f80d1.tgz#c8bbfef76b68a8ff9ddf60d07d3676f7b9a54d7a"
-  integrity sha512-kk+IO8JFQgvC5mKKAY0wbbgbJO4oCWImbP6fZB7KtVyc7eR/Q6L7Z4iNRH32iA8HDWpJOIucPWXBbbm7tcKa2w==
+  version "0.3.0-next.40eba67"
+  resolved "https://registry.yarnpkg.com/sprotty-theia/-/sprotty-theia-0.3.0-next.40eba67.tgz#8ef48b3ff8a21fa33fa0939708852ebceff0e0d7"
+  integrity sha512-b3IWoXLn7AqWscAEBkdbCyUnpPjn3pTFPqxWYTWTsyKUR4iddvk79lHbV87Qfrj2TIjR2vQP2/YSbFC49CPudQ==
   dependencies:
     "@theia/core" next
     "@theia/editor" next
@@ -9044,9 +9097,9 @@ sprotty-theia@next:
     sprotty next
 
 sprotty@next:
-  version "0.5.0-next.873de68"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.5.0-next.873de68.tgz#d69013164f288d653f03f6bfc53473484d4771c5"
-  integrity sha512-eu3BaunbsOUhT/2gsszwwZwXWw2ptmziOQ98BRHoWhcJAoi0YKAcyhOOvP/2gioYuJlh43l4PEIJQHiDFGijHQ==
+  version "0.5.0-next.b31f29d"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.5.0-next.b31f29d.tgz#686c09076e5a1a85e6b91e6048c9cb73e7d39569"
+  integrity sha512-g8iFq5eLLHg9YD5eqkazQ36aOlgHznQ6Wd49BhqcfOdmYe+QXfQPeczAzIuzlzVrF8UL1574SjdoVhyPYqgBqQ==
   dependencies:
     file-saver "1.3.3"
     inversify "^4.3.0"
@@ -9784,9 +9837,9 @@ typescript@2.9.1:
   integrity sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==
 
 typescript@latest:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
-  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
+  version "3.3.3333"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
+  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
 
 uglify-js@^3.1.4:
   version "3.4.9"
@@ -10155,9 +10208,9 @@ vscode-json-languageserver@^1.0.1:
     vscode-uri "^1.0.3"
 
 vscode-json-languageservice@^3.0.12:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.2.1.tgz#991d51128ebd81c5525d0578cabfa5b03e3cba2a"
-  integrity sha512-ee9MJ70/xR55ywvm0bZsDLhA800HCRE27AYgMNTU14RSg20Y+ngHdQnUt6OmiTXrQDI/7sne6QUOtHIN0hPQYA==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.2.0.tgz#fe796c2ddbda966d87905442f9636f139e00f341"
+  integrity sha512-tLAv9/D01fLAvnYnZ1OLy03HSHhVFjaSkUidEjfrwytHrxVDgqXLkHAJg+F6Q3mPYfpnPQvN2jTjiJ1yInuNVg==
   dependencies:
     jsonc-parser "^2.0.2"
     vscode-languageserver-types "^3.13.0"
@@ -10235,9 +10288,9 @@ vscode-ws-jsonrpc@^0.0.2-1:
     vscode-jsonrpc "^3.6.0"
 
 vscode@^1.1.18:
-  version "1.1.29"
-  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.29.tgz#bef148f5eb88b966e425b7fa4287ff4b8b04e017"
-  integrity sha512-E6hzqGtCD65BnBxdZzSIi8FPCM4seEEK/bbTeYdJntg+4D5R6GLbdYFySE9DNTtMJF4iB9UGoucKU/p8Guts1g==
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.30.tgz#700e54fd52e3d7eb757df6b60b030828c940b3a8"
+  integrity sha512-YDj5w0TGOcS8XLIdekT4q6LlLV6hv1ZvuT2aGT3KJll4gMz6dUPDgo2VVAf0i0E8igbbZthwvmaUGRwW9yPIaw==
   dependencies:
     glob "^7.1.2"
     gulp-chmod "^2.0.0"
@@ -10317,14 +10370,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-map "~0.6.1"
 
 webpack@^4.0.0:
-  version "4.29.3"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.3.tgz#e0b406a7b4201ed5e4fb4f84fd7359f9a7db4647"
-  integrity sha512-xPJvFeB+8tUflXFq+OgdpiSnsCD5EANyv56co5q8q8+YtEasn5Sj3kzY44mta+csCIEB0vneSxnuaHkOL2h94A==
+  version "4.29.5"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.5.tgz#52b60a7b0838427c3a894cd801a11dc0836bc79f"
+  integrity sha512-DuWlYUT982c7XVHodrLO9quFbNpVq5FNxLrMUfYUTlgKW0+yPimynYf1kttSQpEneAL1FH3P3OLNgkyImx8qIQ==
   dependencies:
-    "@webassemblyjs/ast" "1.7.11"
-    "@webassemblyjs/helper-module-context" "1.7.11"
-    "@webassemblyjs/wasm-edit" "1.7.11"
-    "@webassemblyjs/wasm-parser" "1.7.11"
+    "@webassemblyjs/ast" "1.8.3"
+    "@webassemblyjs/helper-module-context" "1.8.3"
+    "@webassemblyjs/wasm-edit" "1.8.3"
+    "@webassemblyjs/wasm-parser" "1.8.3"
     acorn "^6.0.5"
     acorn-dynamic-import "^4.0.0"
     ajv "^6.1.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -137,12 +137,12 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@theia/application-manager@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.4.0-next.ba717c52.tgz#fcd6f7eaeb7b66a0d3484bd7a3074a20acadec59"
-  integrity sha512-0N9jzonUPtN6mBCHLESk0G7OivdqG3+7P089ov1+4ovqPqH2eaLnzi8OG9mht74TVq2VnOmZ0UwkoNwGxsjSsQ==
+"@theia/application-manager@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-0.4.0-next.3bc56af7.tgz#06c7bde12c09d81158f86cb7656b93b774d0a718"
+  integrity sha512-80w/ao4JxKcXZk3YBw0PIdLQ6Lxu0zkjjJ2AP6/I5wRx7gtLRK56GYkn3ToKTRLrbcL+ZpSLylPtA1w6g8OO+Q==
   dependencies:
-    "@theia/application-package" "0.4.0-next.ba717c52"
+    "@theia/application-package" "0.4.0-next.3bc56af7"
     "@types/fs-extra" "^4.0.2"
     bunyan "^1.8.10"
     circular-dependency-plugin "^5.0.0"
@@ -164,10 +164,10 @@
     webpack-cli "2.0.12"
     worker-loader "^1.1.1"
 
-"@theia/application-package@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.ba717c52.tgz#00b2007b89223fd8c0122a477db37cfb53e2a936"
-  integrity sha512-nLsYehptIpnUjartn5i0ONwwBh4k/uVZc95CYVQs6hF2G9hcVba4uSYEp80APKLHNphHjhh2pcsZZirQcOvMgA==
+"@theia/application-package@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.3bc56af7.tgz#cfab78fc66c1558765a12cf2feba6cfe5f79d767"
+  integrity sha512-OdCsdLKLPPU8mEw+tRo7HUua47M4EVQPNTSZ/Qb1Figbtp04xPdvCzNbS0aK4eMb/pQhmKVjJsor8n0YoFBw5w==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -180,31 +180,31 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/callhierarchy@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.4.0-next.ba717c52.tgz#0a7d1199a550a20d43ddaaae3a96239af023065d"
-  integrity sha512-4sf9gwSEHaJUNmGNSLa3UQ+a8Ek/HFTBjSioc3iHJSqrWBvxr9VAicQewmZrREIyb8jyE9R5TlEvM5eYsJJPyQ==
+"@theia/callhierarchy@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-0.4.0-next.3bc56af7.tgz#26774cd842be4a4b4df459ff1a85bda75d089199"
+  integrity sha512-Sob88ewgZIbcT/VeZRiJKMSA+4q1Lh2ma+xs4ndX8wDRrJEqvPg2WrKm9oteShA/6pohLdEiBIh58qUAeaBzkA==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/editor" "0.4.0-next.ba717c52"
-    "@theia/languages" "0.4.0-next.ba717c52"
-    "@theia/monaco" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/editor" "0.4.0-next.3bc56af7"
+    "@theia/languages" "0.4.0-next.3bc56af7"
+    "@theia/monaco" "0.4.0-next.3bc56af7"
     ts-md5 "^1.2.2"
 
 "@theia/cli@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.4.0-next.ba717c52.tgz#ae2306f5fd3018e7cad5909079c46f01ca613900"
-  integrity sha512-Ki+i3qYNwW6Ap0ISHOAT4ipP+F6Js/1OtxXQDzQ++B+fSamRXjraraoNwB09N98FITnZ4kFgoCuRR4HlN1Defw==
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-0.4.0-next.3bc56af7.tgz#5002f8ba1c54fb674f1469ba63b2b04822d4cd3d"
+  integrity sha512-9X2+vp6mpMMEO5UW9F8TrRCFfvz9vnT6nYO5l5HNMNISPbGkh3TCdC4NesV3s5iDfaZbWta5TD4sbMGu5hxzoA==
   dependencies:
-    "@theia/application-manager" "0.4.0-next.ba717c52"
+    "@theia/application-manager" "0.4.0-next.3bc56af7"
 
-"@theia/core@0.4.0-next.ba717c52", "@theia/core@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.ba717c52.tgz#6e33ef034eebe3e10d6b1cd315fed03787e82800"
-  integrity sha512-JQTf1F5+Wu22b9RnwYMmCPJJ+zxb+Q79Dtk0loPL59r2DisSWbIK4s2rf3/Sb+C5onuxQ8mgJZ40khthA7fQjw==
+"@theia/core@0.4.0-next.3bc56af7", "@theia/core@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.3bc56af7.tgz#0f566704fc5a768015fc67532980ee11f99bb721"
+  integrity sha512-KoFhmYqfcvQueuh1a0cNfFeP6ofcJ7imNTz7x4jPOsjkgO7CRm5I8w2F3/tv+IrTr2qUyAx8xGr95Nnc7QGK2w==
   dependencies:
     "@phosphor/widgets" "^1.5.0"
-    "@theia/application-package" "0.4.0-next.ba717c52"
+    "@theia/application-package" "0.4.0-next.3bc56af7"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -243,23 +243,23 @@
     ws "^5.2.2"
     yargs "^11.1.0"
 
-"@theia/editor@0.4.0-next.ba717c52", "@theia/editor@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.ba717c52.tgz#1549880ad9b8942adb4fa1e2f20312e3dd9f154b"
-  integrity sha512-uw+qCHRACU046cxDEXTJAsAycr+qzmbAFIRD1ylPFcziXInIOPhS61GAApGnPaYpHnKE+friJ6rgQW/4qmt89Q==
+"@theia/editor@0.4.0-next.3bc56af7", "@theia/editor@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.3bc56af7.tgz#75ba9c409b54ce98c199c516ba080dc12ddf52ca"
+  integrity sha512-mFx0nAVUgepdByQ4nBIBSEsthukmW3rbAs82u2E6Ks6dn3QKsKhkyR80BcjLBDldWtWw5RiC9emUnMGzOM800Q==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/languages" "0.4.0-next.ba717c52"
-    "@theia/variable-resolver" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/languages" "0.4.0-next.3bc56af7"
+    "@theia/variable-resolver" "0.4.0-next.3bc56af7"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
-"@theia/filesystem@0.4.0-next.ba717c52", "@theia/filesystem@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.4.0-next.ba717c52.tgz#d585750ac703da9d0b95707efec089cd2f9cb118"
-  integrity sha512-f0IIGiraeoDkL9SbZUlETlyprAdOqR+B/cgJBhYU4oRYJXRVtPkEzZsd5fr0oLCIk+DUUq5dGrPH1XX02Q1Bcw==
+"@theia/filesystem@0.4.0-next.3bc56af7", "@theia/filesystem@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.4.0-next.3bc56af7.tgz#b1c03fc0d78e06e021cf58fdc30dba8b9210ea6a"
+  integrity sha512-ryTK+x0gaxNXRYemXYPc7eA8b/5TjOTTZOrL1fBMeYkvf0nVTcspTYYkFCGpxo8BV16fYK7baYJY/WSjkG85tA==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
     "@types/base64-js" "^1.2.5"
     "@types/body-parser" "^1.17.0"
     "@types/fs-extra" "^4.0.2"
@@ -283,59 +283,59 @@
     uuid "^3.2.1"
     zip-dir "^1.0.2"
 
-"@theia/json@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.4.0-next.ba717c52.tgz#aacb94316ae1ed6f76ece42d8e5231a81d0a8ffa"
-  integrity sha512-fBb2l8Ntl+fYa/oNpEz0enNEuTnrbz7JK4F3waGP3zzYib66SzxVdVtlQZRSVF475cA+Vt9q+8Lz1hqBCp1y0Q==
+"@theia/json@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.4.0-next.3bc56af7.tgz#e7fd4ece1b05646813361c6e89befa81de373d25"
+  integrity sha512-eatqz0MTnUvf4MOtFj/2aBFm9J4ceJE3LLu4qJwG2PBwQWrCytrrFJ1q6KNunIWFj/51eRUxIYliPCmxafeImg==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/languages" "0.4.0-next.ba717c52"
-    "@theia/monaco" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/languages" "0.4.0-next.3bc56af7"
+    "@theia/monaco" "0.4.0-next.3bc56af7"
     vscode-json-languageserver "^1.0.1"
 
-"@theia/languages@0.4.0-next.ba717c52", "@theia/languages@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.4.0-next.ba717c52.tgz#df6eac02e89f67f395a9b06771c0b24ba298b4fe"
-  integrity sha512-LYeBeCOWmD875P6kMHeSoW5JY2fg/eBPbyvm0OrCiRYPPN/CS1usLS5k/O7UOAVXbUaBBa7/c3Cj/W8LSp7CCw==
+"@theia/languages@0.4.0-next.3bc56af7", "@theia/languages@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.4.0-next.3bc56af7.tgz#085fb8850bfc842dcf049e7d95a405b1ae36abb0"
+  integrity sha512-HYEmLK7Tz64M/fkwmI9sHl9NBkFWK/+9xSrvRx/CrjOPEPVZvkgoZ+lJXt/8cEnZ2YDIbcpL1VD2TD4+deR4Bw==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/output" "0.4.0-next.ba717c52"
-    "@theia/process" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/output" "0.4.0-next.3bc56af7"
+    "@theia/process" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
     "@typefox/monaco-editor-core" "^0.14.6"
     "@types/uuid" "^3.4.3"
     monaco-languageclient "^0.9.0"
     uuid "^3.2.1"
 
-"@theia/markers@0.4.0-next.ba717c52", "@theia/markers@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.ba717c52.tgz#8c03a37ceecf7ce14c97c8ee8fffa8d759b5764b"
-  integrity sha512-oY31c+MagkYVZyPP/W7i5W6S8o4E98edDNrSHx5nB6dxW/IK9pFPq+HfkO+7Vi9LljEMAItuV3A4MhtOKffJzQ==
+"@theia/markers@0.4.0-next.3bc56af7", "@theia/markers@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.3bc56af7.tgz#f4c70a10b7ae62998ed02bbbe9f968efa1777ff6"
+  integrity sha512-J0+4nY4AH9rU2azDgeCO5jEFLVOL+0e5xsAs/s4S6MSI4UYbYnd+ZAt6WJ55acRbHghORTGKwtxaBw/6+kSWFA==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/navigator" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/navigator" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
 
 "@theia/messages@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.4.0-next.ba717c52.tgz#daba36cbb97814f341a853e2159806265d465c01"
-  integrity sha512-njDdyisndrgiyiNrDhiYaHfHK713H+CAmrCerPn74utVcdPpdJTSva0ol7RH4JPEjrRUSYCOK+eHLVvky5ptMg==
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.4.0-next.3bc56af7.tgz#b6c76e69718a285ebaff833a820462101a5f2416"
+  integrity sha512-VL4xzjvrxva6CWWJ/MdiPCVu3wFBFG1k3DFlHCWNJhYDPU2/Gzvbko5yKG54RPD+6jrBQKxEYgeILj/E0QzfnQ==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
 
-"@theia/monaco@0.4.0-next.ba717c52", "@theia/monaco@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.4.0-next.ba717c52.tgz#f376b5f386a2129239dba3d2adf8bf4d1783c23e"
-  integrity sha512-XptxaZsDHb+9u7d0AgLjlMQULKjhNj54QNMVk0fElmIl+WTzzF36XoDpUI+1qnJH5qErdlSACV1SJjJKN0c03w==
+"@theia/monaco@0.4.0-next.3bc56af7", "@theia/monaco@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.4.0-next.3bc56af7.tgz#6e85b577187efb6316213e6590120cdd3fe8cec6"
+  integrity sha512-Jt8Txut9oRszrpowe02KKuBK+GhgEwKxovAILX1zAE8B6NNtda32l8473IjFDCm7rwGQt8gewLYS6OaoXf/U+w==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/editor" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/languages" "0.4.0-next.ba717c52"
-    "@theia/markers" "0.4.0-next.ba717c52"
-    "@theia/outline-view" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/editor" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/languages" "0.4.0-next.3bc56af7"
+    "@theia/markers" "0.4.0-next.3bc56af7"
+    "@theia/outline-view" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
     deepmerge "2.0.1"
     jsonc-parser "^2.0.2"
     monaco-css "^2.0.1"
@@ -343,14 +343,14 @@
     onigasm "^2.1.0"
     vscode-textmate "^4.0.1"
 
-"@theia/navigator@0.4.0-next.ba717c52", "@theia/navigator@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.ba717c52.tgz#709a465c6a44def95eaec8120d7ca7aecbb96740"
-  integrity sha512-BaOAerBCOU9HptOmhT8QIC6Txnf5/StVF9E28tq/PE5DaTsOqnpgYvNS8E+pottLYRfReBx4c1b7U2B9n4+/TA==
+"@theia/navigator@0.4.0-next.3bc56af7", "@theia/navigator@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.3bc56af7.tgz#050ac84871a535f6f6a5e50c19d1778961baf9d0"
+  integrity sha512-OIJvScGy3Rm/GRzAeIdDCOe73rg/j88t1cSkDzSI3hakR29qnbktl6HFy3XB6BfI4vWlT09aWZslGNkFM4B8UA==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
@@ -361,96 +361,96 @@
   dependencies:
     nan "2.10.0"
 
-"@theia/outline-view@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.4.0-next.ba717c52.tgz#18e4efb028486fa2ab8988c2c31c3d8099c935c3"
-  integrity sha512-07qZFHlNoJs8d2xJxN5+4HLcl3+3YCEmV5yIdHyHYtkxwKv6wqdUzIMFSszMTyojzhiSXx/5+6WHYguOMDTZAQ==
+"@theia/outline-view@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.4.0-next.3bc56af7.tgz#d64c56e3977cb9d4dfca73d0193fd02d0cd0feb8"
+  integrity sha512-U0E+wsmHaFpVb5WiJM6Q7JsCFJBBv8m7D7XIIpOfn7UPceyYfvCRxo7t3IM/LZP34eeQ0C4Q3bqNlFvRITc7Ig==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
 
-"@theia/output@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.ba717c52.tgz#4de3eb26652b345898e5ce80c6245cc14aadb044"
-  integrity sha512-NXwMvsiuY0mxYkHIbCe6JqGYxSU90u+yjAOlbjS/E48Farx0wBym3UdTa3YeP46YtdcWC1PSWLaDEKtBsFsXUA==
+"@theia/output@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.3bc56af7.tgz#126da75d3a182f8fbdc523fa195520539a84fd19"
+  integrity sha512-X5sPoAe9Qk2QVHLmrfYnWfkNeWkoNVeoZdMUbK6CsyCN4TZfGUDqcdtmVqrCdeZpOda8VLNPpmjHsn/eku4/GQ==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
 
 "@theia/preferences@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.4.0-next.ba717c52.tgz#5a070fa29457a8348d3b4bc84380527445d11e4b"
-  integrity sha512-dCcqyXHdGCQ5LkncFVlUFzurffr/Ucyhr2B0OWOn0nqewF70Xomk4VmbonhbQsu5wjgtjwjZ44U3htxgomM51w==
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.4.0-next.3bc56af7.tgz#a53169296b7c8c04e04988e430ee3ad42f49b643"
+  integrity sha512-rOPONjY93sGZckaTyB/q1YHUqvnU3ARb+XsZlWmof9aqgZQu+LEEmnTw3vSs4GwGlZA3rh/rEo4XSPsdT+ygHg==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/editor" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/json" "0.4.0-next.ba717c52"
-    "@theia/monaco" "0.4.0-next.ba717c52"
-    "@theia/userstorage" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/editor" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/json" "0.4.0-next.3bc56af7"
+    "@theia/monaco" "0.4.0-next.3bc56af7"
+    "@theia/userstorage" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
     "@types/fs-extra" "^4.0.2"
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
 
-"@theia/process@0.4.0-next.ba717c52", "@theia/process@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.ba717c52.tgz#6f6b56182012ef7caf45cdcb045c3cde4402487e"
-  integrity sha512-1dJwIPWiiaFVWCJ9lOHGSVkXl2sqqFgq6O37sNBdpiqJhWeO3RSxpGvCc7Ep6yPNoFlv5vTADTbt5yX8Dt5ThA==
+"@theia/process@0.4.0-next.3bc56af7", "@theia/process@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.3bc56af7.tgz#57d015e3ca14ca95e771d2ad6959f92e42bda3d9"
+  integrity sha512-65HCzddI6hM+7la8UhaIgq2Fye/JBTMeYrsCrHYf/H+ddA+edzcRP1xGmisJdKI3RmNtnnKkCsxPZxKLhtc8iA==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
     "@theia/node-pty" "0.7.8-theia004"
     string-argv "^0.1.1"
 
 "@theia/terminal@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.4.0-next.ba717c52.tgz#dda4cd8f74bafe57dc1524a3c014eca2b859fa48"
-  integrity sha512-uRsdDxBVFQovA0Wip+Gd7TnB8mVDAPQdzsscKNyzwStEa0urd4e1K+fqa1NwC0TO6m1gdeVog5kLUz28cDVy6Q==
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-0.4.0-next.3bc56af7.tgz#de71034757b3009592feaa6b1494461cbf9a09b0"
+  integrity sha512-6nbhFCYwYK9zz7f5BGZLFKRa9xTgX2x4uk9e7BBOPkFBF2FIilz0FOm0K1DacZojc51c6itl33iU10Ux8uJkFA==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/editor" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/process" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/editor" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/process" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
     xterm "3.9.2"
 
 "@theia/typescript@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.4.0-next.ba717c52.tgz#a58717cb0206994c816b88190e51e770f45732a8"
-  integrity sha512-p9IK0o23k7/PgJgP+Lg1GRwkpW/VEf+7YIPBStlkCJK0epo+h/SyPLyooxajM3I4ZWmJo/aJA6wjNoW7f7Q7lw==
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/typescript/-/typescript-0.4.0-next.3bc56af7.tgz#e0a15c32005649aa9db3cd5a8ed01da585f96bf0"
+  integrity sha512-fu1wjjpXwW5fWL6Rp1hmLGviYO+6rabk52YSFSNZwIldGr5aw6DyDx8xS4zUT9pKNaiOTRkY2TJMCqWpy3OoSQ==
   dependencies:
-    "@theia/application-package" "0.4.0-next.ba717c52"
-    "@theia/callhierarchy" "0.4.0-next.ba717c52"
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/editor" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/languages" "0.4.0-next.ba717c52"
-    "@theia/monaco" "0.4.0-next.ba717c52"
-    "@theia/workspace" "0.4.0-next.ba717c52"
+    "@theia/application-package" "0.4.0-next.3bc56af7"
+    "@theia/callhierarchy" "0.4.0-next.3bc56af7"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/editor" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/languages" "0.4.0-next.3bc56af7"
+    "@theia/monaco" "0.4.0-next.3bc56af7"
+    "@theia/workspace" "0.4.0-next.3bc56af7"
     command-exists "^1.2.8"
     typescript-language-server "^0.3.7"
 
-"@theia/userstorage@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.ba717c52.tgz#99f2ea011d872f9e14ca6bd91ae319752e7cde3c"
-  integrity sha512-fTrn0kjOPbRVtlStUFnm22gmi13HKTLpjDlJgUdZhmRgXh009Zv7SBAIbOdIQqNq74gJW1Mkw2dFgJmscStBTw==
+"@theia/userstorage@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.3bc56af7.tgz#50f644d01607d43a390b8bcd4a09df74a456f88b"
+  integrity sha512-u7AOOrrpSCT1kOXVpzQsf0Q+0+shCDZZVP/Fmfm76YbnYIm439YbidixsW2XettE3Z0tcT+dPGzaX7/ca66cug==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
 
-"@theia/variable-resolver@0.4.0-next.ba717c52":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.ba717c52.tgz#6bc2d4f5d485acfbc658051b7235bfae6c1bc344"
-  integrity sha512-Pm9pxauxgJ7QQn4pLkisilTJsrvrwkfz+g3blM9+U8VyUXiANHllOzdPNlatFLK3E0Go6I0ikDUoeEDGPXjeeQ==
+"@theia/variable-resolver@0.4.0-next.3bc56af7":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.3bc56af7.tgz#435098de9d66e902ddb9bab5655ca2fa9dffa0b6"
+  integrity sha512-F+1bD6uGFV/fE0nWNo2zmzxA6mzxhAoYj6yyL7ZlVguEtkMzp7s7/mCJKBuHy6UgkB1eUbE369e1RGLnzbAqVQ==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
 
-"@theia/workspace@0.4.0-next.ba717c52", "@theia/workspace@next":
-  version "0.4.0-next.ba717c52"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.4.0-next.ba717c52.tgz#5633b163dc1fb8aff28816ee9e45b03005ddf9d2"
-  integrity sha512-zxpqA7DzGus188DrtRx+Jwph2P1UpRHZIHOzYZZMm9GXkCxyPZuD4JO47eBEDxUJFxwPg5lA602mXyG5yPmKMA==
+"@theia/workspace@0.4.0-next.3bc56af7", "@theia/workspace@next":
+  version "0.4.0-next.3bc56af7"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.4.0-next.3bc56af7.tgz#48bdfd435dd573f754826195703945df1931c25b"
+  integrity sha512-JjC9Gb4bWAFqjjyJ9mBGd47VnZRFUMpDJp/5KPjWWWtLQbQlbaOmBwSjUkMCzR+mFqEJCQpX21d7wN/N1WVczw==
   dependencies:
-    "@theia/core" "0.4.0-next.ba717c52"
-    "@theia/filesystem" "0.4.0-next.ba717c52"
-    "@theia/variable-resolver" "0.4.0-next.ba717c52"
+    "@theia/core" "0.4.0-next.3bc56af7"
+    "@theia/filesystem" "0.4.0-next.3bc56af7"
+    "@theia/variable-resolver" "0.4.0-next.3bc56af7"
     "@types/fs-extra" "^4.0.2"
     ajv "^6.5.3"
     fs-extra "^4.0.2"


### PR DESCRIPTION
- Replace 'Routable' interface with 'SRoutableElement' class
- Provide isRoutable function to replace sprotty one
- Provide createReconnectHandle function (now hidden in LinearEdgeRouter)
- Remove unnecessary button handler registry for SelectionTracker
- Replace usage of ActionHandlerRegistry with IActionHandlerInitializer
- Use AnchorComputerRegistry for edge anchoring
- Update yarn.lock and fix compilation errors