### PR TITLE
#274 -Remove sprotty dependencies

### DIFF
--- a/scripts/deployP2.sh
+++ b/scripts/deployP2.sh
@@ -22,16 +22,6 @@ then
     
     GLSP_SNAPSHOT_VERSION=$(resolve_version com.eclipsesource.glsp glsp-parent 1.2.0-SNAPSHOT)
     
-    cd ${REPO_DIR}/glsp-p2/targetplatforms || exit
-    
-    # Regenerate .target from tpd file
-    mvn clean install
-
-    cd .. 
-
-    # Build and deploy composite repository
-    mvn clean install -Pdeploy-composite
-
     git config user.name \""${GLSP_P2_USER}"\"
     git config user.mail \""${GLSP_P2_MAIL}"\"
     # Push changes to glsp-p2 repository

--- a/server/example/workflow-example/pom.xml
+++ b/server/example/workflow-example/pom.xml
@@ -56,11 +56,6 @@
 			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.sprotty</groupId>
-			<artifactId>org.eclipse.sprotty.layout</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
 			<version>3.0</version>

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WFGraphExtension.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WFGraphExtension.java
@@ -22,8 +22,7 @@ import com.eclipsesource.glsp.example.workflow.wfgraph.WfgraphFactory;
 import com.eclipsesource.glsp.example.workflow.wfgraph.WfgraphPackage;
 import com.eclipsesource.glsp.graph.GraphExtension;
 
