### PR TITLE
Fixes #266: Introduce layout commands for sizing and aligning elements

### DIFF
--- a/client/examples/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/examples/workflow/workflow-sprotty/src/di.config.ts
@@ -15,61 +15,68 @@
  ********************************************************************************/
 import "../css/diagram.css";
 
-import {
-    boundsModule,
-    buttonModule,
-    commandPaletteModule,
-    configureModelElement,
-    ConsoleLogger,
-    decorationModule,
-    defaultGLSPModule,
-    defaultModule,
-    DiamondNodeView,
-    edgeLayoutModule,
-    ExpandButtonView,
-    expandModule,
-    exportModule,
-    fadeModule,
-    glspCommandPaletteModule,
-    GLSPGraph,
-    glspMouseToolModule,
-    glspSelectModule,
-    hoverModule,
-    HtmlRoot,
-    HtmlRootView,
-    LogLevel,
-    modelHintsModule,
-    modelSourceModule,
-    openModule,
-    overrideGLSPViewerOptions,
-    paletteModule,
-    PreRenderedElement,
-    PreRenderedView,
-    RectangularNode,
-    RectangularNodeView,
-    requestResponseModule,
-    routingModule,
-    saveModule,
-    SButton,
-    SCompartment,
-    SCompartmentView,
-    SEdge,
-    SGraphView,
-    SLabel,
-    SLabelView,
-    SRoutingHandle,
-    SRoutingHandleView,
-    toolFeedbackModule,
-    TYPES,
-    validationModule,
-    viewportModule
-} from "@glsp/sprotty-client/lib";
-import executeCommandModule from "@glsp/sprotty-client/lib/features/execute/di.config";
-import { Container, ContainerModule } from "inversify";
-
-import { ActivityNode, Icon, TaskNode, WeightedEdge } from "./model";
+import { ActivityNode } from "./model";
+import { ConsoleLogger } from "@glsp/sprotty-client/lib";
+import { Container } from "inversify";
+import { ContainerModule } from "inversify";
+import { DiamondNodeView } from "@glsp/sprotty-client/lib";
+import { ExpandButtonView } from "@glsp/sprotty-client/lib";
+import { GLSPGraph } from "@glsp/sprotty-client/lib";
+import { HtmlRoot } from "@glsp/sprotty-client/lib";
+import { HtmlRootView } from "@glsp/sprotty-client/lib";
+import { Icon } from "./model";
+import { IconView } from "./workflow-views";
+import { LogLevel } from "@glsp/sprotty-client/lib";
+import { PreRenderedElement } from "@glsp/sprotty-client/lib";
+import { PreRenderedView } from "@glsp/sprotty-client/lib";
+import { RectangularNode } from "@glsp/sprotty-client/lib";
+import { RectangularNodeView } from "@glsp/sprotty-client/lib";
+import { SButton } from "@glsp/sprotty-client/lib";
+import { SCompartment } from "@glsp/sprotty-client/lib";
+import { SCompartmentView } from "@glsp/sprotty-client/lib";
+import { SEdge } from "@glsp/sprotty-client/lib";
+import { SGraphView } from "@glsp/sprotty-client/lib";
+import { SLabel } from "@glsp/sprotty-client/lib";
+import { SLabelView } from "@glsp/sprotty-client/lib";
+import { SRoutingHandle } from "@glsp/sprotty-client/lib";
+import { SRoutingHandleView } from "@glsp/sprotty-client/lib";
+import { TaskNode } from "./model";
+import { TaskNodeView } from "./workflow-views";
+import { TYPES } from "@glsp/sprotty-client/lib";
+import { WeightedEdge } from "./model";
+import { WeightedEdgeView } from "./workflow-views";
+import { WorkflowEdgeView } from "./workflow-views";
 import { WorkflowModelFactory } from "./model-factory";
