### PR TITLE
Fix travis build

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -142,7 +142,7 @@
 
 			<build>
 				<plugins>
-					<!-- To release to Maven central -->
+					<!-- To release to Sonatype/Maven central -->
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
@@ -155,42 +155,43 @@
 						</configuration>
 					</plugin>
 					<!-- To generate javadoc -->
-				
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.1.0</version>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<additionalJOption>-Xdoclint:none</additionalJOption>
-									<tags>
-										<tag>
-											<name>generated</name>
-											<placement>a</placement>
-											<head></head>
-										</tag>
-										<tag>
-											<name>ordered</name>
-											<placement>a</placement>
-											<head></head>
-										</tag>
-										<tag>
-											<name>model</name>
-											<placement>a</placement>
-											<head>Model:</head>
-										</tag>
-									</tags>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
+					
+					<!-- Deactivate for now. Not needed for snapshot deployments -->
+<!-- 				<plugin> -->
+<!-- 						<groupId>org.apache.maven.plugins</groupId> -->
+<!-- 						<artifactId>maven-javadoc-plugin</artifactId> -->
+<!-- 						<version>3.1.0</version> -->
+<!-- 						<executions> -->
+<!-- 							<execution> -->
+<!-- 								<id>attach-javadocs</id> -->
+<!-- 								<goals> -->
+<!-- 									<goal>jar</goal> -->
+<!-- 								</goals> -->
+<!-- 								<configuration> -->
+<!-- 									<additionalJOption>-Xdoclint:none</additionalJOption> -->
+<!-- 									<tags> -->
+<!-- 										<tag> -->
+<!-- 											<name>generated</name> -->
+<!-- 											<placement>a</placement> -->
+<!-- 											<head></head> -->
+<!-- 										</tag> -->
+<!-- 										<tag> -->
+<!-- 											<name>ordered</name> -->
+<!-- 											<placement>a</placement> -->
+<!-- 											<head></head> -->
+<!-- 										</tag> -->
+<!-- 										<tag> -->
+<!-- 											<name>model</name> -->
+<!-- 											<placement>a</placement> -->
+<!-- 											<head>Model:</head> -->
+<!-- 										</tag> -->
+<!-- 									</tags> -->
+<!-- 								</configuration> -->
+<!-- 							</execution> -->
+<!-- 						</executions> -->
+<!-- 					</plugin> -->
 
-					<!-- To sign the artifacts -->
+					<!-- To sign the artifacts --> 
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Deactivate the maven-java-doc plugin for now. The JDK11 version used by Travis has a known bug with the maven-java-doc plugin.
This got already fixed in newer JDK releases. Can be reactivated once Travis updates to a new version.