### PR TITLE
Extend GLSP Protocol with "initialize" method

### DIFF
--- a/client/examples/workflow/workflow-theia/src/browser/language/workflow-glsp-client-contribution.ts
+++ b/client/examples/workflow/workflow-theia/src/browser/language/workflow-glsp-client-contribution.ts
@@ -18,9 +18,21 @@ import { injectable } from "inversify";
 
 import { WorkflowLanguage } from "../../common/workflow-language";
 
+export interface WorkflowInitializeOptions {
+    timestamp: Date,
+    message: string
+}
+
 @injectable()
 export class WorkflowGLSPClientContribution extends BaseGLSPClientContribution {
     readonly id = WorkflowLanguage.Id;
     readonly name = WorkflowLanguage.Name;
     readonly fileExtensions = [WorkflowLanguage.FileExtension];
+
+    protected createInitializeOptions(): WorkflowInitializeOptions {
+        return {
+            timestamp: new Date(),
+            message: "Custom Options Available"
+        };
+    }
 }

--- a/client/packages/theia-integration/src/browser/language/glsp-client-contribution.ts
+++ b/client/packages/theia-integration/src/browser/language/glsp-client-contribution.ts
@@ -24,6 +24,7 @@ import { inject, injectable, multiInject } from "inversify";
 import { DiagramManagerProvider } from "sprotty-theia/lib";
 import { MessageConnection, ResponseError } from "vscode-jsonrpc";
 
+import { InitializeParameters } from "../../common";
 import { GLSPClientFactory } from "./glsp-client";
 import { GLSPClient, GLSPClientOptions } from "./glsp-client-services";
 
@@ -105,14 +106,42 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         }));
     }
     protected readonly toDeactivate = new DisposableCollection();
+
     activate(): Disposable {
         if (this.toDeactivate.disposed) {
-            this.doActivate(this.toDeactivate);
+            this.doActivate(this.toDeactivate)
+                .then(() => this.initialize());
         }
         return this.toDeactivate;
     }