-import { IconView, TaskNodeView, WeightedEdgeView, WorkflowEdgeView } from "./workflow-views";
+
+import { boundsModule } from "@glsp/sprotty-client/lib";
+import { buttonModule } from "@glsp/sprotty-client/lib";
+import { commandPaletteModule } from "@glsp/sprotty-client/lib";
+import { configureModelElement } from "@glsp/sprotty-client/lib";
+import { decorationModule } from "@glsp/sprotty-client/lib";
+import { defaultGLSPModule } from "@glsp/sprotty-client/lib";
+import { defaultModule } from "@glsp/sprotty-client/lib";
+import { edgeLayoutModule } from "@glsp/sprotty-client/lib";
+import { expandModule } from "@glsp/sprotty-client/lib";
+import { exportModule } from "@glsp/sprotty-client/lib";
+import { fadeModule } from "@glsp/sprotty-client/lib";
+import { glspCommandPaletteModule } from "@glsp/sprotty-client/lib";
+import { glspMouseToolModule } from "@glsp/sprotty-client/lib";
+import { glspSelectModule } from "@glsp/sprotty-client/lib";
+import { hoverModule } from "@glsp/sprotty-client/lib";
+import { layoutCommandsModule } from "@glsp/sprotty-client/lib";
+import { modelHintsModule } from "@glsp/sprotty-client/lib";
+import { modelSourceModule } from "@glsp/sprotty-client/lib";
+import { openModule } from "@glsp/sprotty-client/lib";
+import { overrideGLSPViewerOptions } from "@glsp/sprotty-client/lib";
+import { paletteModule } from "@glsp/sprotty-client/lib";
+import { requestResponseModule } from "@glsp/sprotty-client/lib";
+import { routingModule } from "@glsp/sprotty-client/lib";
+import { saveModule } from "@glsp/sprotty-client/lib";
+import { toolFeedbackModule } from "@glsp/sprotty-client/lib";
+import { validationModule } from "@glsp/sprotty-client/lib";
+import { viewportModule } from "@glsp/sprotty-client/lib";
+
+import executeCommandModule from "@glsp/sprotty-client/lib/features/execute/di.config";
 
 
 const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -104,7 +111,8 @@ export default function createContainer(widgetId: string): Container {
     container.load(decorationModule, validationModule, defaultModule, glspMouseToolModule, defaultGLSPModule, glspSelectModule, boundsModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
         workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule,
-        commandPaletteModule, glspCommandPaletteModule, paletteModule, requestResponseModule, routingModule, edgeLayoutModule);
+        commandPaletteModule, glspCommandPaletteModule, paletteModule, requestResponseModule, routingModule, edgeLayoutModule,
+        layoutCommandsModule);
 
     overrideGLSPViewerOptions(container, {
         needsClientLayout: true,

--- a/client/packages/sprotty-client/src/features/layout/di.config.ts
+++ b/client/packages/sprotty-client/src/features/layout/di.config.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from "inversify";
+import { configureCommand, TYPES } from "sprotty/lib";
+
+import { AlignElementsCommand, LayoutKeyboardListener, ResizeElementsCommand } from "./layout-commands";
+
+const layoutCommandsModule = new ContainerModule((bind, _unbind, isBound) => {
+    configureCommand({ bind, isBound }, ResizeElementsCommand);
+    configureCommand({ bind, isBound }, AlignElementsCommand);
+    bind(TYPES.KeyListener).to(LayoutKeyboardListener);
+});
+
+export default layoutCommandsModule;

--- a/client/packages/sprotty-client/src/features/layout/layout-commands.ts
+++ b/client/packages/sprotty-client/src/features/layout/layout-commands.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject } from "inversify";
+import { inject, injectable } from "inversify";
 import {
     Action,
     Bounds,
@@ -127,6 +127,7 @@ export class AlignElementsAction implements Action {
     }
 }
 
+@injectable()
 abstract class LayoutElementsCommand extends Command {
     constructor(@inject(TYPES.Action) protected action: ResizeElementsAction | AlignElementsAction,
         @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher,
@@ -160,6 +161,7 @@ abstract class LayoutElementsCommand extends Command {
     }
 }
 
+@injectable()
 export class ResizeElementsCommand extends LayoutElementsCommand {
     static readonly KIND = 'layout:resize';
 
@@ -252,6 +254,7 @@ export class ResizeElementsCommand extends LayoutElementsCommand {
     }
 }
 
+@injectable()
 export class AlignElementsCommand extends LayoutElementsCommand {
     static readonly KIND = 'layout:align';
 

--- a/client/packages/sprotty-client/src/features/layout/layout-commands.ts
+++ b/client/packages/sprotty-client/src/features/layout/layout-commands.ts
@@ -1,0 +1,416 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject } from "inversify";
+import {
+    Action,
+    Bounds,
+    Command,
+    CommandExecutionContext,
+    CommandResult,
+    ElementAndBounds,
+    ElementMove,
+    IActionDispatcher,
+    KeyListener,
+    MoveAction,
+    Point,
+    SetBoundsAction,
+    SModelElement,
+    TYPES
+} from "sprotty";
+import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
+
+import { GLSP_TYPES } from "../../types";
+import { isNonRoutableSelectedBoundsAware, SelectableBoundsAware } from "../../utils/smodel-util";
+import { ChangeBoundsOperationAction } from "../operation/operation-actions";
+import { SelectionService } from "../select/selection-service";
+
+export enum ResizeDimension {
+    Width,
+    Height,
+    Width_And_Height
+}
+
+export namespace Reduce {
+    export function min(...values: number[]): number {
+        return Math.min(...values);
+    }
+
+    export function max(...values: number[]): number {
+        return Math.max(...values);
+    }
+
+    export function avg(...values: number[]): number {
+        return values.reduce((a, b) => a + b, 0) / values.length;
+    }
+
+    export function first(...values: number[]): number {
+        return values[0];
+    }
+
+    export function last(...values: number[]): number {
+        return values[values.length - 1];
+    }
+}
+
+export class ResizeElementsAction implements Action {
+    readonly kind = ResizeElementsCommand.KIND;
+
+    constructor(
+        /**
+         * IDs of the elements that should be resized. If no IDs are given, the selected elements will be resized.
+         */
+        public readonly elementIds: string[] = [],
+        /**
+         * Resize dimension.
+         */
+        public readonly dimension: ResizeDimension = ResizeDimension.Width,
+        /**
+         * Function to reduce the dimension to a target dimension value, see Reduce.* for potential functions.
+         */
+        public readonly reductionFunction: (...values: number[]) => number) {
+    }
+}
+
+export enum Alignment {
+    Left,
+    Center,
+    Right,
+    Top,
+    Middle,
+    Bottom
+}
+
+export namespace Select {
+    export function all(elements: SelectableBoundsAware[]) {
+        return elements;
+    }
+
+    export function first(elements: SelectableBoundsAware[]) {
+        return [elements[0]];
+    }
+
+    export function last(elements: SelectableBoundsAware[]) {
+        return [elements[elements.length - 1]];
+    }
+}
+
+
+export class AlignElementsAction implements Action {
+    readonly kind = AlignElementsCommand.KIND;
+
+    constructor(
+        /**
+         * IDs of the elements that should be aligned. If no IDs are given, the selected elements will be aligned.
+         */
+        public readonly elementIds: string[] = [],
+        /**
+         * Alignment direction.
+         */
+        public readonly alignment: Alignment = Alignment.Left,
+        /**
+         * Function to selected elements that are considered during alignment calculation, see Select.* for potential functions.
+         */
+        public readonly selectionFunction: (elements: SelectableBoundsAware[]) => SelectableBoundsAware[] = Select.all) {
+    }
+}
+
+abstract class LayoutElementsCommand extends Command {
+    constructor(@inject(TYPES.Action) protected action: ResizeElementsAction | AlignElementsAction,
+        @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher,
+        @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService) {
+        super();
+    }
+
+    getActionElements(context: CommandExecutionContext): SelectableBoundsAware[] {
+        const model = context.root;
+        const elementIDs = this.action.elementIds;
+        if (elementIDs.length === 0) {
+            // collect the selected elements from the selection service (selection order is kept by service)
+            this.selectionService.getSelectedElementIDs().forEach(elementID => elementIDs.push(elementID));
+        }
+        const selectableBoundsAware: SelectableBoundsAware[] = [];
+        elementIDs.forEach(id => {
+            const element = model.index.getById(id);
+            if (element && isNonRoutableSelectedBoundsAware(element)) {
+                selectableBoundsAware.push(element);
+            }
+        });
+        return selectableBoundsAware;
+    }
+
+    dispatchAction(action: Action) {
+        this.actionDispatcher.dispatch(action);
+    }
+
+    dispatchActions(actions: Action[]) {
+        this.actionDispatcher.dispatchAll(actions);
+    }
+}
+
+export class ResizeElementsCommand extends LayoutElementsCommand {
+    static readonly KIND = 'layout:resize';
+
+    constructor(@inject(TYPES.Action) protected action: ResizeElementsAction,
+        @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher,
+        @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService) {
+        super(action, actionDispatcher, selectionService);
+    }
+
+    execute(context: CommandExecutionContext): CommandResult {
+        const elements = this.getActionElements(context);
+        if (elements.length > 1) {
+            switch (this.action.dimension) {
+                case ResizeDimension.Width:
+                    this.resizeWidth(elements);
+                    break;
+                case ResizeDimension.Height:
+                    this.resizeHeight(elements);
+                    break;
+                case ResizeDimension.Width_And_Height:
+                    this.resizeWidthAndHeight(elements);
+                    break;
+            }
+        }
+        return context.root;
+    }
+
+    resizeWidth(elements: SelectableBoundsAware[]) {
+        const targetWidth = this.action.reductionFunction(...elements.map(element => element.bounds.width));
+        this.dispatchResizeActions(elements, (element, bounds) => {
+            // resize around center
+            const halfDiffWidth = 0.5 * (targetWidth - element.bounds.width);
+            bounds.newBounds.x = element.bounds.x - halfDiffWidth;
+            bounds.newBounds.width = targetWidth;
+        });
+    }
+
+    resizeHeight(elements: SelectableBoundsAware[]) {
+        const targetHeight = this.action.reductionFunction(...elements.map(element => element.bounds.height));
+        this.dispatchResizeActions(elements, (element, bounds) => {
+            // resize around middle
+            const halfDiffHeight = 0.5 * (targetHeight - element.bounds.height);
+            bounds.newBounds.y = element.bounds.y - halfDiffHeight;
+            bounds.newBounds.height = targetHeight;
+        });
+    }
+
+    resizeWidthAndHeight(elements: SelectableBoundsAware[]) {
+        const targetWidth = this.action.reductionFunction(...elements.map(element => element.bounds.width));
+        const targetHeight = this.action.reductionFunction(...elements.map(element => element.bounds.height));
+        this.dispatchResizeActions(elements, (element, bounds) => {
+            // resize around center and middle
+            const halfDiffWidth = 0.5 * (targetWidth - element.bounds.width);
+            const halfDiffHeight = 0.5 * (targetHeight - element.bounds.height);
+            bounds.newBounds.x = element.bounds.x - halfDiffWidth;
+            bounds.newBounds.y = element.bounds.y - halfDiffHeight;
+            bounds.newBounds.width = targetWidth;
+            bounds.newBounds.height = targetHeight;
+        });
+    }
+
+    dispatchResizeActions(elements: SelectableBoundsAware[], change: (element: SelectableBoundsAware, bounds: WriteableElementAndBounds) => void) {
+        const elementAndBounds: ElementAndBounds[] = []; // client- and server-side resize
+        elements.forEach(element => elementAndBounds.push(this.createElementAndBounds(element, change)));
+        this.dispatchActions([new SetBoundsAction(elementAndBounds), new ChangeBoundsOperationAction(elementAndBounds)]);
+    }
+
+    createElementAndBounds(element: SelectableBoundsAware, change: (element: SelectableBoundsAware, bounds: WriteableElementAndBounds) => void) {
+        const bounds: WriteableElementAndBounds = {
+            elementId: element.id,
+            newBounds: {
+                x: element.bounds.x,
+                y: element.bounds.y,
+                width: element.bounds.width,
+                height: element.bounds.height
+            }
+        };
+        change(element, bounds);
+        return bounds;
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        // we dispatch another action which can be undone, so no explicit implementation necessary
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        // we dispatch another action which can be redone, so no explicit implementation necessary
+        return context.root;
+    }
+}
+
+export class AlignElementsCommand extends LayoutElementsCommand {
+    static readonly KIND = 'layout:align';
+
+    constructor(@inject(TYPES.Action) protected action: AlignElementsAction,
+        @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher,
+        @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService) {
+        super(action, actionDispatcher, selectionService);
+    }
+
+    execute(context: CommandExecutionContext): CommandResult {
+        const elements = this.getActionElements(context);
+        if (elements.length > 1) {
+            switch (this.action.alignment) {
+                case Alignment.Left:
+                    this.alignLeft(elements);
+                    break;
+                case Alignment.Center:
+                    this.alignCenter(elements);
+                    break;
+                case Alignment.Right:
+                    this.alignRight(elements);
+                    break;
+                case Alignment.Top:
+                    this.alignTop(elements);
+                    break;
+                case Alignment.Middle:
+                    this.alignMiddle(elements);
+                    break;
+                case Alignment.Bottom:
+                    this.alignBottom(elements);
+                    break;
+            }
+        }
+        return context.root;
+    }
+
+    alignLeft(elements: SelectableBoundsAware[]) {
+        const calculationElements = this.action.selectionFunction(elements);
+        const minX = calculationElements.map(element => element.bounds.x).reduce((a, b) => Math.min(a, b));
+        this.dispatchAlignActions(elements, (_, move) => move.toPosition.x = minX);
+    }
+
+    alignCenter(elements: SelectableBoundsAware[]) {
+        const calculationElements = this.action.selectionFunction(elements);
+        const minX = calculationElements.map(element => element.bounds.x).reduce((a, b) => Math.min(a, b));
+        const maxX = calculationElements.map(element => element.bounds.x + element.bounds.width).reduce((a, b) => Math.max(a, b));
+        const diffX = maxX - minX;
+        const centerX = minX + 0.5 * diffX;
+        this.dispatchAlignActions(elements, (element, move) => move.toPosition.x = centerX - 0.5 * element.bounds.width);
+    }
+
+    alignRight(elements: SelectableBoundsAware[]) {
+        const calculationElements = this.action.selectionFunction(elements);
+        const maxX = calculationElements.map(element => element.bounds.x + element.bounds.width).reduce((a, b) => Math.max(a, b));
+        this.dispatchAlignActions(elements, (element, move) => move.toPosition.x = maxX - element.bounds.width);
+    }
+
+    alignTop(elements: SelectableBoundsAware[]) {
+        const calculationElements = this.action.selectionFunction(elements);
+        const minY = calculationElements.map(element => element.bounds.y).reduce((a, b) => Math.min(a, b));
+        this.dispatchAlignActions(elements, (_, move) => move.toPosition.y = minY);
+    }
+
+    alignMiddle(elements: SelectableBoundsAware[]) {
+        const calculationElements = this.action.selectionFunction(elements);
+        const minY = calculationElements.map(element => element.bounds.y).reduce((a, b) => Math.min(a, b));
+        const maxY = calculationElements.map(element => element.bounds.y + element.bounds.height).reduce((a, b) => Math.max(a, b));
+        const diffY = maxY - minY;
+        const middleY = minY + 0.5 * diffY;
+        this.dispatchAlignActions(elements, (element, move) => move.toPosition.y = middleY - 0.5 * element.bounds.height);
+    }
+
+    alignBottom(elements: SelectableBoundsAware[]) {
+        const calculationElements = this.action.selectionFunction(elements);
+        const maxY = calculationElements.map(element => element.bounds.y + element.bounds.height).reduce((a, b) => Math.max(a, b));
+        this.dispatchAlignActions(elements, (element, move) => move.toPosition.y = maxY - element.bounds.height);
+    }
+
+    dispatchAlignActions(elements: SelectableBoundsAware[], change: (element: SelectableBoundsAware, move: WriteableElementMove) => void) {
+        const moves: ElementMove[] = []; // client-side move
+        const elementAndBounds: ElementAndBounds[] = []; // server-side move
+        elements.forEach(element => {
+            const move = this.createElementMove(element, change);
+            moves.push(move);
+
+            const elementAndBound = this.createElementAndBounds(element, move);
+            elementAndBounds.push(elementAndBound);
+        });
+        this.dispatchActions([new MoveAction(moves), new ChangeBoundsOperationAction(elementAndBounds)]);
+    }
+
+    createElementMove(element: SelectableBoundsAware, change: (element: SelectableBoundsAware, move: WriteableElementMove) => void) {
+        const move: WriteableElementMove = {
+            elementId: element.id,
+            fromPosition: {
+                x: element.bounds.x,
+                y: element.bounds.y
+            },
+            toPosition: {
+                x: element.bounds.x,
+                y: element.bounds.y
+            }
+        };
+        change(element, move);
+        return move;
+    }
+
+    createElementAndBounds(element: SelectableBoundsAware, move: ElementMove): ElementAndBounds {
+        return {
+            elementId: element.id,
+            newBounds: {
+                x: move.toPosition.x,
+                y: move.toPosition.y,
+                width: element.bounds.width,
+                height: element.bounds.height
+            }
+        };
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        // we dispatch another action which can be undone, so no explicit implementation necessary
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        // we dispatch another action which can be redone, so no explicit implementation necessary
+        return context.root;
+    }
+}
+
+export class LayoutKeyboardListener extends KeyListener {
+    keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+        if (matchesKeystroke(event, 'KeyW', 'shift')) {
+            return [new ResizeElementsAction([], ResizeDimension.Width, Reduce.max)];
+        }
+        if (matchesKeystroke(event, 'KeyH', 'shift')) {
+            return [new ResizeElementsAction([], ResizeDimension.Height, Reduce.max)];
+        }
+        return [];
+    }
+}
+
+interface WriteablePoint extends Point {
+    x: number;
+    y: number;
+}
+
+interface WriteableElementMove extends ElementMove {
+    fromPosition?: WriteablePoint;
+    toPosition: WriteablePoint;
+}
+
+interface WriteableElementAndBounds extends ElementAndBounds {
+    newBounds: WriteableBounds;
+}
+
+interface WriteableBounds extends Bounds {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}

--- a/client/packages/sprotty-client/src/features/tools/change-bounds-tool.ts
+++ b/client/packages/sprotty-client/src/features/tools/change-bounds-tool.ts
@@ -20,12 +20,10 @@ import {
     BoundsAware,
     ElementAndBounds,
     findParentByFeature,
-    isBoundsAware,
     isViewport,
     KeyTool,
     MouseListener,
     Point,
-    Selectable,
     SetBoundsAction,
     SModelElement,
     SModelRoot,
@@ -35,11 +33,10 @@ import {
 
 import { GLSPViewerOptions } from "../../base/views/viewer-options";
 import { GLSP_TYPES } from "../../types";
-import { forEachElement, isSelected } from "../../utils/smodel-util";
+import { forEachElement, isNonRoutableSelectedBoundsAware, isSelected } from "../../utils/smodel-util";
 import { isBoundsAwareMoveable, isResizeable, ResizeHandleLocation, SResizeHandle } from "../change-bounds/model";
 import { IMouseTool } from "../mouse-tool/mouse-tool";
 import { ChangeBoundsOperationAction } from "../operation/operation-actions";
-import { isRoutable } from "../reconnect/model";
 import { SelectionListener, SelectionService } from "../select/selection-service";
 import {
     FeedbackMoveMouseListener,
@@ -316,8 +313,4 @@ function minWidth(element: SModelElement & BoundsAware): number {
 function minHeight(element: SModelElement & BoundsAware): number {
     // currently there are no element-specific constraints
     return 1;
-}
-
-function isNonRoutableSelectedBoundsAware(element: SModelElement): element is SModelElement & BoundsAware & Selectable {
-    return isBoundsAware(element) && isSelected(element) && !isRoutable(element);
 }

--- a/client/packages/sprotty-client/src/index.ts
+++ b/client/packages/sprotty-client/src/index.ts
@@ -14,15 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import defaultGLSPModule from "./base/di.config";
-import glspCommandPaletteModule from "./features/command-palette/di.config";
 import executeModule from "./features/execute/di.config";
-import modelHintsModule from "./features/hints/di.config";
+import glspCommandPaletteModule from "./features/command-palette/di.config";
 import glspMouseToolModule from "./features/mouse-tool/di.config";
+import glspSelectModule from "./features/select/di.config";
+import layoutCommandsModule from "./features/layout/di.config";
+import modelHintsModule from "./features/hints/di.config";
+import paletteModule from "./features/tool-palette/di.config";
 import requestResponseModule from "./features/request-response/di.config";
 import saveModule from "./features/save/di.config";
-import glspSelectModule from "./features/select/di.config";
 import toolFeedbackModule from "./features/tool-feedback/di.config";
-import paletteModule from "./features/tool-palette/di.config";
 import validationModule from "./features/validation/di.config";
 
 export * from 'sprotty/lib';
@@ -54,6 +55,7 @@ export * from './features/tools/creation-tool';
 export * from './features/tools/default-tools';
 export * from './features/tools/delete-tool';
 export * from './features/validation/validate';
+export * from './features/layout/layout-commands';
 export * from './lib/model';
 export * from './types';
 export * from './utils/array-utils';
@@ -62,7 +64,7 @@ export * from './utils/smodel-util';
 export * from './utils/viewpoint-util';
 export {
     validationModule, saveModule, executeModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, glspCommandPaletteModule, requestResponseModule, //
-    glspSelectModule, glspMouseToolModule
+    glspSelectModule, glspMouseToolModule, layoutCommandsModule
 };
 
 

--- a/client/packages/sprotty-client/src/utils/smodel-util.ts
+++ b/client/packages/sprotty-client/src/utils/smodel-util.ts
@@ -13,9 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { isSelectable, Selectable, SModelElement, SParentElement } from "sprotty/lib";
+import { BoundsAware, isBoundsAware, isSelectable, Selectable, SModelElement, SParentElement } from "sprotty/lib";
 
 import { isConfigurableNode, NodeEditConfig } from "../base/edit-config/edit-config";
+import { isRoutable } from "../features/reconnect/model";
 
 export function getIndex(element: SModelElement) {
     return element.root.index;
@@ -25,6 +26,12 @@ export function forEachElement<T>(element: SModelElement, predicate: (element: S
     getIndex(element).all()
         .filter(predicate)
         .forEach(runnable);
+}
+
+export function getMatchingElements<T>(element: SModelElement, predicate: (element: SModelElement) => element is SModelElement & T): (SModelElement & T)[] {
+    const matching: (SModelElement & T)[] = [];
+    forEachElement(element, predicate, item => matching.push(item));
+    return matching;
 }
 
 export function hasSelectedElements(element: SModelElement) {
@@ -74,3 +81,9 @@ export function isContainmentAllowed(element: SModelElement, containableElementT
     : element is SParentElement & NodeEditConfig {
     return isConfigurableNode(element) && element.isContainableElement(containableElementTypeId);
 }
+
+export function isNonRoutableSelectedBoundsAware(element: SModelElement): element is SelectableBoundsAware {
+    return isBoundsAware(element) && isSelected(element) && !isRoutable(element);
+}
+
+export type SelectableBoundsAware = SModelElement & BoundsAware & Selectable;

--- a/client/packages/theia-integration/src/browser/diagram/glsp-diagram-commands.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-diagram-commands.ts
@@ -1,0 +1,334 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    AlignElementsAction,
+    AlignElementsCommand,
+    Alignment,
+    Reduce,
+    ResizeDimension,
+    ResizeElementsAction,
+    ResizeElementsCommand,
+    Select,
+    SelectableBoundsAware
+} from "@glsp/sprotty-client/lib";
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath } from "@theia/core";
+import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from "@theia/core/lib/browser";
+import { inject, injectable } from "inversify";
+import { DiagramCommandHandler, DiagramKeybindingContext, DiagramMenus } from "sprotty-theia";
+
+export namespace GLSPDiagramCommands {
+    export const RESIZE_WIDTH_MIN = 'glsp:' + ResizeElementsCommand.KIND + ":width:min";
+    export const RESIZE_WIDTH_MAX = 'glsp:' + ResizeElementsCommand.KIND + ":width:max";
+    export const RESIZE_WIDTH_AVG = 'glsp:' + ResizeElementsCommand.KIND + ":width:avg";
+    export const RESIZE_WIDTH_FIRST = 'glsp:' + ResizeElementsCommand.KIND + ":width:first";
+    export const RESIZE_WIDTH_LAST = 'glsp:' + ResizeElementsCommand.KIND + ":width:last";
+
+    export const RESIZE_HEIGHT_MIN = 'glsp:' + ResizeElementsCommand.KIND + ":height:min";
+    export const RESIZE_HEIGHT_MAX = 'glsp:' + ResizeElementsCommand.KIND + ":height:max";
+    export const RESIZE_HEIGHT_AVG = 'glsp:' + ResizeElementsCommand.KIND + ":height:avg";
+    export const RESIZE_HEIGHT_FIRST = 'glsp:' + ResizeElementsCommand.KIND + ":height:first";
+    export const RESIZE_HEIGHT_LAST = 'glsp:' + ResizeElementsCommand.KIND + ":height:last";
+
+    export const RESIZE_WIDTH_AND_HEIGHT_MIN = 'glsp:' + ResizeElementsCommand.KIND + ":width_and_height:min";
+    export const RESIZE_WIDTH_AND_HEIGHT_MAX = 'glsp:' + ResizeElementsCommand.KIND + ":width_and_height:max";
+    export const RESIZE_WIDTH_AND_HEIGHT_AVG = 'glsp:' + ResizeElementsCommand.KIND + ":width_and_height:avg";
+    export const RESIZE_WIDTH_AND_HEIGHT_FIRST = 'glsp:' + ResizeElementsCommand.KIND + ":width_and_height:first";
+    export const RESIZE_WIDTH_AND_HEIGHT_LAST = 'glsp:' + ResizeElementsCommand.KIND + ":width_and_height:last";
+
+    export const ALIGN_LEFT = 'glsp:' + AlignElementsCommand.KIND + ":left";
+    export const ALIGN_CENTER = 'glsp:' + AlignElementsCommand.KIND + ":center";
+    export const ALIGN_RIGHT = 'glsp:' + AlignElementsCommand.KIND + ":right";
+    export const ALIGN_TOP = 'glsp:' + AlignElementsCommand.KIND + ":top";
+    export const ALIGN_MIDDLE = 'glsp:' + AlignElementsCommand.KIND + ":middle";
+    export const ALIGN_BOTTOM = 'glsp:' + AlignElementsCommand.KIND + ":bottom";
+
+    export const ALIGN_LEFT_FIRST = 'glsp:' + AlignElementsCommand.KIND + ":left:first";
+    export const ALIGN_CENTER_FIRST = 'glsp:' + AlignElementsCommand.KIND + ":center:first";
+    export const ALIGN_RIGHT_FIRST = 'glsp:' + AlignElementsCommand.KIND + ":right:first";
+    export const ALIGN_TOP_FIRST = 'glsp:' + AlignElementsCommand.KIND + ":top:first";
+    export const ALIGN_MIDDLE_FIRST = 'glsp:' + AlignElementsCommand.KIND + ":middle:first";
+    export const ALIGN_BOTTOM_FIRST = 'glsp:' + AlignElementsCommand.KIND + ":bottom:first";
+
+    export const ALIGN_LEFT_LAST = 'glsp:' + AlignElementsCommand.KIND + ":left:last";
+    export const ALIGN_CENTER_LAST = 'glsp:' + AlignElementsCommand.KIND + ":center:last";
+    export const ALIGN_RIGHT_LAST = 'glsp:' + AlignElementsCommand.KIND + ":right:last";
+    export const ALIGN_TOP_LAST = 'glsp:' + AlignElementsCommand.KIND + ":top:last";
+    export const ALIGN_MIDDLE_LAST = 'glsp:' + AlignElementsCommand.KIND + ":middle:last";
+    export const ALIGN_BOTTOM_LAST = 'glsp:' + AlignElementsCommand.KIND + ":bottom:last";
+}
+
+export namespace GLSPDiagramMenus {
+    export const ALIGN_MENU: MenuPath = DiagramMenus.DIAGRAM.concat("align");
+    export const ALIGN_HORIZONTAL_GROUP: MenuPath = ALIGN_MENU.concat("1_horizontal");
+    export const ALIGN_VERTICAL_GROUP: MenuPath = ALIGN_MENU.concat("2_vertical");
+    export const ALIGN_HORIZONTAL_FIRST_GROUP: MenuPath = ALIGN_MENU.concat("3_horizontal_first");
+    export const ALIGN_VERTICAL_FIRST_GROUP: MenuPath = ALIGN_MENU.concat("4_vertical_first");
+    export const ALIGN_HORIZONTAL_LAST_GROUP: MenuPath = ALIGN_MENU.concat("5_horizontal_last");
+    export const ALIGN_VERTICAL_LAST_GROUP: MenuPath = ALIGN_MENU.concat("6_vertical_last");
+
+    export const RESIZE_MENU: MenuPath = DiagramMenus.DIAGRAM.concat("resize");
+    export const RESIZE_WIDTH_GROUP: MenuPath = RESIZE_MENU.concat("1_width");
+    export const RESIZE_HEIGHT_GROUP: MenuPath = RESIZE_MENU.concat("2_height");
+    export const RESIZE_WIDTH_AND_HEIGHT_GROUP: MenuPath = RESIZE_MENU.concat("3_width_and_height");
+}
+
+@injectable()
+export class GLSPDiagramMenuContribution implements MenuContribution {
+
+    registerMenus(registry: MenuModelRegistry) {
+        registry.registerSubmenu(GLSPDiagramMenus.RESIZE_MENU, "Resize");
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_MIN,
+            order: '1'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_MAX,
+            order: '2'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_AVG,
+            order: '3'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_FIRST,
+            order: '4'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_LAST,
+            order: '5'
+        });
+
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_HEIGHT_MIN,
+            order: '1'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_HEIGHT_MAX,
+            order: '2'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_HEIGHT_AVG,
+            order: '3'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_HEIGHT_FIRST,
+            order: '5'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_HEIGHT_LAST,
+            order: '4'
+        });
+
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_AND_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_MIN,
+            order: '1'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_AND_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_MAX,
+            order: '2'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_AND_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_AVG,
+            order: '3'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_AND_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_FIRST,
+            order: '4'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.RESIZE_WIDTH_AND_HEIGHT_GROUP, {
+            commandId: GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_LAST,
+            order: '5'
+        });
+
+        registry.registerSubmenu(GLSPDiagramMenus.ALIGN_MENU, "Align");
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_LEFT,
+            order: '1'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_CENTER,
+            order: '2'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_RIGHT,
+            order: '3'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_TOP,
+            order: '4'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_MIDDLE,
+            order: '5'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_BOTTOM,
+            order: '6'
+        });
+
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_FIRST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_LEFT_FIRST,
+            order: '1'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_FIRST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_CENTER_FIRST,
+            order: '2'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_FIRST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_RIGHT_FIRST,
+            order: '3'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_FIRST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_TOP_FIRST,
+            order: '4'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_FIRST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_MIDDLE_FIRST,
+            order: '5'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_FIRST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_BOTTOM_FIRST,
+            order: '6'
+        });
+
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_LAST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_LEFT_LAST,
+            order: '1'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_LAST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_CENTER_LAST,
+            order: '2'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_HORIZONTAL_LAST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_RIGHT_LAST,
+            order: '3'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_LAST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_TOP_LAST,
+            order: '4'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_LAST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_MIDDLE_LAST,
+            order: '5'
+        });
+        registry.registerMenuAction(GLSPDiagramMenus.ALIGN_VERTICAL_LAST_GROUP, {
+            commandId: GLSPDiagramCommands.ALIGN_BOTTOM_LAST,
+            order: '6'
+        });
+    }
+}
+
+
+@injectable()
+export class GLSPDiagramCommandContribution implements CommandContribution {
+    constructor(@inject(ApplicationShell) protected readonly shell: ApplicationShell) {
+    }
+
+    registerResize(registry: CommandRegistry, id: string, label: string, dimension: ResizeDimension, f: (...values: number[]) => number) {
+        registry.registerCommand({
+            id: id,
+            label: label,
+        });
+        registry.registerHandler(id,
+            new DiagramCommandHandler(this.shell, widget =>
+                widget.actionDispatcher.dispatch(new ResizeElementsAction([], dimension, f))
+            )
+        );
+    }
+
+    registerAlign(registry: CommandRegistry, id: string, label: string, alignment: Alignment, f: (elements: SelectableBoundsAware[]) => SelectableBoundsAware[]) {
+        registry.registerCommand({
+            id: id,
+            label: label
+        });
+        registry.registerHandler(id,
+            new DiagramCommandHandler(this.shell, widget =>
+                widget.actionDispatcher.dispatch(new AlignElementsAction([], alignment, f))
+            )
+        );
+    }
+
+    registerCommands(reg: CommandRegistry): void {
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_MIN, 'Minimal Width', ResizeDimension.Width, Reduce.min);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_MAX, 'Maximal Width', ResizeDimension.Width, Reduce.max);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_AVG, 'Average Width', ResizeDimension.Width, Reduce.avg);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_FIRST, 'Width of First Selected Element', ResizeDimension.Width, Reduce.first);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_LAST, 'Width of Last Selected Element', ResizeDimension.Width, Reduce.last);
+
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_HEIGHT_MIN, 'Minimal Height', ResizeDimension.Height, Reduce.min);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_HEIGHT_MAX, 'Maximal Height', ResizeDimension.Height, Reduce.max);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_HEIGHT_AVG, 'Average Height', ResizeDimension.Height, Reduce.avg);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_HEIGHT_FIRST, 'Height of First Selected Element', ResizeDimension.Height, Reduce.first);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_HEIGHT_LAST, 'Height of Last Selected Element', ResizeDimension.Height, Reduce.last);
+
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_MIN, 'Minimal Width and Height', ResizeDimension.Width_And_Height, Reduce.min);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_MAX, 'Maximal Width and Height', ResizeDimension.Width_And_Height, Reduce.max);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_AVG, 'Average Width and Height', ResizeDimension.Width_And_Height, Reduce.avg);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_FIRST, 'Width and Height of First Selected Element', ResizeDimension.Width_And_Height, Reduce.first);
+        this.registerResize(reg, GLSPDiagramCommands.RESIZE_WIDTH_AND_HEIGHT_LAST, 'Width and Height of Last Selected Element', ResizeDimension.Width_And_Height, Reduce.last);
+
+
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_LEFT, 'Left', Alignment.Left, Select.all);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_CENTER, 'Center', Alignment.Center, Select.all);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_RIGHT, 'Right', Alignment.Right, Select.all);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_TOP, 'Top', Alignment.Top, Select.all);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_MIDDLE, 'Middle', Alignment.Middle, Select.all);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_BOTTOM, 'Bottom', Alignment.Bottom, Select.all);
+
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_LEFT_FIRST, 'Left of First Selected Element', Alignment.Left, Select.first);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_CENTER_FIRST, 'Center of First Selected Element', Alignment.Center, Select.first);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_RIGHT_FIRST, 'Right of First Selected Element', Alignment.Right, Select.first);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_TOP_FIRST, 'Top of First Selected Element', Alignment.Top, Select.first);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_MIDDLE_FIRST, 'Middle of First Selected Element', Alignment.Middle, Select.first);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_BOTTOM_FIRST, 'Bottom of First Selected Element', Alignment.Bottom, Select.first);
+
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_LEFT_LAST, 'Left of Last Selected Element', Alignment.Left, Select.last);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_CENTER_LAST, 'Center of Last Selected Element', Alignment.Center, Select.last);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_RIGHT_LAST, 'Right of Last Selected Element', Alignment.Right, Select.last);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_TOP_LAST, 'Top of Last Selected Element', Alignment.Top, Select.last);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_MIDDLE_LAST, 'Middle of Last Selected Element', Alignment.Middle, Select.last);
+        this.registerAlign(reg, GLSPDiagramCommands.ALIGN_BOTTOM_LAST, 'Bottom of Last Selected Element', Alignment.Bottom, Select.last);
+    }
+}
+
+@injectable()
+export class GLSPDiagramKeybindingContribution implements KeybindingContribution {
+
+    constructor(@inject(DiagramKeybindingContext) protected readonly diagramKeybindingContext: DiagramKeybindingContext) { }
+
+    registerKeybindings(registry: KeybindingRegistry): void {
+        registry.registerKeybinding({
+            command: GLSPDiagramCommands.ALIGN_LEFT,
+            context: this.diagramKeybindingContext.id,
+            keybinding: 'alt+shift+left'
+        });
+        registry.registerKeybinding({
+            command: GLSPDiagramCommands.ALIGN_RIGHT,
+            context: this.diagramKeybindingContext.id,
+            keybinding: 'alt+shift+right'
+        });
+        registry.registerKeybinding({
+            command: GLSPDiagramCommands.ALIGN_TOP,
+            context: this.diagramKeybindingContext.id,
+            keybinding: 'alt+shift+up'
+        });
+        registry.registerKeybinding({
+            command: GLSPDiagramCommands.ALIGN_BOTTOM,
+            context: this.diagramKeybindingContext.id,
+            keybinding: 'alt+shift+down'
+        });
+    }
+}

