### PR TITLE
Fix #185: Ensure elements can be resized after using the reconnect tool

### DIFF
--- a/client/packages/glsp-sprotty/src/features/reconnect/model.ts
+++ b/client/packages/glsp-sprotty/src/features/reconnect/model.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { edgeInProgressID, edgeInProgressTargetHandleID, RoutingHandleKind, SModelElement, SRoutableElement, SRoutingHandle } from "sprotty/lib";
+import { edgeInProgressID, edgeInProgressTargetHandleID, RoutingHandleKind, selectFeature, SModelElement, SRoutableElement, SRoutingHandle } from "sprotty/lib";
 
 const ROUTING_HANDLE_SOURCE_INDEX: number = -2;
 
@@ -21,8 +21,8 @@ export function isRoutable<T extends SModelElement>(element: T): element is T & 
     return element instanceof SRoutableElement && (element as any).routingPoints !== undefined;
 }
 
-export function isReconnectHandle(element: SModelElement | undefined): element is SRoutingHandle {
-    return element !== undefined && element instanceof SRoutingHandle;
+export function isReconnectHandle(element: SModelElement | undefined): element is SReconnectHandle {
+    return element !== undefined && element instanceof SReconnectHandle;
 }
 
 export function addReconnectHandles(element: SRoutableElement) {
@@ -32,19 +32,19 @@ export function addReconnectHandles(element: SRoutableElement) {
 }
 
 export function removeReconnectHandles(element: SRoutableElement) {
-    element.removeAll(child => child instanceof SRoutingHandle);
+    element.removeAll(child => child instanceof SReconnectHandle);
 }
 
-export function isSourceRoutingHandle(edge: SRoutableElement, routingHandle: SRoutingHandle) {
+export function isSourceRoutingHandle(edge: SRoutableElement, routingHandle: SReconnectHandle) {
     return routingHandle.pointIndex === ROUTING_HANDLE_SOURCE_INDEX;
 }
 
-export function isTargetRoutingHandle(edge: SRoutableElement, routingHandle: SRoutingHandle) {
+export function isTargetRoutingHandle(edge: SRoutableElement, routingHandle: SReconnectHandle) {
     return routingHandle.pointIndex === edge.routingPoints.length;
 }
 
-export function createReconnectHandle(edge: SRoutableElement, kind: RoutingHandleKind, routingPointIndex: number): SRoutingHandle {
-    const handle = new SRoutingHandle();
+export function createReconnectHandle(edge: SRoutableElement, kind: RoutingHandleKind, routingPointIndex: number): SReconnectHandle {
+    const handle = new SReconnectHandle();
     handle.kind = kind;
     handle.pointIndex = routingPointIndex;
     handle.type = 'routing-point';
@@ -53,4 +53,10 @@ export function createReconnectHandle(edge: SRoutableElement, kind: RoutingHandl
     }
     edge.add(handle);
     return handle;
+}
+
+export class SReconnectHandle extends SRoutingHandle {
+    hasFeature(feature: symbol): boolean {
+        return feature !== selectFeature && super.hasFeature(feature);
+    }
 }


### PR DESCRIPTION
The selected reconnect handles mess up the selection tracking of the change bounds tool, as they never get properly de-selected through mouse or key events (how the change bounds tool tracks selection). The change bounds tool therefore always thought we had a multi-selection case for which the tool is not "active". This fix therefore ensures that reconnect handles are never selected in the first place.

As a result, the connectable that you click when changing the source or target of an edge, now shows resize handles (as both are default tools and always active).

Please note that in the long run I believe that we will encounter similar issues as the selection tracking is currently very unstable: It only tracks key and mouse events (as this is the level on which the tools operate), so any SelectAction or direct manipulation of the selection flag will definitely be missed, leading to inconsistent tracking of the selected elements and the single- vs. multi-selection state (that caused this error). 