### PR TITLE
[297] Add support for server to client updates

### DIFF
--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionDispatcher.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/ActionDispatcher.java
@@ -19,13 +19,41 @@ import java.util.Optional;
 
 public interface ActionDispatcher {
 
+	/**
+	 * <p>
+	 * Handle the given action, received from the specified clientId, and optionally
+	 * return a reply Action
+	 * </p>
+	 * 
+	 * @param clientId The client from which the action was received
+	 * @param action   The action to dispatch
+	 * @return An optional Action to be sent to the client as the result of handling
+	 *         the received <code>action</code>
+	 */
 	Optional<Action> dispatch(String clientId, Action action);
+
+	/**
+	 * Send the given action to the specified clientId. This method is intended to
+	 * be used for server-to-client communication, independently from any client
+	 * request (i.e. when it is not possible to simply "reply" to a Client action)
+	 * 
+	 * @param clientId
+	 * 	The client to which the action should be sent
+	 * @param action
+	 * 	The action to send to the client
+	 */
+	void send(String clientId, Action action);
 
 	public static class NullImpl implements ActionDispatcher {
 
 		@Override
 		public Optional<Action> dispatch(String clientId, Action action) {
 			return Optional.empty();
+		}
+
+		@Override
+		public void send(String clientId, Action action) {
+			return;
 		}
 	}
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -23,6 +23,7 @@ import com.eclipsesource.glsp.api.diagram.DiagramConfigurationProvider;
 import com.eclipsesource.glsp.api.factory.GraphGsonConfiguratorFactory;
 import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPClientProvider;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
 import com.eclipsesource.glsp.api.labeledit.LabelEditValidator;
 import com.eclipsesource.glsp.api.layout.ILayoutEngine;
@@ -62,9 +63,12 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(LabelEditValidator.class).to(bindLabelEditValidator());
 		bind(ModelStateProvider.class).to(bindModelStateProvider());
 		bind(GraphGsonConfiguratorFactory.class).to(bindGraphGsonConfiguratorFactory());
+		bind(GLSPClientProvider.class).to(bindGSLPClientProvider());
 		bind(ServerConfiguration.class).to(bindServerConfiguration()).in(Singleton.class);
 		Optional.ofNullable(bindGraphExtension()).ifPresent(ext -> bind(GraphExtension.class).to(ext));
 	}