+
     deactivate(): void {
         this.toDeactivate.dispose();
+    }
+
+    protected createInitializeParameters(): InitializeParameters {
+        const initOptions = this.createInitializeOptions();
+        return initOptions ? { options: initOptions } : {};
+    }
+
+    protected createInitializeOptions(): any {
+        return undefined;
+    }
+
+    initialize(): void {
+        const parameters = this.createInitializeParameters();
+        this.glspClient.then(client => client.initialize(parameters)
+            .then(success => {
+                if (!success) {
+                    this.messageService.error(`Failed to initialize ${this.name} glsp server with ${JSON.stringify(parameters)}`, 'Retry')
+                        .then(retry => {
+                            if (retry) {
+                                this.initialize();
+                            }
+                        });
+                }
+            })
+        );
     }
 
     protected async doActivate(toDeactivate: DisposableCollection): Promise<void> {
@@ -174,7 +203,6 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
     protected createOptions(): GLSPClientOptions {
         return {
             initializationFailedHandler: err => this.handleInitializationFailed(err),
-
         };
     }
 

--- a/client/packages/theia-integration/src/browser/language/glsp-client-services.ts
+++ b/client/packages/theia-integration/src/browser/language/glsp-client-services.ts
@@ -23,7 +23,7 @@ import {
 } from "@theia/languages/lib/browser";
 import { Disposable, Message, MessageConnection, NotificationHandler, NotificationType } from "vscode-jsonrpc";
 
-import { ExitNotification, ShutdownRequest } from "../../common";
+import { ExitNotification, InitializeParameters, InitializeRequest, ShutdownRequest } from "../../common";
 
 
 export const GLSPClient = Symbol.for('GLSPClient');
@@ -31,6 +31,7 @@ export const GLSPClient = Symbol.for('GLSPClient');
 export interface GLSPClient {
     onReady(): Promise<void>
     start(): Disposable;
+    initialize(params: InitializeParameters): Thenable<Boolean>;
     stop(): Thenable<void> | undefined
     onNotification<P, RO>(type: NotificationType<P, RO>, handler: NotificationHandler<P>): void;
     sendNotification<P, RO>(type: NotificationType<P, RO>, params?: P): void;
@@ -57,6 +58,7 @@ export interface Connection {
     listen(): void
     onNotification<P, RO>(type: NotificationType<P, RO>, handler: NotificationHandler<P>): void;
     sendNotification<P, RO>(type: NotificationType<P, RO>, params?: P): void;
+    initialize(params: InitializeParameters): Thenable<Boolean>;
     shutdown(): Thenable<void>;
     exit(): void;
     dispose(): void;
@@ -76,6 +78,7 @@ export function createConnection(connection: MessageConnection, errorHandler: Co
         listen: () => connection.listen(),
         sendNotification: <P, RO>(type: NotificationType<P, RO>, params?: P): void => connection.sendNotification(type, params),
         onNotification: <P, RO>(type: NotificationType<P, RO>, handler: NotificationHandler<P>): void => connection.onNotification(type, handler),
+        initialize: (params: InitializeParameters) => connection.sendRequest(InitializeRequest.type, params),
         shutdown: () => connection.sendRequest(ShutdownRequest.type, undefined),
         exit: () => connection.sendNotification(ExitNotification.type),
         dispose: () => connection.dispose()

--- a/client/packages/theia-integration/src/browser/language/glsp-client.ts
+++ b/client/packages/theia-integration/src/browser/language/glsp-client.ts
@@ -21,6 +21,7 @@ import { LanguageContribution } from "@theia/languages/lib/common";
 import { inject, injectable } from "inversify";
 import { MessageConnection, NotificationType } from "vscode-jsonrpc";
 
+import { InitializeParameters } from "../../common";
 import { Connection, ConnectionProvider, createConnection, GLSPClient, GLSPClientOptions } from "./glsp-client-services";
 
 enum ClientState {
@@ -53,6 +54,7 @@ export class BaseGLSPClient implements GLSPClient {
         this.state = ClientState.Initial;
 
     }
+
     start(): Disposable {
         this.state = ClientState.Starting;
         this.resolveConnection().then((connection) => {
@@ -66,6 +68,13 @@ export class BaseGLSPClient implements GLSPClient {
             dispose: () => this.stop()
         };
 
+    }
+
+    initialize(params: InitializeParameters): Thenable<Boolean> {
+        if (this.connectionPromise && this.resolvedConnection) {
+            return this.resolvedConnection.initialize(params);
+        }
+        return Promise.resolve(false);
     }
 
     public stop(): Thenable<void> | undefined {

--- a/client/packages/theia-integration/src/common/protocol.ts
+++ b/client/packages/theia-integration/src/common/protocol.ts
@@ -14,10 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ActionMessage } from "@glsp/sprotty-client/lib";
-import { NotificationType, NotificationType0, RequestType0 } from "vscode-jsonrpc";
+import { NotificationType, NotificationType0, RequestType, RequestType0 } from "vscode-jsonrpc";
+
+
+export interface InitializeParameters {
+    options?: any
+}
 
 export namespace ActionMessageNotification {
     export const type = new NotificationType<ActionMessage, void>('process');
+}
+
+export namespace InitializeRequest {
+    export const type = new RequestType<InitializeParameters, Boolean, void, void>('initialize');
 }
 
 export namespace ShutdownRequest {

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowGLSPModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowGLSPModule.java
@@ -23,6 +23,7 @@ import com.eclipsesource.glsp.api.diagram.DiagramConfiguration;
 import com.eclipsesource.glsp.api.factory.PopupModelFactory;
 import com.eclipsesource.glsp.api.handler.OperationHandler;
 import com.eclipsesource.glsp.api.handler.ServerCommandHandler;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
 import com.eclipsesource.glsp.api.labeledit.LabelEditValidator;
 import com.eclipsesource.glsp.api.markers.ModelValidator;
 import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
@@ -43,6 +44,7 @@ import com.eclipsesource.glsp.example.workflow.labeledit.WorkflowLabelEditValida
 import com.eclipsesource.glsp.example.workflow.marker.WorkflowModelValidator;
 import com.eclipsesource.glsp.graph.GraphExtension;
 import com.eclipsesource.glsp.server.di.DefaultGLSPModule;
+import com.eclipsesource.glsp.server.jsonrpc.DefaultGLSPServer;
 import com.eclipsesource.glsp.server.operationhandler.ApplyLabelEditOperationHandler;
 import com.eclipsesource.glsp.server.operationhandler.ChangeBoundsOperationHandler;
 import com.eclipsesource.glsp.server.operationhandler.DeleteOperationHandler;
@@ -50,6 +52,11 @@ import com.eclipsesource.glsp.server.operationhandler.DeleteOperationHandler;
 @SuppressWarnings("serial")
 public class WorkflowGLSPModule extends DefaultGLSPModule {
 
+	@Override
+	protected Class<? extends GLSPServer> bindGLSPServer() {
+		return WorkflowGLSPServer.class;
+	}
+	
 	@Override
 	public Class<? extends PopupModelFactory> bindPopupModelFactory() {
 		return WorkflowPopupFactory.class;

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowGLSPServer.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowGLSPServer.java
@@ -13,33 +13,26 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.api.jsonrpc;
+package com.eclipsesource.glsp.example.workflow;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.apache.log4j.Logger;
 
-import com.eclipsesource.glsp.api.action.ActionMessage;
-import com.eclipsesource.glsp.api.types.ServerStatus;
+import com.eclipsesource.glsp.server.jsonrpc.DefaultGLSPServer;
 
-public interface GLSPServer extends GLSPClientAware {
-
-	public interface Provider {
-		GLSPServer getGraphicalLanguageServer(String clientId);
+public class WorkflowGLSPServer extends DefaultGLSPServer<WorkflowInitializeOptions> {
+	static Logger log = Logger.getLogger(WorkflowGLSPServer.class);
+	
+	public WorkflowGLSPServer() {
+		super(WorkflowInitializeOptions.class);
 	}
-
-	@JsonRequest("initialize")
-	CompletableFuture<Boolean> initialize(InitializeParameters params);
-
-	@JsonNotification("process")
-	void process(ActionMessage message);
-
-	@JsonRequest("shutdown")
-	CompletableFuture<Object> shutdown();
-
-	@JsonNotification("exit")
-	void exit(String clientId);
-
-	ServerStatus getStatus();
+	
+	@Override
+	public CompletableFuture<Boolean> handleOptions(WorkflowInitializeOptions options) {
+		if(options != null) {
+			log.debug(options.getTimestamp() + ": " + options.getMessage());			
+		}
+		return CompletableFuture.completedFuture(true);
+	}
 }

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowInitializeOptions.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowInitializeOptions.java
@@ -13,33 +13,19 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.api.jsonrpc;
+package com.eclipsesource.glsp.example.workflow;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.Date;
 
-import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
-
-import com.eclipsesource.glsp.api.action.ActionMessage;
-import com.eclipsesource.glsp.api.types.ServerStatus;
-
-public interface GLSPServer extends GLSPClientAware {
-
-	public interface Provider {
-		GLSPServer getGraphicalLanguageServer(String clientId);
+public class WorkflowInitializeOptions {
+	private Date timestamp;
+	private String message;
+	
+	public Date getTimestamp() {
+		return timestamp;
 	}
-
-	@JsonRequest("initialize")
-	CompletableFuture<Boolean> initialize(InitializeParameters params);
-
-	@JsonNotification("process")
-	void process(ActionMessage message);
-
-	@JsonRequest("shutdown")
-	CompletableFuture<Object> shutdown();
-
-	@JsonNotification("exit")
-	void exit(String clientId);
-
-	ServerStatus getStatus();
+	
+	public String getMessage() {
+		return message;
+	}
 }

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/InitializeParameters.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/jsonrpc/InitializeParameters.java
@@ -15,31 +15,24 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.jsonrpc;
 
-import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 
-import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import com.google.gson.annotations.JsonAdapter;
 
-import com.eclipsesource.glsp.api.action.ActionMessage;
-import com.eclipsesource.glsp.api.types.ServerStatus;
-
-public interface GLSPServer extends GLSPClientAware {
-
-	public interface Provider {
-		GLSPServer getGraphicalLanguageServer(String clientId);
+public class InitializeParameters {
+	@JsonAdapter(JsonElementTypeAdapter.Factory.class)
+	private Object options;
+	
+	public Object getOptions() {
+		return options;
 	}
-
-	@JsonRequest("initialize")
-	CompletableFuture<Boolean> initialize(InitializeParameters params);
-
-	@JsonNotification("process")
-	void process(ActionMessage message);
-
-	@JsonRequest("shutdown")
-	CompletableFuture<Object> shutdown();
-
-	@JsonNotification("exit")
-	void exit(String clientId);
-
-	ServerStatus getStatus();
+	
+	public void setOptions(Object options) {
+		this.options = options;
+	}
+	
+	@Override
+	public String toString() {
+		return "InitializeParameters[options = " + options + "]";
+	}
 }


### PR DESCRIPTION
- Allow client to send an initialize with parameters to server
- Extend server to handle initialize and the initialize options
- Add example options that are logged to the Workflow example