--- a/client/packages/theia-integration/src/browser/frontend-module.ts
+++ b/client/packages/theia-integration/src/browser/frontend-module.ts
@@ -13,15 +13,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { bindContributionProvider } from "@theia/core";
-import { FrontendApplicationContribution } from "@theia/core/lib/browser";
+import { CommandContribution } from "@theia/core";
 import { ContainerModule } from "inversify";
-
-import { GLSPTheiaSprottyConnector } from "./diagram/glsp-theia-sprotty-connector";
-import { GLSPClientFactory } from "./language/glsp-client";
+import { FrontendApplicationContribution } from "@theia/core/lib/browser";
 import { GLSPClientContribution } from "./language/glsp-client-contribution";
-import { GLSPClientProvider, GLSPClientProviderImpl } from "./language/glsp-client-provider";
+import { GLSPClientFactory } from "./language/glsp-client";
+import { GLSPClientProvider } from "./language/glsp-client-provider";
+import { GLSPClientProviderImpl } from "./language/glsp-client-provider";
+import { GLSPDiagramCommandContribution } from "./diagram/glsp-diagram-commands";
+import { GLSPDiagramKeybindingContribution } from "./diagram/glsp-diagram-commands";
+import { GLSPDiagramMenuContribution } from "./diagram/glsp-diagram-commands";
 import { GLSPFrontendContribution } from "./language/glsp-frontend-contribution";
