### PR TITLE
Improve CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 matrix:
   include:
     - language: java
@@ -8,7 +7,7 @@ matrix:
       cache:
         directories:
           - "$HOME/.m2/repository"
-      install: true
+      install: false
       script:
         - mvn clean verify
       branches:
@@ -23,6 +22,13 @@ matrix:
         script: bash ../scripts/deployMaven.sh
         on:
           branch: master
+      after_deploy:
+        - cd  ../scripts
+        - ./deployP2.sh
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
 
     - language: node_js
       node_js:
@@ -45,4 +51,3 @@ matrix:
         on:
           branch: master
         skip_cleanup: true
-

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8671,7 +8671,7 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-stream-to-observable@^0.2.0:
+stream-to-observable@^0.3.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
   integrity sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=

--- a/scripts/deployMaven.sh
+++ b/scripts/deployMaven.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-
-if 	git diff --name-only HEAD^| grep -q "^server" 
-
-then 
-	echo "Deploy maven snapshot plugins"
-	cd ../server
-	mvn deploy --settings ./settings.xml -Dmaven.test.skip=true -U -Prelease
-else	echo "No maven pacakges have been changed. Skip deployment"
+if 	git diff --name-only HEAD^| grep -q "^server"
+then
+    echo "Deploy maven snapshot plugins"
+    cd ../server
+    mvn deploy --settings ./settings.xml -Dmaven.test.skip=true -U -Prelease
+else
+    echo "No maven packages have been changed. Skip deployment"
 fi
-

--- a/scripts/deployNPM.sh
+++ b/scripts/deployNPM.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-
-if 	git diff --name-only HEAD^| grep -q "^client" 
-
-then 
-	echo "Deploy next-packages to npm"
-	cd ../client
-	yarn run publish:next
-else	echo "No NPM packages have been changed. Skip deployment"
+if 	git diff --name-only HEAD^| grep -q "^client" | grep -v "^client/yarn.lock"
+then
+    echo "Deploy next-packages to npm"
+    cd ../client
+    yarn run publish:next
+else
+    echo "No NPM packages have been changed. Skip deployment"
 fi
-

--- a/scripts/deployP2.sh
+++ b/scripts/deployP2.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if 	git diff --name-only HEAD^| grep -q "^server"
+then
+    # Setup configuration variables
+    ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+    REPO_DIR=$ROOT_DIR/.repo
+    
+    rm -rf $REPO_DIR
+    mkdir $REPO_DIR
+    # Clone glsp-p2 and switch to new skeleton branch
+    cd $REPO_DIR || exit
+    git clone  https://${GLSP_P2_USER}:${GLSP_P2_CI_ACCESS}@github.com/eclipsesource/glsp-p2.git
+    cd glsp-p2 || exit
+    
+    git checkout plugin_skeleton
+    git checkout -b new_deploy
+    
+    # (Re)generate plugis
+    cd scripts || exit
+    . ./functions.sh
+    . ./generate.sh
+    
+    GLSP_SNAPSHOT_VERSION=$(resolve_version com.eclipsesource.glsp glsp-parent 1.2.0-SNAPSHOT)
+    
+    cd ${REPO_DIR}/glsp-p2 || exit
+    
+    # Build and deploy composite repository
+    mvn clean install -Pdeploy-composite
+    
+    # Push changes to glsp-p2 repository
+    
+    git add plugins/
+    git commit -m "Update to version $GLSP_SNAPSHOT_VERSION"
+    git tag -a "v$GLSP_SNAPSHOT_VERSION" -m "$GLSP_SNAPSHOT_VERSION"
+    git push -f origin new_deploy:master
+    git push origin "v$GLSP_SNAPSHOT_VERSION"
+else
+    echo
+fi

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -74,6 +74,10 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
 	<build>
 		<resources>
 			<resource>
@@ -87,6 +91,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>


### PR DESCRIPTION
- Clean-up of maven build #41
- Fix selective deployment #241
- Add `deployP2.sh` script and integrate in Travis build.

The `deployP2.sh` script is triggered after each successful maven deployment. The script
 - regenerates the glsp-p2 repository
-  builds and uploads the repository  to bintray
- commits and tags the changes and pushes to https://github.com/eclipsesource/glsp-p2

(The  deployed repository will be available here https://dl.bintray.com/eclipsesource/glsp/nightly)