### PR TITLE
Add support for diagram markers

### DIFF
--- a/client/examples/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/examples/workflow/workflow-sprotty/src/di.config.ts
@@ -53,6 +53,7 @@ import { boundsModule } from "glsp-sprotty/lib";
 import { buttonModule } from "glsp-sprotty/lib";
 import { commandPaletteModule } from "glsp-sprotty/lib";
 import { configureModelElement } from "glsp-sprotty/lib";
+import { decorationModule } from "glsp-sprotty/lib";
 import { defaultGLSPModule } from "glsp-sprotty/lib";
 import { defaultModule } from "glsp-sprotty/lib";
 import { edgeLayoutModule } from "glsp-sprotty/lib";
@@ -70,6 +71,7 @@ import { routingModule } from "glsp-sprotty/lib";
 import { saveModule } from "glsp-sprotty/lib";
 import { selectModule } from "glsp-sprotty/lib";
 import { toolFeedbackModule } from "glsp-sprotty/lib";
+import { validationModule } from "glsp-sprotty/lib";
 import { viewportModule } from "glsp-sprotty/lib";
 
 import executeCommandModule from "glsp-sprotty/lib/features/execute/di.config";
@@ -103,7 +105,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
 export default function createContainer(widgetId: string): Container {
     const container = new Container();
 
-    container.load(defaultModule, defaultGLSPModule, selectModule, boundsModule, viewportModule,
+    container.load(decorationModule, validationModule, defaultModule, defaultGLSPModule, selectModule, boundsModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
         workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule,
         commandPaletteModule, paletteModule, requestResponseModule, routingModule, edgeLayoutModule);

--- a/client/packages/glsp-sprotty/src/features/tool-palette/tool-palette.ts
+++ b/client/packages/glsp-sprotty/src/features/tool-palette/tool-palette.ts
@@ -22,6 +22,7 @@ import { ICommand } from "sprotty/lib";
 import { ILogger } from "sprotty/lib";
 import { MouseDeleteTool } from "../tools/delete-tool";
 import { Operation } from "../operation/set-operations";
+import { RequestMarkersAction } from "../validation/validate";
 import { SelfInitializingActionHandler } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
 import { SetOperationsAction } from "../operation/set-operations";
 import { ShowDiagramUIExtensionAction } from "../../base/diagram-ui-extension/diagram-ui-extension-registry";
@@ -33,6 +34,8 @@ import { inject } from "inversify";
 import { injectable } from "inversify";
 import { isSetOperationsAction } from "../operation/set-operations";
 import { parentGroup } from "../operation/set-operations";
+
+
 
 const CLICKED_CSS_CLASS = "clicked";
 @injectable()
@@ -114,6 +117,14 @@ export class ToolPalette extends BaseDiagramUIExtension {
         const deleteToolButton = createIcon(["fas", "fa-eraser", "fa-xs"]);
         deleteToolButton.onclick = this.onClickToolButton(deleteToolButton, MouseDeleteTool.ID);
         headerTools.appendChild(deleteToolButton);
+
+        // Create button for ValidationTool
+        const validateActionButton = createIcon(["fas", "fa-check-square", "fa-xs"]);
+        validateActionButton.onclick = (ev: MouseEvent) => {
+            const modelIds: string[] = ["sprotty"];
+            this.executeAction(new RequestMarkersAction(modelIds));
+        };
+        headerTools.appendChild(validateActionButton);
 
         headerCompartment.appendChild(headerTools);
         this.containerElement.appendChild(headerCompartment);

--- a/client/packages/glsp-sprotty/src/features/validation/di.config.ts
+++ b/client/packages/glsp-sprotty/src/features/validation/di.config.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from "inversify";
+import { configureCommand } from "sprotty/lib";
+import { SetMarkersCommand } from "./validate";
+
+const validationModule = new ContainerModule((bind, _unbind, isBound) => {
+    configureCommand({ bind, isBound }, SetMarkersCommand);
+});
+
+export default validationModule;

--- a/client/packages/glsp-sprotty/src/features/validation/validate.ts
+++ b/client/packages/glsp-sprotty/src/features/validation/validate.ts
@@ -1,0 +1,154 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Action } from "sprotty/lib";
+import { Command } from "sprotty/lib";
+import { CommandExecutionContext } from "sprotty/lib";
+import { CommandResult } from "sprotty/lib";
+import { Marker } from "../../utils/marker";
+import { MarkerKind } from "../../utils/marker";
+import { SIssue } from "sprotty/lib";
+import { SIssueMarker } from "sprotty/lib";
+import { SModelElement } from "sprotty/lib";
+import { SParentElement } from "sprotty/lib";
+import { TYPES } from "sprotty/lib";
+
+import { inject } from "inversify";
+import { injectable } from "inversify";
+
+/**
+ * Action to retrieve markers for a model
+ */
+export class RequestMarkersAction implements Action {
+
+    static readonly KIND = 'requestMarkers';
+    readonly kind = RequestMarkersAction.KIND;
+
+    constructor(public readonly elementsIDs: string[] = []) { }
+}
+
+/**
+ * Action to set markers for a model
+ */
+export class SetMarkersAction implements Action {
+    readonly kind = SetMarkersCommand.KIND;
+    constructor(public readonly markers: Marker[]) { }
+}
+
+/**
+ * Command for handling SetMarkersActions
+ */
+@injectable()
+export class SetMarkersCommand extends Command {
+
+    static readonly KIND = 'setMarkers';
+
+    markers: Marker[];
+
+    constructor(@inject(TYPES.Action) public action: SetMarkersAction) {
+        super();
+    }
+
+    /**
+     * Creates SIssueMarkers for all received markers and adds them to the respective SModelElements
+     * @param context Context of the command execution
+     */
+    execute(context: CommandExecutionContext): CommandResult {
+        this.markers = this.action.markers;
+        for (let marker of this.markers) {
+            const modelElement: SModelElement | undefined = context.root.index.getById(marker.elementId);
+            if (modelElement instanceof SParentElement) {
+                const issueMarker: SIssueMarker = this.getOrCreateSIssueMarker(modelElement);
+                const issue: SIssue = this.createSIssue(marker);
+                issueMarker.issues.push(issue);
+            }
+        }
+        return context.root;
+    }
+
+    private getOrCreateSIssueMarker(modelElement: SParentElement): SIssueMarker {
+        let issueMarker: SIssueMarker | undefined;
+
+        for (const child of modelElement.children) {
+            if (child instanceof SIssueMarker) {
+                issueMarker = child;
+            }
+        }
+
+        if (issueMarker === undefined) {
+            issueMarker = new SIssueMarker();
+            issueMarker.type = "marker";
+            issueMarker.issues = new Array<SIssue>();
+            modelElement.add(issueMarker);
+        }
+
+        return issueMarker;
+    }
+
+    private createSIssue(marker: Marker): SIssue {
+        const issue: SIssue = new SIssue();
+        issue.message = marker.description;
+
+        switch (marker.kind) {
+            case MarkerKind.ERROR: {
+                issue.severity = 'error';
+                break;
+            }
+            case MarkerKind.INFO: {
+                issue.severity = 'info';
+                break;
+            }
+            case MarkerKind.WARNING: {
+                issue.severity = 'warning';
+                break;
+            }
+        }
+
+        return issue;
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        this.markers = this.action.markers;
+        for (let marker of this.markers) {
+            const modelElement: SModelElement | undefined = context.root.index.getById(marker.elementId);
+            if (modelElement instanceof SParentElement) {
+                for (let child of modelElement.children) {
+                    if (child instanceof SIssueMarker) {
+                        for (let index = 0; index < child.issues.length; ++index) {
+                            const issue = child.issues[index];
+                            if (issue.message === marker.description) {
+                                child.issues.splice(index--, 1);
+                            }
+                        }
+                        if (child.issues.length === 0) {
+                            modelElement.remove(child);
+                        }
+                    }
+                }
+            }
+        }
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        return this.execute(context);
+    }
+
+    getMarkers(): Marker[] {
+        return this.markers;
+    }
+
+}

--- a/client/packages/glsp-sprotty/src/index.ts
+++ b/client/packages/glsp-sprotty/src/index.ts
@@ -41,12 +41,14 @@ export * from './features/tools/change-bounds-tool';
 export * from './features/tools/creation-tool';
 export * from './features/tools/default-tools';
 export * from './features/tools/delete-tool';
+export * from './features/validation/validate';
 export * from './lib/model';
 export * from './types';
 export * from './utils/array-utils';
+export * from './utils/marker';
 export * from './utils/smodel-util';
 export * from './utils/viewpoint-util';
-export { saveModule, executeModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, commandPaletteModule, requestResponseModule };
+export { validationModule, saveModule, executeModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, commandPaletteModule, requestResponseModule };
 
 import commandPaletteModule from './features/command-palette/di.config';
 import defaultGLSPModule from './base/di.config';
@@ -56,4 +58,4 @@ import paletteModule from './features/tool-palette/di.config';
 import requestResponseModule from './features/request-response/di.config';
 import saveModule from './features/save/di.config';
 import toolFeedbackModule from './features/tool-feedback/di.config';
-
+import validationModule from './features/validation/di.config';

--- a/client/packages/glsp-sprotty/src/utils/marker.ts
+++ b/client/packages/glsp-sprotty/src/utils/marker.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export namespace MarkerKind {
+    export const INFO = "info";
+    export const WARNING = "warning";
+    export const ERROR = "error";
+}
+
+export interface Marker {
+
+    readonly label: string;
+
+    readonly description: string;
+
+    readonly elementId: string;
+
+    readonly kind: string;
+}

--- a/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/client/packages/glsp-theia-extension/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -28,6 +28,7 @@ import { OpenAction } from "glsp-sprotty/lib";
 import { OperationKind } from "glsp-sprotty/lib";
 import { RequestBoundsCommand } from "glsp-sprotty/lib";
 import { RequestCommandPaletteActions } from "glsp-sprotty/lib";
+import { RequestMarkersAction } from "glsp-sprotty/lib";
 import { RequestModelAction } from "glsp-sprotty/lib";
 import { RequestOperationsAction } from "glsp-sprotty/lib";
 import { RequestPopupModelAction } from "glsp-sprotty/lib";
@@ -67,6 +68,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements Notify
         registry.register(ExportSvgAction.KIND, this);
         registry.register(RequestCommandPaletteActions.KIND, this);
         registry.register(IdentifiableRequestAction.KIND, this);
+        registry.register(RequestMarkersAction.KIND, this);
 
         // Register an empty handler for SwitchEditMode, to avoid runtime exceptions.
         // We don't want to support SwitchEditMode, but sprotty still sends some corresponding

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowServerRuntimeModule.java
@@ -16,6 +16,7 @@
 package com.eclipsesource.glsp.example.workflow;
 
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
+import com.eclipsesource.glsp.api.markers.ModelValidator;
 import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
 import com.eclipsesource.glsp.api.model.ModelSelectionListener;
@@ -32,6 +33,7 @@ import com.eclipsesource.glsp.example.workflow.handler.DeleteWorkflowElementHand
 import com.eclipsesource.glsp.example.workflow.handler.ReconnectEdgeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.RerouteEdgeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.SimulateCommandHandler;
+import com.eclipsesource.glsp.example.workflow.marker.WorkflowModelValidator;
 import com.eclipsesource.glsp.server.ServerModule;
 import com.eclipsesource.glsp.server.operationhandler.ChangeBoundsOperationHandler;
 import com.eclipsesource.glsp.server.operationhandler.DeleteHandler;
@@ -91,6 +93,11 @@ public class WorkflowServerRuntimeModule extends ServerModule {
 	@Override
 	protected void multiBindServerCommandHandlers() {
 		bindServerCommandHandler().to(SimulateCommandHandler.class);
+	}
+
+	@Override
+	protected Class<? extends ModelValidator> bindModelValidator() {
+		return WorkflowModelValidator.class;
 	}
 
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/marker/WorkflowModelValidator.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/marker/WorkflowModelValidator.java
@@ -1,0 +1,120 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.example.workflow.marker;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.sprotty.SEdge;
+import org.eclipse.sprotty.SModelElement;
+
+import com.eclipsesource.glsp.api.markers.Marker;
+import com.eclipsesource.glsp.api.markers.MarkerKind;
+import com.eclipsesource.glsp.api.markers.ModelValidator;
+import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.example.workflow.schema.ActivityNode;
+import com.eclipsesource.glsp.example.workflow.schema.TaskNode;
+
+public class WorkflowModelValidator implements ModelValidator {
+
+	@Override
+	public List<Marker> validate(ModelState modelState, SModelElement... elements) {
+		List<Marker> markers = new ArrayList<Marker>();
+
+		for (SModelElement element : elements) {
+			if (element instanceof TaskNode) {
+				markers.addAll(validateTaskNode(modelState, element));
+			} else if (element instanceof ActivityNode) {
+				ActivityNode activityNode = (ActivityNode) element;
+				if ("decisionNode".equals(activityNode.getNodeType())) {
+					markers.addAll(validateDecisionNode(modelState, element));
+				} else if ("mergeNode".equals(activityNode.getNodeType())) {
+					markers.addAll(validateMergeNode(modelState, element));
+				}
+			}
+			if (element.getChildren() != null) {
+				markers.addAll(validate(modelState,
+						element.getChildren().toArray(new SModelElement[element.getChildren().size()])));
+			}
+		}
+		return markers;
+	}
+
+	private static List<Marker> validateTaskNode(ModelState modelState, SModelElement taskNode) {
+		List<Marker> markers = new ArrayList<Marker>();
+		validateTaskNode_isAutomated(modelState, taskNode).ifPresent(m -> markers.add(m));
+		validateTaskNode_nameStartsUpperCase(modelState, taskNode).ifPresent(m -> markers.add(m));
+		return markers;
+	}
+
+	private static Optional<Marker> validateTaskNode_isAutomated(ModelState modelState, SModelElement element) {
+		TaskNode taskNode = (TaskNode) element;
+		if ("automated".equals(taskNode.getTaskType())) {
+			return Optional
+					.of(new Marker("Automated task", "This is an automated taks", element.getId(), MarkerKind.INFO));
+		}
+		return Optional.empty();
+	}
+
+	private static Optional<Marker> validateTaskNode_nameStartsUpperCase(ModelState modelState, SModelElement element) {
+		TaskNode taskNode = (TaskNode) element;
+		if (!Character.isUpperCase(taskNode.getName().charAt(0))) {
+			return Optional.of(new Marker("Task node name in upper case",
+					"Task node names should start with upper case letters", element.getId(), MarkerKind.WARNING));
+		}
+		return Optional.empty();
+	}
+
+	private static List<Marker> validateDecisionNode(ModelState modelState, SModelElement decisionNode) {
+		List<Marker> markers = new ArrayList<Marker>();
+		validateDecisionNode_hasOneIncomingEdge(modelState, decisionNode).ifPresent(m -> markers.add(m));
+		return markers;
+	}
+
+	private static Optional<Marker> validateDecisionNode_hasOneIncomingEdge(ModelState modelState,
+			SModelElement decisionNode) {
+		Collection<SEdge> incomingEdges = modelState.getCurrentModelIndex().getIncomingEdges(decisionNode);
+		if (incomingEdges.size() > 1) {
+			return Optional.of(new Marker("Too many incoming edges", "Decision node may only have one incoming edge.",
+					decisionNode.getId(), MarkerKind.ERROR));
+		} else if (incomingEdges.size() == 0) {
+			return Optional.of(new Marker("Missing incoming edge", "Decision node must have one incoming edge.",
+					decisionNode.getId(), MarkerKind.ERROR));
+		}
+		return Optional.empty();
+	}
+
+	private static List<Marker> validateMergeNode(ModelState modelState, SModelElement mergeNode) {
+		List<Marker> markers = new ArrayList<Marker>();
+		validateMergeNode_hasOneOutgoingEdge(modelState, mergeNode).ifPresent(m -> markers.add(m));
+		return markers;
+	}
+
+	private static Optional<Marker> validateMergeNode_hasOneOutgoingEdge(ModelState modelState,
+			SModelElement mergeNode) {
+		Collection<SEdge> outgoingEdges = modelState.getCurrentModelIndex().getOutgoingEdges(mergeNode);
+		if (outgoingEdges.size() > 1) {
+			return Optional.of(new Marker("Too many outgoing edges", "Merge node may only have one outgoing edge.",
+					mergeNode.getId(), MarkerKind.ERROR));
+		} else if (outgoingEdges.size() == 0) {
+			return Optional.of(new Marker("Missing outgoing edge", "Merge node must have one incoming edge.",
+					mergeNode.getId(), MarkerKind.ERROR));
+		}
+		return Optional.empty();
+	}
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
@@ -105,6 +105,8 @@ public abstract class Action {
 		public static final String SET_COMMAND_PALETTE_ACTIONS = "setCommandPaletteActions";
 		public static final String IDENTIFIABLE_REQUEST_ACTION = "identifiableRequestAction";
 		public static final String IDENTIFIABLE_RESPONSE_ACTION = "identifiableResponseAction";
+		public static final String REQUEST_MARKERS = "requestMarkers";
+		public static final String SET_MARKERS = "setMarkers";
 	}
 
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestMarkersAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestMarkersAction.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.api.action.kind;
+
+import java.util.Arrays;
+
+import com.eclipsesource.glsp.api.action.Action;
+
+public class RequestMarkersAction extends Action {
+
+	private String[] elementsIDs;
+
+	public RequestMarkersAction() {
+		super(Action.Kind.REQUEST_MARKERS);
+	}
+
+	public RequestMarkersAction(String[] elementsIDs) {
+		this();
+		this.elementsIDs = elementsIDs;
+	}
+
+	public String[] getElementsIDs() {
+		return elementsIDs;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Arrays.hashCode(elementsIDs);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RequestMarkersAction other = (RequestMarkersAction) obj;
+		if (!Arrays.equals(elementsIDs, other.elementsIDs))
+			return false;
+		return true;
+	}
+
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetMarkersAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetMarkersAction.java
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.api.action.kind;
+
+import java.util.Arrays;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.markers.Marker;
+
+public class SetMarkersAction extends Action {
+
+	private Marker[] markers;
+
+	public SetMarkersAction() {
+		super(Action.Kind.SET_MARKERS);
+	}
+
+	public SetMarkersAction(Marker[] markers) {
+		this();
+		this.markers = markers;
+	}
+
+	public Marker[] getMarkers() {
+		return markers;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Arrays.hashCode(markers);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SetMarkersAction other = (SetMarkersAction) obj;
+		if (!Arrays.equals(markers, other.markers))
+			return false;
+		return true;
+	}
+
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -23,6 +23,7 @@ import com.eclipsesource.glsp.api.handler.ActionHandler;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.handler.ServerCommandHandler;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
+import com.eclipsesource.glsp.api.markers.ModelValidator;
 import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
 import com.eclipsesource.glsp.api.model.ModelSelectionListener;
@@ -58,6 +59,7 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(ServerCommandHandlerProvider.class).to(bindServerCommandHandlerProvider());
 		bind(ModelTypeConfigurationProvider.class).to(bindModelTypesConfigurationProvider());
 		bind(CommandPaletteActionProvider.class).to(bindCommandPaletteActionProvider());
+		bind(ModelValidator.class).to(bindModelValidator());
 		configureMultibindings();
 	}
 
@@ -138,5 +140,9 @@ public abstract class GLSPModule extends AbstractModule {
 
 	protected Class<? extends ServerCommandHandlerProvider> bindServerCommandHandlerProvider() {
 		return ServerCommandHandlerProvider.NullImpl.class;
+	}
+	
+	protected Class<? extends ModelValidator> bindModelValidator() {
+		return ModelValidator.NullImpl.class;
 	}
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/markers/Marker.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/markers/Marker.java
@@ -1,0 +1,89 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.api.markers;
+
+public class Marker {
+
+	private String label;
+	private String description;
+	private String elementId;
+	private String kind;
+
+	public Marker(String label, String description, String elementId, String kind) {
+		super();
+		this.label = label;
+		this.description = description;
+		this.elementId = elementId;
+		this.kind = kind;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public String getElementId() {
+		return elementId;
+	}
+
+	public String getType() {
+		return kind;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((description == null) ? 0 : description.hashCode());
+		result = prime * result + ((elementId == null) ? 0 : elementId.hashCode());
+		result = prime * result + ((label == null) ? 0 : label.hashCode());
+		result = prime * result + ((kind == null) ? 0 : kind.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Marker other = (Marker) obj;
+		if (description == null) {
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (elementId == null) {
+			if (other.elementId != null)
+				return false;
+		} else if (!elementId.equals(other.elementId))
+			return false;
+		if (label == null) {
+			if (other.label != null)
+				return false;
+		} else if (!label.equals(other.label))
+			return false;
+		if (kind != other.kind)
+			return false;
+		return true;
+	}
+
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/markers/MarkerKind.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/markers/MarkerKind.java
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.api.markers;
+
+/**
+ * Defines kinds of model markers
+ *
+ */
+public class MarkerKind {
+
+	/**
+	 * Declares markers providing some information about a model element
+	 */
+	public static final String INFO = "info";
+	/**
+	 * Declares markers providing warnings about a model element
+	 */
+	public static final String WARNING = "warning";
+	/**
+	 * Declares markers providing error information about a model element
+	 */
+	public static final String ERROR = "error";
+
+	private MarkerKind() {
+		// prevent instantiation for class only holding constants.
+	}
+
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/markers/ModelValidator.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/markers/ModelValidator.java
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.api.markers;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.sprotty.SModelElement;
+
+import com.eclipsesource.glsp.api.model.ModelState;
+
+public interface ModelValidator {
+
+	public List<Marker> validate(ModelState modelState, SModelElement... elements);
+
+	final static class NullImpl implements ModelValidator {
+
+		@Override
+		public List<Marker> validate(ModelState modelState, SModelElement... elements) {
+			return Collections.emptyList();
+		}
+	}
+}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/SModelIndex.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/utils/SModelIndex.java
@@ -171,12 +171,12 @@ public class SModelIndex {
 		return typeToElements.computeIfAbsent(type, t -> new HashSet<>()).size();
 	}
 
-	public Collection<SEdge> getIncomingEdges(SModelElement nodeToDelete) {
-		return incomingEdges.computeIfAbsent(nodeToDelete, n -> new HashSet<>());
+	public Collection<SEdge> getIncomingEdges(SModelElement node) {
+		return incomingEdges.computeIfAbsent(node, n -> new HashSet<>());
 	}
 
-	public Collection<SEdge> getOutgoingEdges(SModelElement nodeToDelete) {
-		return outgoingEdges.computeIfAbsent(nodeToDelete, n -> new HashSet<>());
+	public Collection<SEdge> getOutgoingEdges(SModelElement node) {
+		return outgoingEdges.computeIfAbsent(node, n -> new HashSet<>());
 	}
 
 	public void removeFromIndex(SModelElement element) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerModule.java
@@ -29,6 +29,7 @@ import com.eclipsesource.glsp.server.actionhandler.OpenActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.OperationActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestCommandPaletteActionsHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestElementTypeHintsActionHandler;
+import com.eclipsesource.glsp.server.actionhandler.RequestMarkersHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestModelActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestOperationsHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestPopupModelActionHandler;
@@ -94,6 +95,7 @@ public abstract class ServerModule extends GLSPModule {
 		bindActionHandler().to(ExecuteServerCommandActionHandler.class);
 		bindActionHandler().to(RequestElementTypeHintsActionHandler.class);
 		bindActionHandler().to(RequestCommandPaletteActionsHandler.class);
+		bindActionHandler().to(RequestMarkersHandler.class);
 	}
 
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestMarkersHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestMarkersHandler.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018 EclipseSource Services GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *   
+ * Contributors:
+ * 	Tanja Mayerhofer - initial API and implementation
+ ******************************************************************************/
+package com.eclipsesource.glsp.server.actionhandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.sprotty.SModelElement;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.RequestMarkersAction;
+import com.eclipsesource.glsp.api.action.kind.SetMarkersAction;
+import com.eclipsesource.glsp.api.handler.ActionHandler;
+import com.eclipsesource.glsp.api.markers.Marker;
+import com.eclipsesource.glsp.api.markers.ModelValidator;
+import com.eclipsesource.glsp.api.model.ModelState;
+import com.eclipsesource.glsp.api.utils.SModelIndex;
+import com.google.inject.Inject;
+
+public class RequestMarkersHandler implements ActionHandler {
+
+	@Inject
+	private ModelValidator validator;
+
+	@Override
+	public boolean handles(Action action) {
+		return action instanceof RequestMarkersAction;
+	}
+
+	@Override
+	public Optional<Action> execute(Action action, ModelState modelState) {
+		RequestMarkersAction execAction = (RequestMarkersAction) action;
+		String[] elementsIDs = execAction.getElementsIDs();
+		if (elementsIDs == null || elementsIDs.length == 0) { // if no element ID is provided, compute the markers for
+																// the complete model
+			elementsIDs = new String[] { modelState.getCurrentModel().getId() };
+		}
+		List<Marker> markers = new ArrayList<Marker>();
+		SModelIndex currentModelIndex = modelState.getCurrentModelIndex();
+		for (String elementID : elementsIDs) {
+			SModelElement modelElement = currentModelIndex.get(elementID);
+			markers.addAll(validator.validate(modelState, modelElement));
+		}
+
+		// TODO get element ID of root element on client side and send it (see
+		// glsp-palette-contribution.ts)
+		// TODO wrap into setmarkersaction and return that action
+		SetMarkersAction setMarkersAction = new SetMarkersAction(markers.toArray(new Marker[markers.size()]));
+		return Optional.of(setMarkersAction);
+	}
+
+}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
@@ -38,6 +38,7 @@ import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
 import com.eclipsesource.glsp.api.action.kind.RequestCommandPaletteActions;
 import com.eclipsesource.glsp.api.action.kind.RequestExportSvgAction;
 import com.eclipsesource.glsp.api.action.kind.RequestLayersAction;
+import com.eclipsesource.glsp.api.action.kind.RequestMarkersAction;
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
 import com.eclipsesource.glsp.api.action.kind.RequestOperationsAction;
 import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
@@ -84,6 +85,7 @@ public class DefaultActionProvider implements ActionProvider {
 		defaultActions.add(new RequestModelAction());
 		defaultActions.add(new RequestOperationsAction());
 		defaultActions.add(new RequestPopupModelAction());
+		defaultActions.add(new RequestMarkersAction());
 		defaultActions.add(new SaveModelAction());
 		defaultActions.add(new SelectAction());
 		defaultActions.add(new SelectAllAction());


### PR DESCRIPTION
From #216 :
Closes #30

This is an initial contribution for offering model validation support that shows validation info/warning/error messages as diagram decorators. I opened issues #213 and #214 for further improving this initial model validation support. I am happy to work on these issues if you think the suggested improvements make sense.