### PR TITLE
Resolve #194: Provide re-routing action for edges

### DIFF
--- a/client/examples/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/examples/workflow/workflow-sprotty/src/di.config.ts
@@ -16,7 +16,7 @@
 
 import {
     boundsModule, buttonModule, commandPaletteModule, configureModelElement, ConsoleLogger, defaultGLSPModule, defaultModule, //
-    DiamondNodeView, ExpandButtonView, expandModule, exportModule, fadeModule, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelHintsModule, //
+    DiamondNodeView, edgeEditModule, edgeLayoutModule, ExpandButtonView, expandModule, exportModule, fadeModule, GLSPGraph, hoverModule, HtmlRoot, HtmlRootView, LogLevel, modelHintsModule, //
     modelSourceModule, openModule, overrideViewerOptions, paletteModule, PreRenderedElement, PreRenderedView, RectangularNode, RectangularNodeView, requestResponseModule, //
     routingModule, saveModule, SButton, SCompartment, SCompartmentView, SEdge, selectModule, SGraphView, SLabel, SLabelView, SRoutingHandle, SRoutingHandleView, //
     toolFeedbackModule, TYPES, viewportModule
@@ -60,7 +60,7 @@ export default function createContainer(widgetId: string): Container {
     container.load(defaultModule, defaultGLSPModule, selectModule, boundsModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
         workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule,
-        commandPaletteModule, paletteModule, requestResponseModule, routingModule);
+        commandPaletteModule, paletteModule, requestResponseModule, routingModule, edgeEditModule, edgeLayoutModule);
 
     overrideViewerOptions(container, {
         needsClientLayout: true,

--- a/client/packages/glsp-sprotty/css/glsp-sprotty.css
+++ b/client/packages/glsp-sprotty/css/glsp-sprotty.css
@@ -36,7 +36,7 @@
 }
 
 .edge-creation-select-source-mode,
-.edge-reconnect-select-source-mode {
+.edge-edit-select-source-mode {
     cursor: pointer;
 }
 

--- a/client/packages/glsp-sprotty/src/features/operation/set-operations.ts
+++ b/client/packages/glsp-sprotty/src/features/operation/set-operations.ts
@@ -19,6 +19,7 @@ export namespace OperationKind {
     export const CREATE_NODE = "createNode";
     export const CREATE_CONNECTION = "createConnection";
     export const RECONNECT_CONNECTION = "reconnectConnection";
+    export const REROUTE_CONNECTION = "rerouteConnection";
     export const DELETE_ELEMENT = "delete";
     export const CHANGE_BOUNDS = "changeBoundsOperation";
     export const CHANGE_CONTAINER = "changeContainer"

--- a/client/packages/glsp-sprotty/src/features/reconnect/action-definitions.ts
+++ b/client/packages/glsp-sprotty/src/features/reconnect/action-definitions.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action } from "sprotty/lib";
+import { Action, Point } from "sprotty/lib";
 import { OperationKind } from "../operation/set-operations";
 
 export class ReconnectConnectionOperationAction implements Action {
@@ -22,4 +22,12 @@ export class ReconnectConnectionOperationAction implements Action {
     constructor(public readonly connectionElementId: string,
         public readonly sourceElementId: string,
         public readonly targetElementId: string) { }
+}
+
+
+export class RerouteConnectionOperationAction implements Action {
+    readonly kind = OperationKind.REROUTE_CONNECTION;
+
+    constructor(public readonly connectionElementId: string,
+        public readonly routingPoints: Point[]) { }
 }

--- a/client/packages/glsp-sprotty/src/features/reconnect/model.ts
+++ b/client/packages/glsp-sprotty/src/features/reconnect/model.ts
@@ -25,6 +25,10 @@ export function isReconnectHandle(element: SModelElement | undefined): element i
     return element !== undefined && element instanceof SReconnectHandle;
 }
 
+export function isRoutingHandle(element: SModelElement | undefined): element is SRoutingHandle {
+    return element !== undefined && element instanceof SRoutingHandle;
+}
+
 export function addReconnectHandles(element: SRoutableElement) {
     removeReconnectHandles(element);
     createReconnectHandle(element, 'source', ROUTING_HANDLE_SOURCE_INDEX);

--- a/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-feedback/di.config.ts
@@ -24,11 +24,11 @@ import {
     ShowEdgeCreationSelectSourceFeedbackCommand, ShowEdgeCreationSelectTargetFeedbackCommand, //
     ShowNodeCreationToolFeedbackCommand
 } from "./creation-tool-feedback";
-import { FeedbackActionDispatcher } from "./feedback-action-dispatcher";
 import {
     HideEdgeReconnectHandlesFeedbackCommand, HideEdgeReconnectToolFeedbackCommand, // 
     ShowEdgeReconnectHandlesFeedbackCommand, ShowEdgeReconnectSelectSourceFeedbackCommand
-} from "./reconnect-tool-feedback";
+} from "./edge-edit-tool-feedback";
+import { FeedbackActionDispatcher } from "./feedback-action-dispatcher";
 import { FeedbackEdgeEndView, SResizeHandleView } from "./view";
 
 const toolFeedbackModule = new ContainerModule((bind, _unbind, isBound) => {

--- a/client/packages/glsp-sprotty/src/features/tools/change-bounds-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/change-bounds-tool.ts
@@ -100,15 +100,12 @@ class ChangeBoundsListener extends SelectionTracker {
                 active = true;
             } else {
                 // check if we have a moveable element (multi-selection allowed)
+                this.tool.dispatchFeedback([new HideChangeBoundsToolResizeFeedbackAction()]);
                 const moveableElement = findParentByFeature(target, isBoundsAwareMoveable);
-
-                // check if we have a resizeable element (only single-selection)
-                if (this.isSingleSelection()) {
-                    this.activeResizeElementId = this.getSelectedElementIDs().values().next().value;
+                if (moveableElement) {
+                    // only allow one element to have the element resize handles
+                    this.activeResizeElementId = moveableElement.id;
                     this.tool.dispatchFeedback([new ShowChangeBoundsToolResizeFeedbackAction(this.activeResizeElementId)]);
-                } else {
-                    this.activeResizeElementId = undefined;
-                    this.tool.dispatchFeedback([new HideChangeBoundsToolResizeFeedbackAction()]);
                 }
                 active = moveableElement !== undefined || this.activeResizeElementId !== undefined;
             }

--- a/client/packages/glsp-sprotty/src/features/tools/default-tools.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/default-tools.ts
@@ -17,13 +17,13 @@ import { interfaces } from "inversify";
 import { ToolManager, TYPES } from "sprotty/lib";
 import { ChangeBoundsTool } from "./change-bounds-tool";
 import { DelKeyDeleteTool, MouseDeleteTool } from "./delete-tool";
-import { EdgeReconnectTool } from "./reconnect-tool";
+import { EdgeEditTool } from "./edge-edit-tool";
 
 export function registerDefaultTools(container: interfaces.Container) {
     const toolManager: ToolManager = container.get(TYPES.IToolManager);
     toolManager.registerDefaultTools(
         container.resolve(ChangeBoundsTool),
-        container.resolve(EdgeReconnectTool),
+        container.resolve(EdgeEditTool),
         container.resolve(DelKeyDeleteTool));
     toolManager.registerTools(container.resolve(MouseDeleteTool));
     toolManager.enableDefaultTools();

--- a/client/packages/glsp-sprotty/src/features/tools/edge-edit-tool.ts
+++ b/client/packages/glsp-sprotty/src/features/tools/edge-edit-tool.ts
@@ -13,34 +13,37 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from "inversify";
+import { inject, injectable, optional } from "inversify";
 import {
-    Action, AnchorComputerRegistry, Connectable, findParentByFeature, isConnectable, MouseTool, //
+    Action, AnchorComputerRegistry, Connectable, EdgeRouterRegistry, findParentByFeature, isConnectable, MouseTool, //
     SModelElement, SRoutableElement, SRoutingHandle, Tool
 } from "sprotty/lib";
 import { GLSP_TYPES } from "../../types";
-import { ReconnectConnectionOperationAction } from "../reconnect/action-definitions";
-import { isReconnectHandle, isRoutable, isSourceRoutingHandle, isTargetRoutingHandle } from "../reconnect/model";
+import { ReconnectConnectionOperationAction, RerouteConnectionOperationAction } from "../reconnect/action-definitions";
+import { isReconnectHandle, isRoutable, isRoutingHandle, isSourceRoutingHandle, isTargetRoutingHandle, SReconnectHandle } from "../reconnect/model";
 import { SelectionTracker } from "../select/selection-tracker";
+import { FeedbackMoveMouseListener } from "../tool-feedback/change-bounds-tool-feedback";
 import { feedbackEdgeId } from "../tool-feedback/creation-tool-feedback";
-import { IFeedbackActionDispatcher } from "../tool-feedback/feedback-action-dispatcher";
 import {
-    FeedbackEdgeSourceMovingMouseListener, FeedbackEdgeTargetMovingMouseListener, HideEdgeReconnectHandlesFeedbackAction, HideEdgeReconnectToolFeedbackAction, //
-    ShowEdgeReconnectHandlesFeedbackAction, ShowEdgeReconnectSelectSourceFeedbackAction, ShowEdgeReconnectSelectTargetFeedbackAction
-} from "../tool-feedback/reconnect-tool-feedback";
+    FeedbackEdgeRouteMovingMouseListener, FeedbackEdgeSourceMovingMouseListener, FeedbackEdgeTargetMovingMouseListener, HideEdgeReconnectHandlesFeedbackAction, //
+    HideEdgeReconnectToolFeedbackAction, ShowEdgeReconnectHandlesFeedbackAction, ShowEdgeReconnectSelectSourceFeedbackAction, ShowEdgeReconnectSelectTargetFeedbackAction
+} from "../tool-feedback/edge-edit-tool-feedback";
+import { IFeedbackActionDispatcher } from "../tool-feedback/feedback-action-dispatcher";
 
 @injectable()
-export class EdgeReconnectTool implements Tool {
-    static ID = "glsp.edge-reconnect-tool";
-    readonly id = EdgeReconnectTool.ID;
+export class EdgeEditTool implements Tool {
+    static ID = "glsp.edge-edit-tool";
+    readonly id = EdgeEditTool.ID;
 
     protected feedbackEdgeSourceMovingListener: FeedbackEdgeSourceMovingMouseListener;
     protected feedbackEdgeTargetMovingListener: FeedbackEdgeTargetMovingMouseListener;
+    protected feedbackMovingListener: FeedbackMoveMouseListener;
     protected reconnectEdgeListener: ReconnectEdgeListener;
 
     constructor(@inject(MouseTool) protected mouseTool: MouseTool,
         @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher,
-        @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry) {
+        @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry,
+        @inject(EdgeRouterRegistry) @optional() protected edgeRouterRegistry?: EdgeRouterRegistry) {
     }
 
     enable(): void {
@@ -50,14 +53,17 @@ export class EdgeReconnectTool implements Tool {
         // install feedback move mouse listener for client-side move updates
         this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener(this.anchorRegistry);
         this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener(this.anchorRegistry);
+        this.feedbackMovingListener = new FeedbackEdgeRouteMovingMouseListener(this.edgeRouterRegistry);
         this.mouseTool.register(this.feedbackEdgeSourceMovingListener);
         this.mouseTool.register(this.feedbackEdgeTargetMovingListener);
+        this.mouseTool.register(this.feedbackMovingListener);
     }
 
     disable(): void {
         this.reconnectEdgeListener.reset();
         this.mouseTool.deregister(this.feedbackEdgeSourceMovingListener);
         this.mouseTool.deregister(this.feedbackEdgeTargetMovingListener);
+        this.mouseTool.deregister(this.feedbackMovingListener);
         this.mouseTool.deregister(this.reconnectEdgeListener);
     }
 
@@ -69,19 +75,17 @@ export class EdgeReconnectTool implements Tool {
 class ReconnectEdgeListener extends SelectionTracker {
     private isMouseDown: boolean;
 
-    // active edge data
-    private edgeId?: string;
-    private edgeTypeId?: string;
-    private edgeSourceId?: string;
-    private edgeTargetId?: string;
-
-    // active reconnect handle data
-    private reconnectMode?: 'NEW_SOURCE' | 'NEW_TARGET';
+    // active selection data
+    private edge?: SRoutableElement;
+    private routingHandle?: SRoutingHandle;
 
     // new connectable (source or target) for edge
     private newConnectable?: SModelElement & Connectable;
 
-    constructor(protected tool: EdgeReconnectTool) {
+    // active reconnect handle data
+    private reconnectMode?: 'NEW_SOURCE' | 'NEW_TARGET';
+
+    constructor(protected tool: EdgeEditTool) {
         super();
     }
 
@@ -90,29 +94,26 @@ class ReconnectEdgeListener extends SelectionTracker {
     }
 
     private setEdgeSelected(edge: SRoutableElement) {
-        if (this.edgeId && this.edgeId !== edge.id) {
+        if (this.edge && this.edge.id !== edge.id) {
             // reset from a previously selected edge
             this.reset();
         }
 
-        this.edgeId = edge.id;
-        this.edgeSourceId = edge.sourceId;
-        this.edgeTargetId = edge.targetId;
-        this.edgeTypeId = edge.type;
-        this.tool.dispatchFeedback([new ShowEdgeReconnectHandlesFeedbackAction(this.edgeId)]);
+        this.edge = edge;
+        this.tool.dispatchFeedback([new ShowEdgeReconnectHandlesFeedbackAction(this.edge.id)]);
     }
 
     private isEdgeSelected(): boolean {
-        return this.edgeId !== undefined && this.edgeTypeId !== undefined;
+        return this.edge !== undefined;
     }
 
-    private setReconnectHandleSelected(edge: SRoutableElement, reconnectHandle: SRoutingHandle) {
-        if (this.edgeTypeId && this.edgeSourceId && this.edgeTargetId) {
+    private setReconnectHandleSelected(edge: SRoutableElement, reconnectHandle: SReconnectHandle) {
+        if (this.edge && this.edge.target && this.edge.source) {
             if (isSourceRoutingHandle(edge, reconnectHandle)) {
-                this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectSourceFeedbackAction(this.edgeTypeId, this.edgeTargetId)]);
+                this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectSourceFeedbackAction(this.edge.type, this.edge.target.id)]);
                 this.reconnectMode = "NEW_SOURCE";
             } else if (isTargetRoutingHandle(edge, reconnectHandle)) {
-                this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectTargetFeedbackAction(this.edgeTypeId, this.edgeSourceId)]);
+                this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(), new ShowEdgeReconnectSelectTargetFeedbackAction(this.edge.type, this.edge.source.id)]);
                 this.reconnectMode = "NEW_TARGET";
             }
         }
@@ -126,8 +127,14 @@ class ReconnectEdgeListener extends SelectionTracker {
         return this.reconnectMode === "NEW_SOURCE";
     }
 
+    private setRoutingHandleSelected(edge: SRoutableElement, routingHandle: SRoutingHandle) {
+        if (this.edge && this.edge.target && this.edge.source) {
+            this.routingHandle = routingHandle;
+        }
+    }
+
     private requiresReconnect(sourceId: string, targetId: string): boolean {
-        return this.edgeSourceId !== sourceId || this.edgeTargetId !== targetId;
+        return this.edge !== undefined && (this.edge.sourceId !== sourceId || this.edge.targetId !== targetId);
     }
 
     private setNewConnectable(connectable?: SModelElement & Connectable) {
@@ -138,20 +145,28 @@ class ReconnectEdgeListener extends SelectionTracker {
         return this.isEdgeSelected() && this.isReconnecting() && this.newConnectable !== undefined;
     }
 
+    private isReadyToReroute() {
+        return this.routingHandle !== undefined;
+    }
+
     mouseDown(target: SModelElement, event: MouseEvent): Action[] {
         const result: Action[] = [];
         this.isMouseDown = true;
         if (event.button === 0) {
             const reconnectHandle = findParentByFeature(target, isReconnectHandle);
+            const routingHandle = findParentByFeature(target, isRoutingHandle);
             const edge = findParentByFeature(target, isRoutable);
             if (this.isEdgeSelected() && edge && reconnectHandle) {
-                // PHASE 2: Select reconnect handle on selected edge
+                // PHASE 2 Reconnect: Select reconnect handle on selected edge
                 this.setReconnectHandleSelected(edge, reconnectHandle);
+            } else if (this.isEdgeSelected() && edge && routingHandle) {
+                // PHASE 2 Reroute: Select routing handle on selected edge
+                this.setRoutingHandleSelected(edge, routingHandle);
             } else if (this.isValidEdge(edge)) {
                 // PHASE 1: Select edge
                 this.setEdgeSelected(edge);
             } else if (this.isReconnecting()) {
-                // PHASE 3: Select new connectable (target or source) for reconnecting the selected edge
+                // PHASE 3 Reconnect: Select new connectable (target or source) for reconnecting the selected edge
                 // if no connectable was selected, do nothing, allow clicking on other elements and empty area during this phase
                 const connectable = findParentByFeature(target, isConnectable);
                 if (connectable) {
@@ -174,19 +189,19 @@ class ReconnectEdgeListener extends SelectionTracker {
 
     mouseUp(target: SModelElement, event: MouseEvent): Action[] {
         this.isMouseDown = false;
-        if (!this.isReadyToReconnect()) {
+        if (!this.isReadyToReconnect() && !this.isReadyToReroute()) {
             return [];
         }
 
         const result: Action[] = [];
-        if (this.newConnectable) {
-            const id = this.edgeId;
-            const type = this.edgeTypeId;
-            const sourceId = this.isReconnectingNewSource() ? this.newConnectable.id : this.edgeSourceId;
-            const targetId = this.isReconnectingNewSource() ? this.edgeTargetId : this.newConnectable.id;
-            if (id && type && sourceId && targetId && this.requiresReconnect(sourceId, targetId)) {
-                result.push(new ReconnectConnectionOperationAction(id, sourceId, targetId));
+        if (this.edge && this.newConnectable) {
+            const sourceId = this.isReconnectingNewSource() ? this.newConnectable.id : this.edge.sourceId;
+            const targetId = this.isReconnectingNewSource() ? this.edge.targetId : this.newConnectable.id;
+            if (this.requiresReconnect(sourceId, targetId)) {
+                result.push(new ReconnectConnectionOperationAction(this.edge.id, sourceId, targetId));
             }
+        } else if (this.edge && this.routingHandle) {
+            result.push(new RerouteConnectionOperationAction(this.edge.id, this.edge.routingPoints));
         }
         this.reset();
         return result;
@@ -199,12 +214,10 @@ class ReconnectEdgeListener extends SelectionTracker {
 
     private resetData() {
         this.isMouseDown = false;
-        this.edgeId = undefined;
-        this.edgeSourceId = undefined;
-        this.edgeTargetId = undefined;
-        this.edgeTypeId = undefined;
+        this.edge = undefined;
         this.reconnectMode = undefined;
         this.newConnectable = undefined;
+        this.routingHandle = undefined;
     }
 
     private resetFeedback() {

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -18,7 +18,7 @@ import {
     Action, ActionHandlerRegistry, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, ExecuteServerCommandAction, ExportSvgAction, IdentifiableRequestAction, //
     ModelSource, OpenAction, OperationKind, RequestBoundsCommand, RequestCommandPaletteActions, RequestModelAction, RequestOperationsAction, RequestPopupModelAction, //
     RequestTypeHintsAction, SaveModelAction, ServerStatusAction, //
-    SetTypeHintsAction, SwitchEditModeCommand
+    SetTypeHintsAction
 } from "glsp-sprotty/lib";
 import { injectable } from "inversify";
 import { TheiaDiagramServer } from "sprotty-theia/lib";
@@ -32,6 +32,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         registry.register(SaveModelAction.KIND, this)
         registry.register(OperationKind.CREATE_CONNECTION, this)
         registry.register(OperationKind.RECONNECT_CONNECTION, this)
+        registry.register(OperationKind.REROUTE_CONNECTION, this)
         registry.register(OperationKind.CREATE_NODE, this)
         registry.register(OperationKind.CHANGE_BOUNDS, this)
         registry.register(OperationKind.DELETE_ELEMENT, this)
@@ -53,7 +54,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         // Register an empty handler for SwitchEditMode, to avoid runtime exceptions.
         // We don't want to support SwitchEditMode, but sprotty still sends some corresponding
         // actions.
-        registry.register(SwitchEditModeCommand.KIND, { handle: action => undefined })
+        // registry.register(SwitchEditModeCommand.KIND, { handle: action => undefined })
     }
 
 

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
@@ -30,6 +30,7 @@ import com.eclipsesource.glsp.example.workflow.handler.CreateMergeNodeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.CreateWeightedEdgeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.DeleteWorkflowElementHandler;
 import com.eclipsesource.glsp.example.workflow.handler.ReconnectEdgeHandler;
+import com.eclipsesource.glsp.example.workflow.handler.RerouteEdgeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.SimulateCommandHandler;
 import com.eclipsesource.glsp.server.ServerModule;
 import com.eclipsesource.glsp.server.operationhandler.ChangeBoundsOperationHandler;
@@ -81,6 +82,7 @@ public class WorkflowServerRuntimeModule extends ServerModule {
 		bindOperationHandler().to(CreateWeightedEdgeHandler.class);
 		bindOperationHandler().to(CreateEdgeHandler.class);
 		bindOperationHandler().to(ReconnectEdgeHandler.class);
+		bindOperationHandler().to(RerouteEdgeHandler.class);
 		bindOperationHandler().to(DeleteWorkflowElementHandler.class);
 		bindOperationHandler().to(ChangeBoundsOperationHandler.class);
 		bindOperationHandler().to(DeleteHandler.class);

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
@@ -94,6 +94,7 @@ public abstract class Action {
 		public static final String SAVE_MODEL = "saveModel";
 		public static final String CREATE_CONNECTION_OPERATION = Operation.Kind.CREATE_CONNECTION;
 		public static final String RECONNECT_CONNECTION_OPERATION = Operation.Kind.RECONNECT_CONNECTION;
+		public static final String REROUTE_CONNECTION_OPERATION = Operation.Kind.REROUTE_CONNECTION;
 		public static final String CREATE_NODE_OPERATION = Operation.Kind.CREATE_NODE;
 		public static final String DELETE_ELEMENT_OPERATION = Operation.Kind.DELETE_ELEMENT;
 		public static final String CHANGE_BOUNDS_OPERATION = Operation.Kind.CHANGE_BOUNDS;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RerouteConnectionOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RerouteConnectionOperationAction.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.api.action.kind;
+
+import java.util.Arrays;
+
+import org.eclipse.sprotty.Point;
+
+import com.eclipsesource.glsp.api.action.Action;
+
+public class RerouteConnectionOperationAction extends AbstractOperationAction {
+
+	private String connectionElementId;
+	private Point[] routingPoints;
+
+	public RerouteConnectionOperationAction() {
+		super(Action.Kind.REROUTE_CONNECTION_OPERATION);
+	}
+
+	public RerouteConnectionOperationAction(String connectionElementId, Point[] routingPoints) {
+		this();
+		this.connectionElementId = connectionElementId;
+		this.routingPoints = routingPoints;
+	}
+
+	public String getConnectionElementId() {
+		return connectionElementId;
+	}
+
+	public Point[] getRoutingPoints() {
+		return routingPoints;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((connectionElementId == null) ? 0 : connectionElementId.hashCode());
+		result = prime * result + Arrays.hashCode(routingPoints);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		if (!(obj instanceof RerouteConnectionOperationAction)) {
+			return false;
+		}
+		RerouteConnectionOperationAction other = (RerouteConnectionOperationAction) obj;
+		if (connectionElementId == null) {
+			if (other.connectionElementId != null) {
+				return false;
+			}
+		} else if (!connectionElementId.equals(other.connectionElementId)) {
+			return false;
+		}
+		if (!Arrays.equals(routingPoints, other.routingPoints)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/Operation.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/Operation.java
@@ -25,6 +25,7 @@ public class Operation {
 		public static final String CHANGE_CONTAINER = "changeContainer";
 		public static final String GENERIC = "generic";
 		public static final String RECONNECT_CONNECTION = "reconnectConnection";
+		public static final String REROUTE_CONNECTION = "rerouteConnection";
 	}
 
 	private String label;

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
@@ -31,6 +31,7 @@ import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.DeleteElementOperationAction;
 import com.eclipsesource.glsp.api.action.kind.ReconnectConnectionOperationAction;
+import com.eclipsesource.glsp.api.action.kind.RerouteConnectionOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.ModelState;
 import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
@@ -45,7 +46,7 @@ public class OperationActionHandler extends AbstractActionHandler {
 	protected Collection<Action> handleableActionsKinds() {
 		return Arrays.asList(new CreateNodeOperationAction(), new CreateConnectionOperationAction(),
 				new DeleteElementOperationAction(), new ChangeBoundsOperationAction(),
-				new ReconnectConnectionOperationAction());
+				new ReconnectConnectionOperationAction(), new RerouteConnectionOperationAction());
 	}
 
 	@Override
@@ -54,6 +55,7 @@ public class OperationActionHandler extends AbstractActionHandler {
 		case Action.Kind.CREATE_NODE_OPERATION:
 		case Action.Kind.CREATE_CONNECTION_OPERATION:
 		case Action.Kind.RECONNECT_CONNECTION_OPERATION:
+		case Action.Kind.REROUTE_CONNECTION_OPERATION:
 		case Action.Kind.DELETE_ELEMENT_OPERATION:
 		case Action.Kind.CHANGE_BOUNDS_OPERATION:
 			return doHandle((AbstractOperationAction) action, modelState);

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
@@ -37,6 +37,7 @@ import com.eclipsesource.glsp.api.action.kind.ReconnectConnectionOperationAction
 import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
 import com.eclipsesource.glsp.api.action.kind.RequestCommandPaletteActions;
 import com.eclipsesource.glsp.api.action.kind.RequestTypeHints;
+import com.eclipsesource.glsp.api.action.kind.RerouteConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.RequestExportSvgAction;
 import com.eclipsesource.glsp.api.action.kind.RequestLayersAction;
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
@@ -98,6 +99,7 @@ public class DefaultActionProvider implements ActionProvider {
 		defaultActions.add(new RequestCommandPaletteActions());
 		defaultActions.add(new IdentifiableRequestAction());
 		defaultActions.add(new ReconnectConnectionOperationAction());
+		defaultActions.add(new RerouteConnectionOperationAction());
 	}
 
 	@Override


### PR DESCRIPTION
- [server] Implement RerouteConnectionOperationAction and handler
- [client] Include edge edit and edge layout module from sprotty
- [client] Provide routing handles as feedback (SwitchEditModeAction)
- [client] Rename 'EdgeReconnectTool' to 'EdgeEditTool'
- [client] Send RerouteConnectionOperationAction from edge edit tool
- [client] Remove multi-selection restriction on change-bounds-tool