### PR TITLE
GModelIndexImpl isn't recursive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
 matrix:
   include:
     - language: java
-      jdk: oraclejdk8
+      jdk: oraclejdk11
       before_script:
         - cd server
       cache:

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/impl/GModelIndexImpl.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/impl/GModelIndexImpl.java
@@ -73,11 +73,19 @@ public class GModelIndexImpl extends ECrossReferenceAdapter implements GModelInd
 	}
 
 	protected void notifyAdd(GModelElement element) {
-		idToElement.put(element.getId(), element);
+		if (idToElement.put(element.getId(), element) == null) {
+			for (GModelElement child : element.getChildren()) {
+				notifyAdd(child);
+			}
+		}
 	}
 
 	protected void notifyRemove(GModelElement element) {
-		idToElement.remove(element.getId());
+		if (idToElement.remove(element.getId()) != null) {
+			for (GModelElement child : element.getChildren()) {
+				notifyRemove(child);
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
- Iterate on the node's children when indexing a new node

fixes #284

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>