+import { GLSPTheiaSprottyConnector } from "./diagram/glsp-theia-sprotty-connector";
+import { KeybindingContribution } from "@theia/core/lib/browser";
+import { MenuContribution } from "@theia/core";
+
+import { bindContributionProvider } from "@theia/core";
 
 
 export default new ContainerModule(bind => {
@@ -35,4 +42,7 @@ export default new ContainerModule(bind => {
 
     bind(GLSPTheiaSprottyConnector).toSelf().inSingletonScope();
 
+    bind(CommandContribution).to(GLSPDiagramCommandContribution).inSingletonScope();
+    bind(MenuContribution).to(GLSPDiagramMenuContribution).inSingletonScope();
+    bind(KeybindingContribution).to(GLSPDiagramKeybindingContribution).inSingletonScope();
 });


### PR DESCRIPTION
Action and command to resize given or selected elements to:
- min/max/avg/first/last width or height

Action and command to align given or selected elements to:
- left/center/right for all/first/last selected element(s)
- top/middle/bottom for all/first/last selected element(s)

Use keybindings within Sprotty for some actions
Register actions in the 'Diagram' menu for Theia

### Align
![align](https://user-images.githubusercontent.com/19170971/58326591-8e726300-7e2d-11e9-8ddb-e5458779bc10.png)

### Resize
![resize](https://user-images.githubusercontent.com/19170971/58326593-9205ea00-7e2d-11e9-9891-1c3588f5b34b.png)