-public class WFGraphExtension implements GraphExtension{
-
+public class WFGraphExtension implements GraphExtension {
 
 	@Override
 	public EPackage getEPackage() {

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowPopupFactory.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowPopupFactory.java
@@ -15,19 +15,18 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import static com.eclipsesource.glsp.server.util.GModelUtil.bounds;
 
-import org.eclipse.sprotty.Bounds;
-import org.eclipse.sprotty.HtmlRoot;
-import org.eclipse.sprotty.PreRenderedElement;
-import org.eclipse.sprotty.SModelElement;
+import java.util.Arrays;
 
 import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.example.workflow.wfgraph.TaskNode;
 import com.eclipsesource.glsp.graph.GBounds;
+import com.eclipsesource.glsp.graph.GHtmlRoot;
 import com.eclipsesource.glsp.graph.GModelElement;
+import com.eclipsesource.glsp.graph.GPreRenderedElement;
+import com.eclipsesource.glsp.graph.GraphFactory;
 
 public class WorkflowPopupFactory implements PopupModelFactory {
 
@@ -43,21 +42,20 @@ public class WorkflowPopupFactory implements PopupModelFactory {
 	private static final String NL = "<br>";
 
 	@Override
-	public HtmlRoot createPopuModel(GModelElement element, RequestPopupModelAction action) {
+	public GHtmlRoot createPopuModel(GModelElement element, RequestPopupModelAction action) {
 		if (element != null && element instanceof TaskNode) {
 			TaskNode task = (TaskNode) element;
-			HtmlRoot root = new HtmlRoot();
+			GHtmlRoot root = GraphFactory.eINSTANCE.createGHtmlRoot();
 			GBounds bounds = action.getBounds();
-			root.setCanvasBounds(toBounds(bounds));
+			root.setCanvasBounds(bounds(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight()));
 			root.setType("html");
 			root.setId("sprotty-popup");
-			root.setChildren(new ArrayList<SModelElement>());
-			PreRenderedElement p1 = new PreRenderedElement();
+			GPreRenderedElement p1 = GraphFactory.eINSTANCE.createGPreRenderedElement();
 			p1.setType("pre-rendered");
 			p1.setId("popup-title");
 			p1.setCode("<div class=\"sprotty-popup-title\">" + generateTitle(task) + "</div>");
 
-			PreRenderedElement p2 = new PreRenderedElement();
+			GPreRenderedElement p2 = GraphFactory.eINSTANCE.createGPreRenderedElement();
 			p2.setType("pre-rendered");
 			p2.setId("popup-body");
 			p2.setCode("<div class=\"sprotty-popup-body\">" + generateBody(task) + "</div>");
@@ -66,10 +64,6 @@ public class WorkflowPopupFactory implements PopupModelFactory {
 		}
 		return null;
 
-	}
-
-	private Bounds toBounds(GBounds bounds) {
-		return new Bounds(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
 	}
 
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateManualTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateManualTaskHandler.java
@@ -16,12 +16,10 @@
 package com.eclipsesource.glsp.example.workflow.handler;
 
 import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
-import com.eclipsesource.glsp.example.workflow.wfgraph.TaskNode;
-import com.eclipsesource.glsp.example.workflow.wfgraph.WfgraphPackage;
 
 public class CreateManualTaskHandler extends CreateTaskHandler {
 
 	public CreateManualTaskHandler() {
-		super(ModelTypes.MANUAL_TASK,"manual", i -> "ManualTask" + i);
+		super(ModelTypes.MANUAL_TASK, "manual", i -> "ManualTask" + i);
 	}
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -37,7 +37,6 @@ public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 	private String taskType;
 	private Function<Integer, String> labelProvider;
 
-
 	public CreateTaskHandler(String elementTypeId, String taskType, Function<Integer, String> labelProvider) {
 		super(elementTypeId);
 		this.taskType = taskType;
@@ -73,7 +72,8 @@ public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 		layoutOptions.setResizeContainer(false);
 		icon.setLayoutOptions(layoutOptions);
 		GLabel iconLabel = GraphFactory.eINSTANCE.createGLabel();
-		iconLabel.setType(ModelTypes.LABEL_ICON);;
+		iconLabel.setType(ModelTypes.LABEL_ICON);
+		;
 		iconLabel.setId(taskNode.getId() + "_ticon");
 		iconLabel.setText("" + taskNode.getTaskType().toUpperCase().charAt(0));
 		icon.getChildren().add(iconLabel);

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/handler/CreateTaskHandler.java
@@ -73,7 +73,6 @@ public abstract class CreateTaskHandler extends CreateNodeOperationHandler {
 		icon.setLayoutOptions(layoutOptions);
 		GLabel iconLabel = GraphFactory.eINSTANCE.createGLabel();
 		iconLabel.setType(ModelTypes.LABEL_ICON);
-		;
 		iconLabel.setId(taskNode.getId() + "_ticon");
 		iconLabel.setText("" + taskNode.getTaskType().toUpperCase().charAt(0));
 		icon.getChildren().add(iconLabel);

--- a/server/glsp-api/pom.xml
+++ b/server/glsp-api/pom.xml
@@ -71,19 +71,6 @@
 			<artifactId>log4j</artifactId>
 			<version>1.2.16</version>
 		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/io.typefox.sprotty/diagram-api -->
-		<dependency>
-			<groupId>org.eclipse.sprotty</groupId>
-			<artifactId>org.eclipse.sprotty</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.eclipse.sprotty</groupId>
-			<artifactId>org.eclipse.sprotty.server</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
@@ -109,5 +96,11 @@
 			<artifactId>glsp-graph</artifactId>
 			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.websocket</groupId>
+			<artifactId>javax.websocket-api</artifactId>
+			<version>1.1</version>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ChangeBoundsOperationAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ChangeBoundsOperationAction.java
@@ -21,7 +21,7 @@ import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.types.ElementAndBounds;
 
 public class ChangeBoundsOperationAction extends AbstractOperationAction {
-	
+
 	private List<ElementAndBounds> newBounds;
 
 	public ChangeBoundsOperationAction() {

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestBoundsAction.java
@@ -19,7 +19,7 @@ import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.graph.GModelRoot;
 
 public class RequestBoundsAction extends Action {
-	
+
 	private GModelRoot newRoot;
 
 	public RequestBoundsAction() {

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ServerStatusAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/ServerStatusAction.java
@@ -15,9 +15,8 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import org.eclipse.sprotty.ServerStatus;
-
 import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.types.ServerStatus;
 
 public class ServerStatusAction extends Action {
 	private String severity;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetModelAction.java
@@ -19,7 +19,7 @@ import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.graph.GModelRoot;
 
 public class SetModelAction extends Action {
-	
+
 	private GModelRoot newRoot;
 
 	public SetModelAction() {

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetPopupModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetPopupModelAction.java
@@ -15,27 +15,26 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
-import org.eclipse.sprotty.HtmlRoot;
-
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.graph.GBounds;
+import com.eclipsesource.glsp.graph.GHtmlRoot;
 
 public class SetPopupModelAction extends Action {
 
-	private HtmlRoot newRoot;
+	private GHtmlRoot newRoot;
 	private GBounds bounds;
 
 	public SetPopupModelAction() {
 		super(Action.Kind.SET_POPUP_MODEL);
 	}
 
-	public SetPopupModelAction(HtmlRoot newRoot, GBounds bounds) {
+	public SetPopupModelAction(GHtmlRoot newRoot, GBounds bounds) {
 		this();
 		this.newRoot = newRoot;
 		this.bounds = bounds;
 	}
 
-	public HtmlRoot getNewRoot() {
+	public GHtmlRoot getNewRoot() {
 		return newRoot;
 	}
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/UpdateModelAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/UpdateModelAction.java
@@ -19,7 +19,7 @@ import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.graph.GModelRoot;
 
 public class UpdateModelAction extends Action {
-	
+
 	private GModelRoot newRoot;
 	private boolean animate = true;
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -15,6 +15,8 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.di;
 
+import java.util.Optional;
+
 import com.eclipsesource.glsp.api.action.ActionDispatcher;
 import com.eclipsesource.glsp.api.diagram.DiagramConfigurationProvider;
 import com.eclipsesource.glsp.api.factory.GraphGsonConfiguratorFactory;
@@ -120,11 +122,11 @@ public abstract class GLSPModule extends AbstractModule {
 	protected Class<? extends ActionDispatcher> bindActionDispatcher() {
 		return ActionDispatcher.NullImpl.class;
 	}
-  
+
 	protected Class<? extends LabelEditValidator> bindLabelEditValidator() {
 		return LabelEditValidator.NullImpl.class;
 	}
-  
+
 	protected Class<? extends GraphExtension> bindGraphExtension() {
 		return null;
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -58,7 +58,7 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(LabelEditValidator.class).to(bindLabelEditValidator());
 		bind(ModelStateProvider.class).to(bindModelStateProvider());
 		bind(GraphGsonConfiguratorFactory.class).to(bindGraphGsonConfiguratorFactory());
-		bind(GraphExtension.class).to(bindGraphExtension());
+		Optional.ofNullable(bindGraphExtension()).ifPresent(ext -> bind(GraphExtension.class).to(ext));
 	}
 
 	protected abstract Class<? extends ModelStateProvider> bindModelStateProvider();

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -118,8 +118,8 @@ public abstract class GLSPModule extends AbstractModule {
 	protected Class<? extends ActionDispatcher> bindActionDispatcher() {
 		return ActionDispatcher.NullImpl.class;
 	}
-	
-	protected  Class<? extends GraphExtension> bindGraphExtension(){
+
+	protected Class<? extends GraphExtension> bindGraphExtension() {
 		return null;
 	}
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/diagram/DiagramConfiguration.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/diagram/DiagramConfiguration.java
@@ -38,7 +38,7 @@ public interface DiagramConfiguration {
 
 	List<Operation> getOperations();
 
-	default Optional<EPackage> getEPackage(){
+	default Optional<EPackage> getEPackage() {
 		return Optional.empty();
 	}
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/GraphGsonConfiguratorFactory.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/factory/GraphGsonConfiguratorFactory.java
@@ -21,7 +21,7 @@ import com.google.gson.GsonBuilder;
 public interface GraphGsonConfiguratorFactory {
 
 	public GGraphGsonConfigurator create();
-	
+
 	default GsonBuilder configureGson() {
 		return this.create().configureGsonBuilder(new GsonBuilder());
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/handler/Handler.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/handler/Handler.java
@@ -16,7 +16,7 @@
 package com.eclipsesource.glsp.api.handler;
 
 public interface Handler<T> {
-	
+
 	default int getPriority() {
 		return Integer.MIN_VALUE;
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
@@ -20,9 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.sprotty.server.json.PropertyBasedTypeAdapter;
-
 import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.graph.gson.PropertyBasedTypeAdapter;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/ActionTypeAdapter.java
@@ -67,5 +67,5 @@ public class ActionTypeAdapter extends PropertyBasedTypeAdapter<Action> {
 			return (TypeAdapter<T>) new ActionTypeAdapter(gson, actions);
 		}
 	}
-	
+
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/GsonConfigurator.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/json/GsonConfigurator.java
@@ -15,10 +15,9 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.json;
 
-import org.eclipse.sprotty.server.json.EnumTypeAdapter;
-
 import com.eclipsesource.glsp.api.action.ActionRegistry;
 import com.eclipsesource.glsp.api.factory.GraphGsonConfiguratorFactory;
+import com.eclipsesource.glsp.graph.gson.EnumTypeAdapter;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapterFactory;
 import com.google.inject.Inject;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GLSPServer.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GLSPServer.java
@@ -19,9 +19,9 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
-import org.eclipse.sprotty.ServerStatus;
 
 import com.eclipsesource.glsp.api.action.ActionMessage;
+import com.eclipsesource.glsp.api.types.ServerStatus;
 
 public interface GLSPServer extends GLSPClientAware {
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelExpansionListener.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelExpansionListener.java
@@ -19,7 +19,7 @@ import com.eclipsesource.glsp.api.action.kind.CollapseExpandAction;
 import com.eclipsesource.glsp.api.action.kind.CollapseExpandAllAction;
 
 public interface ModelExpansionListener {
-	
+
 	void expansionChanged(CollapseExpandAction action);
 
 	void expansionChanged(CollapseExpandAllAction action);
@@ -35,5 +35,5 @@ public interface ModelExpansionListener {
 		}
 
 	}
-	
+
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelSelectionListener.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/model/ModelSelectionListener.java
@@ -19,7 +19,7 @@ import com.eclipsesource.glsp.api.action.kind.SelectAction;
 import com.eclipsesource.glsp.api.action.kind.SelectAllAction;
 
 public interface ModelSelectionListener {
-	
+
 	void selectionChanged(SelectAction acion);
 
 	void selectionChanged(SelectAllAction action);

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/Group.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/operations/Group.java
@@ -16,7 +16,7 @@
 package com.eclipsesource.glsp.api.operations;
 
 public class Group {
-	
+
 	private String id;
 	private String label;
 	private Group parentGroup;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/EdgeTypeHint.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/EdgeTypeHint.java
@@ -18,7 +18,7 @@ package com.eclipsesource.glsp.api.types;
 import java.util.List;
 
 public class EdgeTypeHint extends ElementTypeHint {
-	
+
 	private boolean routable;
 	private List<String> sourceElementTypeIds;
 	private List<String> targetElementTypeIds;

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/LabeledAction.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/LabeledAction.java
@@ -22,7 +22,7 @@ import java.util.List;
 import com.eclipsesource.glsp.api.action.Action;
 
 public class LabeledAction {
-	
+
 	private String label;
 	private List<Action> actions;
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Match.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/Match.java
@@ -18,7 +18,7 @@ package com.eclipsesource.glsp.api.types;
 import com.eclipsesource.glsp.graph.GModelElement;
 
 public class Match {
-	
+
 	private GModelElement left;
 	private GModelElement right;
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/NodeTypeHint.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/NodeTypeHint.java
@@ -18,7 +18,7 @@ package com.eclipsesource.glsp.api.types;
 import java.util.List;
 
 public class NodeTypeHint extends ElementTypeHint {
-	
+
 	private boolean resizable;
 	private List<String> containableElementTypeIds;
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/ServerStatus.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/ServerStatus.java
@@ -13,22 +13,27 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.api.factory;
+package com.eclipsesource.glsp.api.types;
 
-import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
-import com.eclipsesource.glsp.graph.GHtmlRoot;
-import com.eclipsesource.glsp.graph.GModelElement;
+public class ServerStatus {
+	private Severity severity;
+	private String message;
 
-public interface PopupModelFactory {
+	public ServerStatus(Severity severity, String message) {
+		super();
+		this.severity = severity;
+		this.message = message;
+	}
 
-	GHtmlRoot createPopuModel(GModelElement element, RequestPopupModelAction action);
+	public String getMessage() {
+		return message;
+	}
 
-	public static class NullImpl implements PopupModelFactory {
+	public Severity getSeverity() {
+		return severity;
+	}
 
-		@Override
-		public GHtmlRoot createPopuModel(GModelElement element, RequestPopupModelAction action) {
-			return null;
-		}
-
+	public enum Severity {
+		FATAL, ERROR, WARNING, INFO, OK
 	}
 }

--- a/server/glsp-graph/pom.xml
+++ b/server/glsp-graph/pom.xml
@@ -90,10 +90,5 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.2</version>
 		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sprotty</groupId>
-			<artifactId>org.eclipse.sprotty.server</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GHtmlRoot.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GHtmlRoot.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2019 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.eclipsesource.glsp.graph;
+
+import org.eclipse.emf.common.util.EList;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>GHtml Root</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link com.eclipsesource.glsp.graph.GHtmlRoot#getClasses <em>Classes</em>}</li>
+ * </ul>
+ *
+ * @see com.eclipsesource.glsp.graph.GraphPackage#getGHtmlRoot()
+ * @model
+ * @generated
+ */
+public interface GHtmlRoot extends GModelRoot {
+	/**
+	 * Returns the value of the '<em><b>Classes</b></em>' attribute list.
+	 * The list contents are of type {@link java.lang.String}.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Classes</em>' attribute list.
+	 * @see com.eclipsesource.glsp.graph.GraphPackage#getGHtmlRoot_Classes()
+	 * @model
+	 * @generated
+	 */
+	EList<String> getClasses();
+
+} // GHtmlRoot

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GPreRenderedElement.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GPreRenderedElement.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2019 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.eclipsesource.glsp.graph;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>GPre Rendered Element</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link com.eclipsesource.glsp.graph.GPreRenderedElement#getCode <em>Code</em>}</li>
+ * </ul>
+ *
+ * @see com.eclipsesource.glsp.graph.GraphPackage#getGPreRenderedElement()
+ * @model
+ * @generated
+ */
+public interface GPreRenderedElement extends GModelElement {
+	/**
+	 * Returns the value of the '<em><b>Code</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Code</em>' attribute.
+	 * @see #setCode(String)
+	 * @see com.eclipsesource.glsp.graph.GraphPackage#getGPreRenderedElement_Code()
+	 * @model
+	 * @generated
+	 */
+	String getCode();
+
+	/**
+	 * Sets the value of the '{@link com.eclipsesource.glsp.graph.GPreRenderedElement#getCode <em>Code</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Code</em>' attribute.
+	 * @see #getCode()
+	 * @generated
+	 */
+	void setCode(String value);
+
+} // GPreRenderedElement

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GraphFactory.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GraphFactory.java
@@ -179,6 +179,24 @@ public interface GraphFactory extends EFactory {
 	GIssue createGIssue();
 
 	/**
+	 * Returns a new object of class '<em>GHtml Root</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>GHtml Root</em>'.
+	 * @generated
+	 */
+	GHtmlRoot createGHtmlRoot();
+
+	/**
+	 * Returns a new object of class '<em>GPre Rendered Element</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>GPre Rendered Element</em>'.
+	 * @generated
+	 */
+	GPreRenderedElement createGPreRenderedElement();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GraphPackage.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GraphPackage.java
@@ -1856,6 +1856,206 @@ public interface GraphPackage extends EPackage {
 	int GISSUE_OPERATION_COUNT = 0;
 
 	/**
+	 * The meta object id for the '{@link com.eclipsesource.glsp.graph.impl.GHtmlRootImpl <em>GHtml Root</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see com.eclipsesource.glsp.graph.impl.GHtmlRootImpl
+	 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGHtmlRoot()
+	 * @generated
+	 */
+	int GHTML_ROOT = 21;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__ID = GMODEL_ROOT__ID;
+
+	/**
+	 * The feature id for the '<em><b>Css Classes</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__CSS_CLASSES = GMODEL_ROOT__CSS_CLASSES;
+
+	/**
+	 * The feature id for the '<em><b>Children</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__CHILDREN = GMODEL_ROOT__CHILDREN;
+
+	/**
+	 * The feature id for the '<em><b>Parent</b></em>' container reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__PARENT = GMODEL_ROOT__PARENT;
+
+	/**
+	 * The feature id for the '<em><b>Trace</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__TRACE = GMODEL_ROOT__TRACE;
+
+	/**
+	 * The feature id for the '<em><b>Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__TYPE = GMODEL_ROOT__TYPE;
+
+	/**
+	 * The feature id for the '<em><b>Canvas Bounds</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__CANVAS_BOUNDS = GMODEL_ROOT__CANVAS_BOUNDS;
+
+	/**
+	 * The feature id for the '<em><b>Revision</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__REVISION = GMODEL_ROOT__REVISION;
+
+	/**
+	 * The feature id for the '<em><b>Classes</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT__CLASSES = GMODEL_ROOT_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>GHtml Root</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT_FEATURE_COUNT = GMODEL_ROOT_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>GHtml Root</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GHTML_ROOT_OPERATION_COUNT = GMODEL_ROOT_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl <em>GPre Rendered Element</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl
+	 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGPreRenderedElement()
+	 * @generated
+	 */
+	int GPRE_RENDERED_ELEMENT = 22;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__ID = GMODEL_ELEMENT__ID;
+
+	/**
+	 * The feature id for the '<em><b>Css Classes</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__CSS_CLASSES = GMODEL_ELEMENT__CSS_CLASSES;
+
+	/**
+	 * The feature id for the '<em><b>Children</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__CHILDREN = GMODEL_ELEMENT__CHILDREN;
+
+	/**
+	 * The feature id for the '<em><b>Parent</b></em>' container reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__PARENT = GMODEL_ELEMENT__PARENT;
+
+	/**
+	 * The feature id for the '<em><b>Trace</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__TRACE = GMODEL_ELEMENT__TRACE;
+
+	/**
+	 * The feature id for the '<em><b>Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__TYPE = GMODEL_ELEMENT__TYPE;
+
+	/**
+	 * The feature id for the '<em><b>Code</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT__CODE = GMODEL_ELEMENT_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>GPre Rendered Element</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT_FEATURE_COUNT = GMODEL_ELEMENT_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>GPre Rendered Element</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GPRE_RENDERED_ELEMENT_OPERATION_COUNT = GMODEL_ELEMENT_OPERATION_COUNT + 0;
+
+	/**
 	 * The meta object id for the '{@link com.eclipsesource.glsp.graph.GSide <em>GSide</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1863,7 +2063,7 @@ public interface GraphPackage extends EPackage {
 	 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGSide()
 	 * @generated
 	 */
-	int GSIDE = 21;
+	int GSIDE = 23;
 
 	/**
 	 * The meta object id for the '{@link com.eclipsesource.glsp.graph.GSeverity <em>GSeverity</em>}' enum.
@@ -1873,7 +2073,7 @@ public interface GraphPackage extends EPackage {
 	 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGSeverity()
 	 * @generated
 	 */
-	int GSEVERITY = 22;
+	int GSEVERITY = 24;
 
 	/**
 	 * Returns the meta object for class '{@link com.eclipsesource.glsp.graph.GModelElement <em>GModel Element</em>}'.
@@ -2614,6 +2814,48 @@ public interface GraphPackage extends EPackage {
 	EAttribute getGIssue_Message();
 
 	/**
+	 * Returns the meta object for class '{@link com.eclipsesource.glsp.graph.GHtmlRoot <em>GHtml Root</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>GHtml Root</em>'.
+	 * @see com.eclipsesource.glsp.graph.GHtmlRoot
+	 * @generated
+	 */
+	EClass getGHtmlRoot();
+
+	/**
+	 * Returns the meta object for the attribute list '{@link com.eclipsesource.glsp.graph.GHtmlRoot#getClasses <em>Classes</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute list '<em>Classes</em>'.
+	 * @see com.eclipsesource.glsp.graph.GHtmlRoot#getClasses()
+	 * @see #getGHtmlRoot()
+	 * @generated
+	 */
+	EAttribute getGHtmlRoot_Classes();
+
+	/**
+	 * Returns the meta object for class '{@link com.eclipsesource.glsp.graph.GPreRenderedElement <em>GPre Rendered Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>GPre Rendered Element</em>'.
+	 * @see com.eclipsesource.glsp.graph.GPreRenderedElement
+	 * @generated
+	 */
+	EClass getGPreRenderedElement();
+
+	/**
+	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.graph.GPreRenderedElement#getCode <em>Code</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Code</em>'.
+	 * @see com.eclipsesource.glsp.graph.GPreRenderedElement#getCode()
+	 * @see #getGPreRenderedElement()
+	 * @generated
+	 */
+	EAttribute getGPreRenderedElement_Code();
+
+	/**
 	 * Returns the meta object for enum '{@link com.eclipsesource.glsp.graph.GSide <em>GSide</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -3249,6 +3491,42 @@ public interface GraphPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute GISSUE__MESSAGE = eINSTANCE.getGIssue_Message();
+
+		/**
+		 * The meta object literal for the '{@link com.eclipsesource.glsp.graph.impl.GHtmlRootImpl <em>GHtml Root</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see com.eclipsesource.glsp.graph.impl.GHtmlRootImpl
+		 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGHtmlRoot()
+		 * @generated
+		 */
+		EClass GHTML_ROOT = eINSTANCE.getGHtmlRoot();
+
+		/**
+		 * The meta object literal for the '<em><b>Classes</b></em>' attribute list feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute GHTML_ROOT__CLASSES = eINSTANCE.getGHtmlRoot_Classes();
+
+		/**
+		 * The meta object literal for the '{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl <em>GPre Rendered Element</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl
+		 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGPreRenderedElement()
+		 * @generated
+		 */
+		EClass GPRE_RENDERED_ELEMENT = eINSTANCE.getGPreRenderedElement();
+
+		/**
+		 * The meta object literal for the '<em><b>Code</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute GPRE_RENDERED_ELEMENT__CODE = eINSTANCE.getGPreRenderedElement_Code();
 
 		/**
 		 * The meta object literal for the '{@link com.eclipsesource.glsp.graph.GSide <em>GSide</em>}' enum.

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GHtmlRootImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GHtmlRootImpl.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2019 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.eclipsesource.glsp.graph.impl;
+
+import com.eclipsesource.glsp.graph.GHtmlRoot;
+import com.eclipsesource.glsp.graph.GraphPackage;
+
+import java.util.Collection;
+
+import org.eclipse.emf.common.util.EList;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>GHtml Root</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GHtmlRootImpl#getClasses <em>Classes</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class GHtmlRootImpl extends GModelRootImpl implements GHtmlRoot {
+	/**
+	 * The cached value of the '{@link #getClasses() <em>Classes</em>}' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getClasses()
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<String> classes;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public GHtmlRootImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return GraphPackage.Literals.GHTML_ROOT;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EList<String> getClasses() {
+		if (classes == null) {
+			classes = new EDataTypeUniqueEList<String>(String.class, this, GraphPackage.GHTML_ROOT__CLASSES);
+		}
+		return classes;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+		case GraphPackage.GHTML_ROOT__CLASSES:
+			return getClasses();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+		case GraphPackage.GHTML_ROOT__CLASSES:
+			getClasses().clear();
+			getClasses().addAll((Collection<? extends String>) newValue);
+			return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+		case GraphPackage.GHTML_ROOT__CLASSES:
+			getClasses().clear();
+			return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+		case GraphPackage.GHTML_ROOT__CLASSES:
+			return classes != null && !classes.isEmpty();
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy())
+			return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (classes: ");
+		result.append(classes);
+		result.append(')');
+		return result.toString();
+	}
+
+} //GHtmlRootImpl

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GPreRenderedElementImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GPreRenderedElementImpl.java
@@ -1,0 +1,545 @@
+/**
+ * Copyright (c) 2019 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.eclipsesource.glsp.graph.impl;
+
+import com.eclipsesource.glsp.graph.GModelElement;
+import com.eclipsesource.glsp.graph.GPreRenderedElement;
+import com.eclipsesource.glsp.graph.GraphPackage;
+
+import java.util.Collection;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+
+import org.eclipse.emf.common.util.EList;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
+
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
+import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.util.InternalEList;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>GPre Rendered Element</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getId <em>Id</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getCssClasses <em>Css Classes</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getChildren <em>Children</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getParent <em>Parent</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getTrace <em>Trace</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getType <em>Type</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GPreRenderedElementImpl#getCode <em>Code</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class GPreRenderedElementImpl extends MinimalEObjectImpl.Container implements GPreRenderedElement {
+	/**
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String ID_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
+	protected String id = ID_EDEFAULT;
+
+	/**
+	 * The cached value of the '{@link #getCssClasses() <em>Css Classes</em>}' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCssClasses()
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<String> cssClasses;
+
+	/**
+	 * The cached value of the '{@link #getChildren() <em>Children</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getChildren()
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<GModelElement> children;
+
+	/**
+	 * The default value of the '{@link #getTrace() <em>Trace</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTrace()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String TRACE_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getTrace() <em>Trace</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTrace()
+	 * @generated
+	 * @ordered
+	 */
+	protected String trace = TRACE_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String TYPE_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
+	protected String type = TYPE_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getCode() <em>Code</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCode()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String CODE_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getCode() <em>Code</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCode()
+	 * @generated
+	 * @ordered
+	 */
+	protected String code = CODE_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public GPreRenderedElementImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return GraphPackage.Literals.GPRE_RENDERED_ELEMENT;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setId(String newId) {
+		String oldId = id;
+		id = newId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GPRE_RENDERED_ELEMENT__ID, oldId, id));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EList<String> getCssClasses() {
+		if (cssClasses == null) {
+			cssClasses = new EDataTypeUniqueEList<String>(String.class, this,
+					GraphPackage.GPRE_RENDERED_ELEMENT__CSS_CLASSES);
+		}
+		return cssClasses;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EList<GModelElement> getChildren() {
+		if (children == null) {
+			children = new EObjectContainmentWithInverseEList<GModelElement>(GModelElement.class, this,
+					GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN, GraphPackage.GMODEL_ELEMENT__PARENT);
+		}
+		return children;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public GModelElement getParent() {
+		if (eContainerFeatureID() != GraphPackage.GPRE_RENDERED_ELEMENT__PARENT)
+			return null;
+		return (GModelElement) eInternalContainer();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public NotificationChain basicSetParent(GModelElement newParent, NotificationChain msgs) {
+		msgs = eBasicSetContainer((InternalEObject) newParent, GraphPackage.GPRE_RENDERED_ELEMENT__PARENT, msgs);
+		return msgs;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setParent(GModelElement newParent) {
+		if (newParent != eInternalContainer()
+				|| (eContainerFeatureID() != GraphPackage.GPRE_RENDERED_ELEMENT__PARENT && newParent != null)) {
+			if (EcoreUtil.isAncestor(this, newParent))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newParent != null)
+				msgs = ((InternalEObject) newParent).eInverseAdd(this, GraphPackage.GMODEL_ELEMENT__CHILDREN,
+						GModelElement.class, msgs);
+			msgs = basicSetParent(newParent, msgs);
+			if (msgs != null)
+				msgs.dispatch();
+		} else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GPRE_RENDERED_ELEMENT__PARENT, newParent,
+					newParent));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getTrace() {
+		return trace;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setTrace(String newTrace) {
+		String oldTrace = trace;
+		trace = newTrace;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GPRE_RENDERED_ELEMENT__TRACE, oldTrace,
+					trace));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setType(String newType) {
+		String oldType = type;
+		type = newType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GPRE_RENDERED_ELEMENT__TYPE, oldType,
+					type));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setCode(String newCode) {
+		String oldCode = code;
+		code = newCode;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GPRE_RENDERED_ELEMENT__CODE, oldCode,
+					code));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN:
+			return ((InternalEList<InternalEObject>) (InternalEList<?>) getChildren()).basicAdd(otherEnd, msgs);
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			return basicSetParent((GModelElement) otherEnd, msgs);
+		}
+		return super.eInverseAdd(otherEnd, featureID, msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN:
+			return ((InternalEList<?>) getChildren()).basicRemove(otherEnd, msgs);
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			return basicSetParent(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
+		switch (eContainerFeatureID()) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			return eInternalContainer().eInverseRemove(this, GraphPackage.GMODEL_ELEMENT__CHILDREN, GModelElement.class,
+					msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__ID:
+			return getId();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CSS_CLASSES:
+			return getCssClasses();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN:
+			return getChildren();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			return getParent();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TRACE:
+			return getTrace();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TYPE:
+			return getType();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CODE:
+			return getCode();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__ID:
+			setId((String) newValue);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CSS_CLASSES:
+			getCssClasses().clear();
+			getCssClasses().addAll((Collection<? extends String>) newValue);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN:
+			getChildren().clear();
+			getChildren().addAll((Collection<? extends GModelElement>) newValue);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			setParent((GModelElement) newValue);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TRACE:
+			setTrace((String) newValue);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TYPE:
+			setType((String) newValue);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CODE:
+			setCode((String) newValue);
+			return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__ID:
+			setId(ID_EDEFAULT);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CSS_CLASSES:
+			getCssClasses().clear();
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN:
+			getChildren().clear();
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			setParent((GModelElement) null);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TRACE:
+			setTrace(TRACE_EDEFAULT);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TYPE:
+			setType(TYPE_EDEFAULT);
+			return;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CODE:
+			setCode(CODE_EDEFAULT);
+			return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+		case GraphPackage.GPRE_RENDERED_ELEMENT__ID:
+			return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CSS_CLASSES:
+			return cssClasses != null && !cssClasses.isEmpty();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CHILDREN:
+			return children != null && !children.isEmpty();
+		case GraphPackage.GPRE_RENDERED_ELEMENT__PARENT:
+			return getParent() != null;
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TRACE:
+			return TRACE_EDEFAULT == null ? trace != null : !TRACE_EDEFAULT.equals(trace);
+		case GraphPackage.GPRE_RENDERED_ELEMENT__TYPE:
+			return TYPE_EDEFAULT == null ? type != null : !TYPE_EDEFAULT.equals(type);
+		case GraphPackage.GPRE_RENDERED_ELEMENT__CODE:
+			return CODE_EDEFAULT == null ? code != null : !CODE_EDEFAULT.equals(code);
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy())
+			return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (id: ");
+		result.append(id);
+		result.append(", cssClasses: ");
+		result.append(cssClasses);
+		result.append(", trace: ");
+		result.append(trace);
+		result.append(", type: ");
+		result.append(type);
+		result.append(", code: ");
+		result.append(code);
+		result.append(')');
+		return result.toString();
+	}
+
+} //GPreRenderedElementImpl

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphFactoryImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphFactoryImpl.java
@@ -15,6 +15,7 @@
  */
 package com.eclipsesource.glsp.graph.impl;
 
+import com.eclipsesource.glsp.graph.*;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
@@ -118,6 +119,10 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
 			return createGAlignable();
 		case GraphPackage.GISSUE:
 			return createGIssue();
+		case GraphPackage.GHTML_ROOT:
+			return createGHtmlRoot();
+		case GraphPackage.GPRE_RENDERED_ELEMENT:
+			return createGPreRenderedElement();
 		default:
 			throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -331,6 +336,28 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
 	public GIssue createGIssue() {
 		GIssueImpl gIssue = new GIssueImpl();
 		return gIssue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public GHtmlRoot createGHtmlRoot() {
+		GHtmlRootImpl gHtmlRoot = new GHtmlRootImpl();
+		return gHtmlRoot;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public GPreRenderedElement createGPreRenderedElement() {
+		GPreRenderedElementImpl gPreRenderedElement = new GPreRenderedElementImpl();
+		return gPreRenderedElement;
 	}
 
 	/**

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphPackageImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphPackageImpl.java
@@ -25,6 +25,7 @@ import com.eclipsesource.glsp.graph.GEdge;
 import com.eclipsesource.glsp.graph.GEdgeLayoutable;
 import com.eclipsesource.glsp.graph.GEdgePlacement;
 import com.eclipsesource.glsp.graph.GGraph;
+import com.eclipsesource.glsp.graph.GHtmlRoot;
 import com.eclipsesource.glsp.graph.GIssue;
 import com.eclipsesource.glsp.graph.GIssueMarker;
 import com.eclipsesource.glsp.graph.GLabel;
@@ -35,6 +36,7 @@ import com.eclipsesource.glsp.graph.GModelRoot;
 import com.eclipsesource.glsp.graph.GNode;
 import com.eclipsesource.glsp.graph.GPoint;
 import com.eclipsesource.glsp.graph.GPort;
+import com.eclipsesource.glsp.graph.GPreRenderedElement;
 import com.eclipsesource.glsp.graph.GSeverity;
 import com.eclipsesource.glsp.graph.GShapeElement;
 import com.eclipsesource.glsp.graph.GSide;
@@ -202,6 +204,20 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 	 * @generated
 	 */
 	private EClass gIssueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass gHtmlRootEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass gPreRenderedElementEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -977,6 +993,46 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 	 * @generated
 	 */
 	@Override
+	public EClass getGHtmlRoot() {
+		return gHtmlRootEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EAttribute getGHtmlRoot_Classes() {
+		return (EAttribute) gHtmlRootEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EClass getGPreRenderedElement() {
+		return gPreRenderedElementEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EAttribute getGPreRenderedElement_Code() {
+		return (EAttribute) gPreRenderedElementEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EEnum getGSide() {
 		return gSideEEnum;
 	}
@@ -1111,6 +1167,12 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 		createEAttribute(gIssueEClass, GISSUE__SEVERITY);
 		createEAttribute(gIssueEClass, GISSUE__MESSAGE);
 
+		gHtmlRootEClass = createEClass(GHTML_ROOT);
+		createEAttribute(gHtmlRootEClass, GHTML_ROOT__CLASSES);
+
+		gPreRenderedElementEClass = createEClass(GPRE_RENDERED_ELEMENT);
+		createEAttribute(gPreRenderedElementEClass, GPRE_RENDERED_ELEMENT__CODE);
+
 		// Create enums
 		gSideEEnum = createEEnum(GSIDE);
 		gSeverityEEnum = createEEnum(GSEVERITY);
@@ -1162,6 +1224,8 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 		gIssueMarkerEClass.getESuperTypes().add(this.getGShapeElement());
 		gPortEClass.getESuperTypes().add(this.getGShapeElement());
 		gButtonEClass.getESuperTypes().add(this.getGShapeElement());
+		gHtmlRootEClass.getESuperTypes().add(this.getGModelRoot());
+		gPreRenderedElementEClass.getESuperTypes().add(this.getGModelElement());
 
 		// Initialize classes, features, and operations; add parameters
 		initEClass(gModelElementEClass, GModelElement.class, "GModelElement", IS_ABSTRACT, IS_INTERFACE,
@@ -1341,6 +1405,17 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getGIssue_Message(), ecorePackage.getEString(), "message", null, 0, 1, GIssue.class,
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(gHtmlRootEClass, GHtmlRoot.class, "GHtmlRoot", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getGHtmlRoot_Classes(), ecorePackage.getEString(), "classes", null, 0, -1, GHtmlRoot.class,
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(gPreRenderedElementEClass, GPreRenderedElement.class, "GPreRenderedElement", !IS_ABSTRACT,
+				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getGPreRenderedElement_Code(), ecorePackage.getEString(), "code", null, 0, 1,
+				GPreRenderedElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID,
+				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize enums and add enum literals
 		initEEnum(gSideEEnum, GSide.class, "GSide");

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/util/GraphAdapterFactory.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/util/GraphAdapterFactory.java
@@ -185,6 +185,16 @@ public class GraphAdapterFactory extends AdapterFactoryImpl {
 		}
 
 		@Override
+		public Adapter caseGHtmlRoot(GHtmlRoot object) {
+			return createGHtmlRootAdapter();
+		}
+
+		@Override
+		public Adapter caseGPreRenderedElement(GPreRenderedElement object) {
+			return createGPreRenderedElementAdapter();
+		}
+
+		@Override
 		public Adapter defaultCase(EObject object) {
 			return createEObjectAdapter();
 		}
@@ -494,6 +504,34 @@ public class GraphAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createGIssueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.graph.GHtmlRoot <em>GHtml Root</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see com.eclipsesource.glsp.graph.GHtmlRoot
+	 * @generated
+	 */
+	public Adapter createGHtmlRootAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.graph.GPreRenderedElement <em>GPre Rendered Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see com.eclipsesource.glsp.graph.GPreRenderedElement
+	 * @generated
+	 */
+	public Adapter createGPreRenderedElementAdapter() {
 		return null;
 	}
 

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/util/GraphSwitch.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/util/GraphSwitch.java
@@ -286,6 +286,26 @@ public class GraphSwitch<T> extends Switch<T> {
 				result = defaultCase(theEObject);
 			return result;
 		}
+		case GraphPackage.GHTML_ROOT: {
+			GHtmlRoot gHtmlRoot = (GHtmlRoot) theEObject;
+			T result = caseGHtmlRoot(gHtmlRoot);
+			if (result == null)
+				result = caseGModelRoot(gHtmlRoot);
+			if (result == null)
+				result = caseGModelElement(gHtmlRoot);
+			if (result == null)
+				result = defaultCase(theEObject);
+			return result;
+		}
+		case GraphPackage.GPRE_RENDERED_ELEMENT: {
+			GPreRenderedElement gPreRenderedElement = (GPreRenderedElement) theEObject;
+			T result = caseGPreRenderedElement(gPreRenderedElement);
+			if (result == null)
+				result = caseGModelElement(gPreRenderedElement);
+			if (result == null)
+				result = defaultCase(theEObject);
+			return result;
+		}
 		default:
 			return defaultCase(theEObject);
 		}
@@ -603,6 +623,36 @@ public class GraphSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseGIssue(GIssue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>GHtml Root</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>GHtml Root</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseGHtmlRoot(GHtmlRoot object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>GPre Rendered Element</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>GPre Rendered Element</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseGPreRenderedElement(GPreRenderedElement object) {
 		return null;
 	}
 

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/EnumTypeAdapter.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/EnumTypeAdapter.java
@@ -1,0 +1,109 @@
+/********************************************************************************
+ * Copyright (c) 2017-2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.graph.gson;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A custom type adapter for enums that uses integer values.
+ */
+public class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
+
+	public static class Factory implements TypeAdapterFactory {
+
+		@Override
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+			Class<?> rawType = typeToken.getRawType();
+			if (!Enum.class.isAssignableFrom(rawType) || rawType == Enum.class)
+				return null;
+			if (!rawType.isEnum())
+				rawType = rawType.getSuperclass();
+			try {
+				return new EnumTypeAdapter(rawType);
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+	}
+
+	private static String VALUE_FIELD_NAME = "value";
+
+	private final Map<String, T> nameToConstant = new HashMap<>();
+	private final Map<Integer, T> valueToConstant = new HashMap<>();
+	private final Map<T, Integer> constantToValue = new HashMap<>();
+
+	EnumTypeAdapter(Class<T> classOfT) throws IllegalAccessException {
+		try {
+			Field valueField = classOfT.getDeclaredField(VALUE_FIELD_NAME);
+			if (valueField.getType() != int.class && valueField.getType() != Integer.class)
+				throw new IllegalArgumentException("The field 'value' must contain an integer value.");
+			valueField.setAccessible(true);
+			for (T constant : classOfT.getEnumConstants()) {
+				nameToConstant.put(constant.name(), constant);
+				Integer constValue = (Integer) valueField.get(constant);
+				valueToConstant.put(constValue, constant);
+				constantToValue.put(constant, constValue);
+			}
+		} catch (NoSuchFieldException e) {
+			for (T constant : classOfT.getEnumConstants()) {
+				nameToConstant.put(constant.name(), constant);
+				int constValue = constant.ordinal();
+				valueToConstant.put(constValue, constant);
+				constantToValue.put(constant, constValue);
+			}
+		}
+	}
+
+	@Override
+	public T read(JsonReader in) throws IOException {
+		JsonToken peek = in.peek();
+		if (peek == JsonToken.NULL) {
+			in.nextNull();
+			return null;
+		} else if (peek == JsonToken.NUMBER) {
+			return valueToConstant.get(in.nextInt());
+		} else {
+			String string = in.nextString();
+			try {
+				return valueToConstant.get(Integer.parseInt(string));
+			} catch (NumberFormatException e) {
+				return nameToConstant.get(string);
+			}
+		}
+	}
+
+	@Override
+	public void write(JsonWriter out, T value) throws IOException {
+		if (value != null)
+			out.value(constantToValue.get(value));
+		else
+			out.value((String) null);
+	}
+
+}

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/GModelElementTypeAdapter.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/GModelElementTypeAdapter.java
@@ -28,7 +28,6 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.sprotty.server.json.PropertyBasedTypeAdapter;
 
 import com.eclipsesource.glsp.graph.GModelElement;
 import com.google.gson.Gson;

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/GModelElementTypeAdapter.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/GModelElementTypeAdapter.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
@@ -78,7 +76,7 @@ public class GModelElementTypeAdapter extends PropertyBasedTypeAdapter<GModelEle
 	protected GModelElement createInstance(String type) {
 		EClass eClass = typeMap.get(type);
 		if (eClass != null) {
-			GModelElement element= (GModelElement) eClass.getEPackage().getEFactoryInstance().create(eClass);
+			GModelElement element = (GModelElement) eClass.getEPackage().getEFactoryInstance().create(eClass);
 			element.setType(type);
 			return element;
 		}

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/PropertyBasedTypeAdapter.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/gson/PropertyBasedTypeAdapter.java
@@ -1,0 +1,212 @@
+/********************************************************************************
+ * Copyright (c) 2017-2018 TypeFox and others.	
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package com.eclipsesource.glsp.graph.gson;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.JsonTreeWriter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Gson type adapter that can determine the actual Java class to use for a JSON
+ * object based on a discriminator property.
+ */
+public abstract class PropertyBasedTypeAdapter<T> extends TypeAdapter<T> {
+
+	private final Gson gson;
+
+	private final String discriminator;
+
+	public PropertyBasedTypeAdapter(Gson gson, String discriminator) {
+		this.gson = gson;
+		this.discriminator = discriminator;
+	}
+
+	@Override
+	public T read(JsonReader in) throws IOException {
+		try {
+			in.beginObject();
+			T result = null;
+			Map<String, JsonElement> unassignedProperties = null;
+			while (in.hasNext()) {
+				String propertyName = in.nextName();
+				if (propertyName.equals(discriminator)) {
+					if (result != null)
+						throw new IllegalStateException("Property '" + discriminator + "' is defined twice.");
+					result = createInstance(in.nextString());
+					if (unassignedProperties != null) {
+						for (Map.Entry<String, JsonElement> entry : unassignedProperties.entrySet()) {
+							assignProperty(result, entry.getKey(), entry.getValue());
+						}
+					}
+				} else if (result != null) {
+					assignProperty(result, propertyName, in);
+				} else {
+					if (unassignedProperties == null)
+						unassignedProperties = new HashMap<>();
+					unassignedProperties.put(propertyName, toTree(in));
+				}
+			}
+			in.endObject();
+			return result;
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected abstract T createInstance(String parameter);
+
+	protected void assignProperty(T instance, String propertyName, JsonReader in) throws IllegalAccessException {
+		try {
+			Field field = findField(instance.getClass(), propertyName);
+			Object value = gson.fromJson(in, field.getGenericType());
+			field.set(instance, value);
+		} catch (NoSuchFieldException e) {
+			// Ignore this property
+		}
+	}
+
+	protected void assignProperty(T instance, String propertyName, JsonElement element) throws IllegalAccessException {
+		try {
+			Field field = findField(instance.getClass(), propertyName);
+			Object value = gson.fromJson(element, field.getGenericType());
+			field.set(instance, value);
+		} catch (NoSuchFieldException e) {
+			// Ignore this property
+		}
+	}
+
+	protected Field findField(Class<?> type, String propertyName) throws NoSuchFieldException {
+		try {
+			Field field = type.getDeclaredField(propertyName);
+			field.setAccessible(true);
+			return field;
+		} catch (NoSuchFieldException e) {
+			Class<?> superType = type.getSuperclass();
+			if (superType != null)
+				return findField(superType, propertyName);
+			else
+				throw e;
+		}
+	}
+
+	protected JsonElement toTree(JsonReader in) throws IOException {
+		JsonTreeWriter writer = new JsonTreeWriter();
+		transfer(in, writer);
+		return writer.get();
+	}
+
+	protected void transfer(JsonReader in, JsonWriter out) throws IOException {
+		JsonToken token = in.peek();
+		switch (token) {
+		case BEGIN_ARRAY:
+			in.beginArray();
+			out.beginArray();
+			while (in.hasNext()) {
+				transfer(in, out);
+			}
+			out.endArray();
+			in.endArray();
+			break;
+
+		case BEGIN_OBJECT:
+			in.beginObject();
+			out.beginObject();
+			while (in.hasNext()) {
+				out.name(in.nextName());
+				transfer(in, out);
+			}
+			out.endObject();
+			in.endObject();
+			break;
+
+		case STRING:
+			out.value(in.nextString());
+			break;
+
+		case NUMBER:
+			out.value(in.nextDouble());
+			break;
+
+		case BOOLEAN:
+			out.value(in.nextBoolean());
+			break;
+
+		case NULL:
+			in.nextNull();
+			out.nullValue();
+			break;
+
+		default:
+			throw new IllegalStateException();
+		}
+	}
+
+	@Override
+	public void write(JsonWriter out, T value) throws IOException {
+		if (value == null) {
+			out.nullValue();
+		} else {
+			try {
+				out.beginObject();
+				Set<String> written = new HashSet<>();
+				writeProperties(out, value, value.getClass(), written);
+				if (!written.contains(discriminator))
+					throw new RuntimeException("Object does not contain a field '" + discriminator + "'.");
+				out.endObject();
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	protected void writeProperties(JsonWriter out, T instance, Class<?> type, Set<String> written)
+			throws IOException, IllegalAccessException {
+		for (Field field : type.getDeclaredFields()) {
+			int modifiers = field.getModifiers();
+			if (!Modifier.isTransient(modifiers) && !Modifier.isStatic(modifiers) && written.add(field.getName())) {
+				writeProperty(out, instance, field);
+			}
+		}
+		Class<?> superType = type.getSuperclass();
+		if (superType != null) {
+			writeProperties(out, instance, superType, written);
+		}
+	}
+
+	protected void writeProperty(JsonWriter out, T instance, Field field) throws IOException, IllegalAccessException {
+		field.setAccessible(true);
+		out.name(field.getName());
+		Object value = field.get(instance);
+		if (value == null)
+			out.nullValue();
+		else if (value == instance)
+			throw new RuntimeException("Object has a reference to itself.");
+		else
+			gson.toJson(value, value.getClass(), out);
+	}
+
+}

--- a/server/glsp-graph/src/main/resources/glsp-graph.ecore
+++ b/server/glsp-graph/src/main/resources/glsp-graph.ecore
@@ -130,4 +130,11 @@
     <eLiterals name="warning" value="1"/>
     <eLiterals name="info" value="2"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="GHtmlRoot" eSuperTypes="#//GModelRoot">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="classes" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="GPreRenderedElement" eSuperTypes="#//GModelElement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="code" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/server/glsp-graph/src/main/resources/glsp-graph.genmodel
+++ b/server/glsp-graph/src/main/resources/glsp-graph.genmodel
@@ -109,5 +109,11 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GIssue/severity"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GIssue/message"/>
     </genClasses>
+    <genClasses ecoreClass="glsp-graph.ecore#//GHtmlRoot">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GHtmlRoot/classes"/>
+    </genClasses>
+    <genClasses ecoreClass="glsp-graph.ecore#//GPreRenderedElement">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GPreRenderedElement/code"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/server/glsp-server-websocket/pom.xml
+++ b/server/glsp-server-websocket/pom.xml
@@ -59,11 +59,6 @@
 			<version>3.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.sprotty</groupId>
-			<artifactId>org.eclipse.sprotty</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.jetty.websocket</groupId>
 			<artifactId>javax-websocket-server-impl</artifactId>
 			<version>9.4.10.v20180503</version>

--- a/server/glsp-server/pom.xml
+++ b/server/glsp-server/pom.xml
@@ -58,10 +58,5 @@
 			<artifactId>guice</artifactId>
 			<version>3.0</version>
 		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sprotty</groupId>
-			<artifactId>org.eclipse.sprotty</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/AbstractActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/AbstractActionHandler.java
@@ -17,14 +17,13 @@ package com.eclipsesource.glsp.server.actionhandler;
 
 import java.util.Optional;
 
-import org.eclipse.sprotty.ServerStatus;
-import org.eclipse.sprotty.ServerStatus.Severity;
-
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.ServerStatusAction;
 import com.eclipsesource.glsp.api.handler.ActionHandler;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.model.ModelStateProvider;
+import com.eclipsesource.glsp.api.types.ServerStatus;
+import com.eclipsesource.glsp.api.types.ServerStatus.Severity;
 import com.google.inject.Inject;
 
 public abstract class AbstractActionHandler implements ActionHandler {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
@@ -18,12 +18,10 @@ package com.eclipsesource.glsp.server.actionhandler;
 import java.util.Optional;
 
 import com.eclipsesource.glsp.api.action.Action;
-import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
 import com.eclipsesource.glsp.api.action.kind.SetModelAction;
 import com.eclipsesource.glsp.api.action.kind.UpdateModelAction;
 import com.eclipsesource.glsp.api.layout.ILayoutEngine;
 import com.eclipsesource.glsp.api.layout.ServerLayoutKind;
-import com.eclipsesource.glsp.api.layout.ILayoutEngine.NullImpl;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.graph.GModelRoot;
 import com.google.inject.Inject;
@@ -32,15 +30,14 @@ import com.google.inject.Singleton;
 @Singleton
 public class ModelSubmissionHandler {
 	@Inject(optional = true)
-	ILayoutEngine layoutEngine= new ILayoutEngine.NullImpl();
+	ILayoutEngine layoutEngine = new ILayoutEngine.NullImpl();
 	private Object modelLock = new Object();
 	private int revision = 0;
-
 
 	public Optional<Action> doSubmitModel(boolean update, GraphicalModelState modelState) {
 		GModelRoot newRoot = modelState.getRoot();
 		if (modelState.getServerOptions().getLayoutKind() == ServerLayoutKind.AUTOMATIC) {
-				layoutEngine.layout(newRoot);
+			layoutEngine.layout(newRoot);
 		}
 		synchronized (modelLock) {
 			if (newRoot.getRevision() == revision) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
@@ -17,13 +17,12 @@ package com.eclipsesource.glsp.server.actionhandler;
 
 import java.util.Optional;
 
-import org.eclipse.sprotty.HtmlRoot;
-
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.kind.RequestPopupModelAction;
 import com.eclipsesource.glsp.api.action.kind.SetPopupModelAction;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.graph.GHtmlRoot;
 import com.eclipsesource.glsp.graph.GModelElement;
 import com.google.inject.Inject;
 
@@ -42,7 +41,7 @@ public class RequestPopupModelActionHandler extends AbstractActionHandler {
 			RequestPopupModelAction requestAction = (RequestPopupModelAction) action;
 			Optional<GModelElement> element = modelState.getIndex().get(requestAction.getElementId());
 			if (popupModelFactory != null && element.isPresent()) {
-				HtmlRoot popupModel = popupModelFactory.createPopuModel(element.get(), requestAction);
+				GHtmlRoot popupModel = popupModelFactory.createPopuModel(element.get(), requestAction);
 				if (popupModel != null) {
 					return Optional.of(new SetPopupModelAction(popupModel, requestAction.getBounds()));
 				}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/jsonrpc/DefaultGLSPServer.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/jsonrpc/DefaultGLSPServer.java
@@ -19,8 +19,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.log4j.Logger;
-import org.eclipse.sprotty.ServerStatus;
-import org.eclipse.sprotty.ServerStatus.Severity;
 
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.ActionDispatcher;
@@ -30,6 +28,8 @@ import com.eclipsesource.glsp.api.action.kind.IdentifiableResponseAction;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPClient;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
 import com.eclipsesource.glsp.api.model.ModelStateProvider;
+import com.eclipsesource.glsp.api.types.ServerStatus;
+import com.eclipsesource.glsp.api.types.ServerStatus.Severity;
 import com.google.inject.Inject;
 
 public class DefaultGLSPServer implements GLSPServer {
@@ -81,6 +81,7 @@ public class DefaultGLSPServer implements GLSPServer {
 		}
 	}
 
+	@Override
 	public ServerStatus getStatus() {
 		return status;
 	}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/CreateConnectionOperationHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/operationhandler/CreateConnectionOperationHandler.java
@@ -70,7 +70,8 @@ public abstract class CreateConnectionOperationHandler implements OperationHandl
 
 		Optional<GEdge> connection = createConnection(source.get(), target.get(), modelState);
 		if (!connection.isPresent()) {
-			log.warn(String.format("Creation of connection failed for source: %s , target: %s", source.get().getId(), target.get().getId()));
+			log.warn(String.format("Creation of connection failed for source: %s , target: %s", source.get().getId(),
+					target.get().getId()));
 			return Optional.empty();
 		}
 		GModelRoot currentModel = modelState.getRoot();

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/util/GModelUtil.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/util/GModelUtil.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.graph.GBounds;
 import com.eclipsesource.glsp.graph.GModelElement;
 import com.eclipsesource.glsp.graph.GNode;
 import com.eclipsesource.glsp.graph.GPoint;
@@ -28,6 +29,15 @@ import com.eclipsesource.glsp.graph.GraphFactory;
 public final class GModelUtil {
 
 	private GModelUtil() {
+	}
+
+	public static GBounds bounds(double x, double y, double width, double height) {
+		GBounds bounds = GraphFactory.eINSTANCE.createGBounds();
+		bounds.setX(x);
+		bounds.setY(y);
+		bounds.setWidth(width);
+		bounds.setHeight(height);
+		return bounds;
 	}
 
 	public static GPoint point(double x, double y) {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -113,6 +113,19 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.1</version>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>
@@ -140,19 +153,7 @@
 						</configuration>
 					</plugin>
 					<!-- To generate javadoc -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<version>3.0.1</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar-no-fork</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
+				
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -79,6 +79,11 @@
 			<version>5.4.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>21.0</version>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>
@@ -147,8 +152,8 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>		
-				<plugin>
+					</plugin>
+					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.1.0</version>
@@ -159,19 +164,19 @@
 									<goal>jar</goal>
 								</goals>
 								<configuration>
-								   <additionalJOption>-Xdoclint:none</additionalJOption>
+									<additionalJOption>-Xdoclint:none</additionalJOption>
 									<tags>
 										<tag>
 											<name>generated</name>
 											<placement>a</placement>
 											<head></head>
 										</tag>
-											<tag>
+										<tag>
 											<name>ordered</name>
 											<placement>a</placement>
 											<head></head>
 										</tag>
-											<tag>
+										<tag>
 											<name>model</name>
 											<placement>a</placement>
 											<head>Model:</head>


### PR DESCRIPTION
Note: This PR is based #287. I closed #287 in favor of this one

- Refactor and cleanup server code to get rid of the remaining sprotty dependencies
- Popups are now working again
- Fix issue #291

The transition from SModel to GModel is almost complete with this change.
The only thing left is the implementation of a GModel-based layout engine. (#292)