### PR TITLE
Fix wrong Inject imports

### DIFF
--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGLSPServer.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/DefaultGLSPServer.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import javax.inject.Inject;
-
 import org.apache.log4j.Logger;
 import org.eclipse.sprotty.ServerStatus;
 import org.eclipse.sprotty.ServerStatus.Severity;
@@ -39,6 +37,7 @@ import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
 import com.eclipsesource.glsp.api.model.ModelStateProvider;
 import com.eclipsesource.glsp.api.utils.ClientOptions;
 import com.eclipsesource.glsp.api.utils.ClientOptions.ParsedClientOptions;
+import com.google.inject.Inject;
 
 public class DefaultGLSPServer implements GLSPServer {
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
@@ -17,12 +17,11 @@ package com.eclipsesource.glsp.server.actionhandler;
 
 import java.util.Optional;
 
-import javax.inject.Inject;
-
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.OpenAction;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
+import com.google.inject.Inject;
 
 public class OpenActionHandler extends AbstractActionHandler {
 	@Inject

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
@@ -17,8 +17,6 @@ package com.eclipsesource.glsp.server.actionhandler;
 
 import java.util.Optional;
 
-import javax.inject.Inject;
-
 import org.eclipse.sprotty.SModelRoot;
 
 import com.eclipsesource.glsp.api.action.Action;
@@ -26,6 +24,7 @@ import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
+import com.google.inject.Inject;
 
 public class OperationActionHandler extends AbstractActionHandler {
 	@Inject


### PR DESCRIPTION
Some Java classes were importing the wrong `@Inject` annotation which could cause issues when consuming the GLSP packages via maven central.