### PR TITLE
Fix #199 Use Typscript Hero to organize imports

### DIFF
--- a/client/.vscode/extensions.json
+++ b/client/.vscode/extensions.json
@@ -4,7 +4,8 @@
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"eg2.tslint",
-		"mflo999.import-splitnsort"
+		"mflo999.import-splitnsort",
+		"rbbit.typescript-hero"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -6,10 +6,10 @@
 {
     "tslint.enable": true,
     "tslint.configFile": "configs/tslint.json",
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": true,
-        "source.fixAll.tslint": true
-    },
+    "tslint.autoFixOnSave": true,
+    "typescriptHero.imports.organizeOnSave": true,
+    "typescriptHero.imports.disableImportsSorting": true,
+    "typescriptHero.imports.stringQuoteStyle": "\"",
     "import-splitnsort.on-save": true,
     "editor.formatOnSave": true,
     "search.exclude": {


### PR DESCRIPTION
The default organize imports action of VS code does not play along with `import split'n'sort`. (see #199)
This change uses the `TypeScript Hero` plugin to organize imports instead. 

Note: Typscript Hero also provides the possibility to sort imports but in my opinion the sorting of `import split'n'sort` is superior. If needed we can rely only on TypeScript Hero as well. The sorting then will look similar to the style used in the JsonForms project.
