### PR TITLE
Provide a stoppable implementation of ServerLauncher

### DIFF
--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerLauncher.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/ServerLauncher.java
@@ -19,12 +19,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.Channels;
+import java.nio.channels.CompletionHandler;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -45,6 +49,10 @@ public class ServerLauncher {
 	private int port;
 	private DefaultGLSPModule module;
 
+	private ExecutorService threadPool;
+	private AsynchronousServerSocketChannel serverSocket;
+	private CompletableFuture<Void> onShutdown;
+
 	public ServerLauncher(String host, int port, DefaultGLSPModule module) {
 		this.module = module;
 		this.host = host;
@@ -52,29 +60,63 @@ public class ServerLauncher {
 	}
 
 	public void run() throws IOException, InterruptedException, ExecutionException {
+		Future<Void> onClose = asyncRun();
+		onClose.get();
+		log.info("Stopped language server");
+	}
+
+	public Future<Void> asyncRun() throws IOException, InterruptedException, ExecutionException {
+		onShutdown = new CompletableFuture<Void>();
+
+		serverSocket = AsynchronousServerSocketChannel.open().bind(new InetSocketAddress(host, port));
+		threadPool = Executors.newCachedThreadPool();
+
+		CompletionHandler<AsynchronousSocketChannel, Void> handler = new CompletionHandler<AsynchronousSocketChannel, Void>() {
+			public void completed(AsynchronousSocketChannel result, Void attachment) {
+				serverSocket.accept(null, this); // Prepare for the next connection
+				ServerLauncher.this.createClientConnection(result);
+			}
+
+			public void failed(Throwable exc, Void attachment) {
+				log.error("Client Connection Failed: " + exc.getMessage(), exc);
+			}
+		};
+
+		serverSocket.accept(null, handler);
+		log.info("The graphical server launcher is ready to accept new client requests");
+
+		return onShutdown;
+	}
+
+	private void createClientConnection(AsynchronousSocketChannel socketChannel) {
 		Injector injector = Guice.createInjector(module);
 		GsonConfigurator gsonConf = injector.getInstance(GsonConfigurator.class);
-		AsynchronousServerSocketChannel serverSocket = AsynchronousServerSocketChannel.open()
-				.bind(new InetSocketAddress(host, port));
-		ExecutorService threadPool = Executors.newCachedThreadPool();
-		log.info("The graphical server launcher is ready to accept new client requests");
-		while (true) {
-			AsynchronousSocketChannel socketChannel = serverSocket.accept().get();
-			InputStream in = Channels.newInputStream(socketChannel);
-			OutputStream out = Channels.newOutputStream(socketChannel);
 
-			Consumer<GsonBuilder> configureGson = (GsonBuilder builder) -> gsonConf.configureGsonBuilder(builder);
-			Function<MessageConsumer, MessageConsumer> wrapper = (MessageConsumer it) -> {
-				return it;
-			};
-			GLSPServer languageServer = injector.getInstance(GLSPServer.class);
-			Launcher<GLSPClient> launcher = Launcher.createIoLauncher(languageServer, GLSPClient.class, in, out,
-					threadPool, wrapper, configureGson);
+		InputStream in = Channels.newInputStream(socketChannel);
+		OutputStream out = Channels.newOutputStream(socketChannel);
 
-			languageServer.connect(launcher.getRemoteProxy());
-			launcher.startListening();
-			log.info("Started language server for client " + socketChannel.getRemoteAddress());
+		Consumer<GsonBuilder> configureGson = (GsonBuilder builder) -> gsonConf.configureGsonBuilder(builder);
+		Function<MessageConsumer, MessageConsumer> wrapper = Function.identity();
+		GLSPServer languageServer = injector.getInstance(GLSPServer.class);
+
+		Launcher<GLSPClient> launcher = Launcher.createIoLauncher(languageServer, GLSPClient.class, in, out, threadPool,
+				wrapper, configureGson);
+		languageServer.connect(launcher.getRemoteProxy());
+		launcher.startListening();
+
+		try {
+			SocketAddress remoteAddress = socketChannel.getRemoteAddress();
+			log.info("Started language server for client " + remoteAddress);
+		} catch (IOException ex) {
+			log.error("Failed to get the remoteAddress for the new client connection: " + ex.getMessage(), ex);
 		}
+	}
 
+	public void stop() throws IOException {
+		log.info("Stopping all connections to the language server...");
+		serverSocket.close();
+		threadPool.shutdown();
+		onShutdown.complete(null);
+		log.info("Stopped language server");
 	}
 }


### PR DESCRIPTION
- Add an asyncRun() and stop() method to ServerLauncher
- Change the implementation to avoid the infinite loop

fixes #238

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>