+
+	protected abstract Class<? extends GLSPClientProvider> bindGSLPClientProvider();
 
 	protected abstract Class<? extends ModelStateProvider> bindModelStateProvider();
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GLSPClientProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/GLSPClientProvider.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.api.jsonrpc;
+
+/**
+ * A registry to associate & retrieve a {@link GLSPClient} from a
+ * <code>clientId</code>
+ */
+public interface GLSPClientProvider {
+	void register(String clientId, GLSPClient client);
+
+	GLSPClient resolve(String clientId);
+
+	void remove(String clientId);
+}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/DIActionDispatcher.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/DIActionDispatcher.java
@@ -30,10 +30,10 @@ public class DIActionDispatcher implements ActionDispatcher {
 
 	@Inject
 	protected GLSPClientProvider clientProvider;
-	
+
 	@Inject
 	protected ActionHandlerProvider handlerProvider;
-	
+
 	@Override
 	public Optional<Action> dispatch(String clientId, Action action) {
 		Optional<ActionHandler> handler = handlerProvider.getHandler(action);
@@ -42,14 +42,12 @@ public class DIActionDispatcher implements ActionDispatcher {
 		}
 		return Optional.empty();
 	}
-	
+
 	@Override
 	public void send(String clientId, Action action) {
 		GLSPClient client = clientProvider.resolve(clientId);
 		if (client == null) {
-			System.err.println("Client not initialized yet; unable to trigger server-to-client notification");
-			return;
-			//throw new IllegalStateException();
+			throw new IllegalStateException("Unable to send a message to Client ID:" + clientId + ". This ID does not match any known client (Client disconnected or not initialized yet?)");
 		}
 		ActionMessage message = new ActionMessage(clientId, action);
 		client.process(message);

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/DIActionDispatcher.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/DIActionDispatcher.java
@@ -19,20 +19,39 @@ import java.util.Optional;
 
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.ActionDispatcher;
+import com.eclipsesource.glsp.api.action.ActionMessage;
 import com.eclipsesource.glsp.api.handler.ActionHandler;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPClient;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPClientProvider;
 import com.eclipsesource.glsp.api.provider.ActionHandlerProvider;
 import com.google.inject.Inject;
 
 public class DIActionDispatcher implements ActionDispatcher {
 
 	@Inject
+	protected GLSPClientProvider clientProvider;
+	
+	@Inject
 	protected ActionHandlerProvider handlerProvider;
-
+	
+	@Override
 	public Optional<Action> dispatch(String clientId, Action action) {
 		Optional<ActionHandler> handler = handlerProvider.getHandler(action);
 		if (handler.isPresent()) {
 			return handler.get().execute(clientId, action);
 		}
 		return Optional.empty();
+	}
+	
+	@Override
+	public void send(String clientId, Action action) {
+		GLSPClient client = clientProvider.resolve(clientId);
+		if (client == null) {
+			System.err.println("Client not initialized yet; unable to trigger server-to-client notification");
+			return;
+			//throw new IllegalStateException();
+		}
+		ActionMessage message = new ActionMessage(clientId, action);
+		client.process(message);
 	}
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
@@ -27,6 +27,7 @@ import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.handler.ActionHandler;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.handler.ServerCommandHandler;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPClientProvider;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
 import com.eclipsesource.glsp.api.model.ModelStateProvider;
 import com.eclipsesource.glsp.api.provider.ActionHandlerProvider;
@@ -52,6 +53,7 @@ import com.eclipsesource.glsp.server.actionhandler.UndoRedoActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.ValidateLabelEditActionHandler;
 import com.eclipsesource.glsp.server.diagram.DIDiagramConfigurationProvider;
 import com.eclipsesource.glsp.server.factory.DefaultGraphGsonConfiguratorFactory;
+import com.eclipsesource.glsp.server.jsonrpc.DefaultGLSPClientProvider;
 import com.eclipsesource.glsp.server.jsonrpc.DefaultGLSPServer;
 import com.eclipsesource.glsp.server.model.DefaultModelStateProvider;
 import com.eclipsesource.glsp.server.model.FileBasedModelFactory;
@@ -149,5 +151,10 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 	@Override
 	protected Class<? extends ActionDispatcher> bindActionDispatcher() {
 		return DIActionDispatcher.class;
+	}
+	
+	@Override
+	protected Class<? extends GLSPClientProvider> bindGSLPClientProvider() {
+		return DefaultGLSPClientProvider.class;
 	}
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/jsonrpc/DefaultGLSPClientProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/jsonrpc/DefaultGLSPClientProvider.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.server.jsonrpc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.eclipsesource.glsp.api.jsonrpc.GLSPClient;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPClientProvider;
+import com.google.inject.Singleton;
+
+@Singleton
+public class DefaultGLSPClientProvider implements GLSPClientProvider {
+
+	private final Map<String, GLSPClient> clients = new HashMap<>();
+	
+	@Override
+	public void register(String clientId, GLSPClient client) {
+		clients.put(clientId, client);
+	}
+
+	@Override
+	public GLSPClient resolve(String clientId) {
+		return clients.get(clientId);
+	}
+
+	@Override
+	public void remove(String clientId) {
+		clients.remove(clientId);
+	}
+
+}


### PR DESCRIPTION
- Add a method to ActionDispatcher to send actions to the client directly
- Add a mapping from clientId to GLSPClient in the new GLSPClientProvider API
  - I'm not 100% satisfied with this: the client ID is specific to each client, so the same clientID can exist in different instances of GLSPServer. However, all instances of GLSPServer use the same GSLPClientProvider so they currently conflict with each other. We could register a (GLSPServer, clientId) pair instead to avoid this issue. On top of that, the clientID is not initially known to the GLSPServer; it's only known when we receive the first message (Typically OpenModel, I guess), so I'm not sure when/where's the best place to register this ClientID - to - GLSPClient mapping