### PR TITLE
Fix Travis CI Build

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -90,6 +90,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<additionalJOption>-Xdoclint:none</additionalJOption>
 	</properties>
 
 	<build>
@@ -155,17 +156,37 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>
-					<plugin>
+					</plugin>		
+				<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.10.4</version>
+						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
 								<goals>
 									<goal>jar</goal>
 								</goals>
+								<configuration>
+								   <additionalJOption>-Xdoclint:none</additionalJOption>
+									<tags>
+										<tag>
+											<name>generated</name>
+											<placement>a</placement>
+											<head></head>
+										</tag>
+											<tag>
+											<name>ordered</name>
+											<placement>a</placement>
+											<head></head>
+										</tag>
+											<tag>
+											<name>model</name>
+											<placement>a</placement>
+											<head>Model:</head>
+										</tag>
+									</tags>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
Reconfigure maven-javadoc-plugin to avoid errors due to incomplete javadoc during deployment process