### PR TITLE
Configure and document watching (#212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,32 @@ The example workspace should be opend automatically on Theia launch. This worksp
 ## Contributing to the Graphical LSP project
 We'd be thrilled to receive your contribution! Please feel free to open issues, fork this repo, and/or open pull requests. Note that we will ask you to sign a [CLA](https://cla-assistant.io/eclipsesource/graphical-lsp) to ensure all contributions can be distributed under the terms of the following open-source licenses: Apache License 2.0, BSD 2/3 License, MIT License, and Eclipse Public License v2.0.
 
-## Tips & Tricks
-### Typescript MonoRepo Import Fixer
-This repository is a lerna mono repository which means that VS Code might have some troubles to correctly auto-generate import statements. It's recommended to install the "Typescript MonoRepo Import Fixer" extension.
+## Development
 
-	Launch VS Code
-	Open the "Quick Open" Window (ctrl + p)
-	
-Paste the following commmand and press enter
+### Building in VSCode
 
-	ext install q.typescript-mono-repo-import-helper
+The build task *Build all packages* of the VSCode workspace in `client` performs `yarn`. This build task is also marked as the default build task of this workspace. Thus, to perform a full build in VSCode, you can simply click the menu *Terminal --> Run Build Task...*, or press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> (unless you have changed the keybinding for invoking a build in VSCode), or use the command palette task *Tasks: Run Build Task*.
+
+### Watching
+
+To avoid having to perform a full build after each change, you can use the following workflow *in VSCode* to enable watching and automatic rebuilding.
+
+As a prerequisite, perform a full build once (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> or `cd client; yarn`; see above). Now perform the following steps to watch and automatically build on every file change in any package.
+
+1. Start the browser backend: start the launch configuration *Start Browser Backend* by invoking *Debug: Start Debugging*, or by switching to *Debug* perspective and select *Start Browser Backend*, or via the command palette *Tasks: Run Task --> Start Browser Backend for Workflow Example*.
+2. Start watching all packages: run the task *Watch all packages* via the command palette *Tasks: Run Task --> Watch all packages* or via the menu *Terminal --> Run Task... --> Watch all packages*.
+
+Alternatively, you can use the *command line* workflow detailed below.
+
+1. Start the browser backend:
+   
+   ```
+   cd client/examples/workflow/browser-app
+   yarn start:debug
+   ```
+2. In a new terminal, invoke the following command to watch all packages:
+   
+   ```
+   cd client
+   yarn watch
+   ```

--- a/client/.vscode/launch.json
+++ b/client/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "node",
             "request": "launch",
             "name": "Start Browser Backend",
-            "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
+            "program": "${workspaceRoot}/examples/workflow/browser-app/src-gen/backend/main.js",
             "args": [
                 "--loglevel=debug",
                 "--port=3000",
@@ -29,41 +29,12 @@
             "outputCapture": "std"
         },
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Start Electron Backend",
-            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-            "windows": {
-                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
-            },
-            "program": "${workspaceRoot}/electron-app/src-gen/frontend/electron-main.js",
-            "protocol": "inspector",
-            "args": [
-                "--loglevel=debug",
-                "--hostname=localhost",
-                "--no-cluster"
-            ],
-            "env": {
-                "NODE_ENV": "development"
-            },
-            "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/electron-app/src-gen/frontend/electron-main.js",
-                "${workspaceRoot}/electron-app/src-gen/backend/main.js",
-                "${workspaceRoot}/electron-app/lib/**/*.js",
-                "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js"
-            ],
-            "smartStep": true,
-            "internalConsoleOptions": "openOnSessionStart",
-            "outputCapture": "std"
-        },
-        {
             "name": "Launch Browser Frontend",
             "type": "chrome",
             "request": "launch",
             "url": "http://localhost:3000/",
             "sourceMaps": true,
-            "webRoot": "${workspaceRoot}/examples/browser-app"
+            "webRoot": "${workspaceRoot}/examples/workflow/browser-app"
         }
     ]
 }

--- a/client/.vscode/tasks.json
+++ b/client/.vscode/tasks.json
@@ -4,10 +4,13 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Workflow Example: Watch browser-app",
+            "label": "Build all packages",
             "type": "shell",
-            "group": "build",
-            "command": "cd examples/workflow/browser-app && yarn watch",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "command": "yarn",
             "presentation": {
                 "reveal": "always",
                 "panel": "new"
@@ -15,20 +18,20 @@
             "problemMatcher": []
         },
         {
-            "label": "GLSP: Watch all packages",
+            "label": "Start Browser Backend for Workflow Example",
+            "type": "shell",
+            "command": "cd examples/workflow/browser-app && yarn start:debug",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Watch all packages",
             "type": "shell",
             "group": "build",
             "command": "yarn watch",
-            "presentation": {
-                "reveal": "always",
-                "panel": "new"
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Workflow Example: Start in Browser",
-            "type": "shell",
-            "command": "cd examples/workflow/browser-app && yarn start:debug",
             "presentation": {
                 "reveal": "always",
                 "panel": "new"

--- a/client/examples/workflow/browser-app/package.json
+++ b/client/examples/workflow/browser-app/package.json
@@ -22,10 +22,10 @@
     "@theia/cli": "next"
   },
   "scripts": {
-    "prepare": "theia build",    
+    "prepare": "theia build --mode development",
     "start": "theia start --WORKFLOW_LSP=5007 --root-dir=../workspace",
-    "start:debug": "yarn start --log-level=debug",
-  	"watch": "theia build --watch"
+    "start:debug": "theia start --WORKFLOW_LSP=5007 --root-dir=../workspace --loglevel=debug",
+    "watch": "theia build --watch --mode development"
   },
   "theia": {
     "target": "browser"

--- a/client/package.json
+++ b/client/package.json
@@ -14,8 +14,8 @@
     "prepare": "lerna run prepare",
     "rebuild:browser": "theia rebuild:browser",
     "rebuild:electron": "theia rebuild:electron",
+    "watch": "lerna run --parallel watch",
     "publish": "yarn && yarn publish:latest",
-    "watch": "lerna-watch",
     "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git --force-publish",
     "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary=next --npm-tag=next --force-publish --skip-git --yes"
   },


### PR DESCRIPTION
Fixes and streamlines the scripts in the package.jsons, tasks.json,
and launch.json. Also adds the usage of those configurations to
the readme.

Fixes #212
