### PR TITLE
Automatically split and organize imports with split-n-sort extension

### DIFF
--- a/client/.vscode/extensions.json
+++ b/client/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-vscode.vscode-typescript-tslint-plugin",
+		"mflo999.import-splitnsort"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -6,10 +6,12 @@
 {
     "tslint.enable": true,
     "tslint.configFile": "configs/tslint.json",
-    "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": true,
+        "source.fixAll.tslint": true
     },
+    "import-splitnsort.on-save": true,
+    "editor.formatOnSave": true,
     "search.exclude": {
         "**/node_modules": true,
         "**/lib": true


### PR DESCRIPTION

I think this will help with the unnecessary conflicts we often have on
the lines with imports. I configured this extension as recommended
ones so that they should be suggested by VSCode on first open.