### PR TITLE
Add handlers for directly writing into XMI resources via model access

### DIFF
--- a/client/examples/workflow/workspace/SuperBrewer3000.coffee
+++ b/client/examples/workflow/workspace/SuperBrewer3000.coffee
@@ -9,6 +9,7 @@
     <nodes xsi:type="com.eclipsesource.modelserver.coffee.model:AutomaticTask" name="PreHeat"/>
     <nodes xsi:type="com.eclipsesource.modelserver.coffee.model:AutomaticTask" name="Brew"/>
     <nodes xsi:type="com.eclipsesource.modelserver.coffee.model:ManualTask" name="CheckWt"/>
+    <nodes xsi:type="com.eclipsesource.modelserver.coffee.model:AutomaticTask" name="AnotherTask"/>
     <flows source="//@workflows.0/@nodes.0" target="//@workflows.0/@nodes.1"/>
     <flows xsi:type="com.eclipsesource.modelserver.coffee.model:WeightedFlow" source="//@workflows.0/@nodes.0" target="//@workflows.0/@nodes.1" probability="0.8"/>
   </workflows>

--- a/client/examples/workflow/workspace/SuperBrewer3000.coffeenotation
+++ b/client/examples/workflow/workspace/SuperBrewer3000.coffeenotation
@@ -3,18 +3,28 @@
   <semanticElement uri="//@workflows.0"/>
   <elements xsi:type="wfnotation:Shape">
     <semanticElement uri="//@workflows.0/@nodes.0"/>
-    <position x="23.0" y="46.0" />
+    <position x="28.0" y="162.0"/>
+    <size width="129.953125" height="52.0"/>
   </elements>
   <elements xsi:type="wfnotation:Shape">
     <semanticElement uri="//@workflows.0/@nodes.1"/>
+    <position x="212.0" y="202.0"/>
+    <size width="103.359375" height="52.0"/>
   </elements>
   <elements xsi:type="wfnotation:Shape">
     <semanticElement uri="//@workflows.0/@nodes.2"/>
+    <position x="293.0" y="81.0"/>
+    <size width="140.921875" height="52.0"/>
   </elements>
   <elements xsi:type="wfnotation:Edge">
     <semanticElement uri="//@workflows.0/@flows.0"/>
   </elements>
   <elements xsi:type="wfnotation:Edge">
     <semanticElement uri="//@workflows.0/@flows.1"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.3"/>
+    <position x="577.0" y="226.0"/>
+    <size width="175.65625" height="52.0"/>
   </elements>
 </wfnotation:Diagram>

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/utils/WorkflowBuilder.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/utils/WorkflowBuilder.java
@@ -226,8 +226,7 @@ public final class WorkflowBuilder {
 		private GLabel createCompartmentHeader(TaskNode taskNode) {
 			GLabel heading = GraphFactory.eINSTANCE.createGLabel();
 			heading.setType(ModelTypes.LABEL_HEADING);
-			int nodeCounter = GModelUtil.generateId(taskNode.eClass(), "task", modelState);
-			heading.setId("task" + nodeCounter + "_classname");
+			heading.setId(taskNode.getId() + "_classname");
 			heading.setText(taskNode.getName());
 			return heading;
 		}

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Diagram.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Diagram.java
@@ -18,15 +18,15 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.common.util.EList;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Diagram</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Diagram</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram#getElements <em>Elements</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram#getElements
+ * <em>Elements</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDiagram()
@@ -35,10 +35,11 @@ import org.eclipse.emf.common.util.EList;
  */
 public interface Diagram extends DiagramElement {
 	/**
-	 * Returns the value of the '<em><b>Elements</b></em>' containment reference list.
-	 * The list contents are of type {@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement}.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Elements</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement}.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Elements</em>' containment reference list.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDiagram_Elements()
 	 * @model containment="true"

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/DiagramElement.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/DiagramElement.java
@@ -18,15 +18,15 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.ecore.EObject;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Diagram Element</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Diagram
+ * Element</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement <em>Semantic Element</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement
+ * <em>Semantic Element</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDiagramElement()
@@ -35,9 +35,9 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface DiagramElement extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Semantic Element</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Semantic Element</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Semantic Element</em>' containment reference.
 	 * @see #setSemanticElement(SemanticProxy)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDiagramElement_SemanticElement()
@@ -47,10 +47,13 @@ public interface DiagramElement extends EObject {
 	SemanticProxy getSemanticElement();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement <em>Semantic Element</em>}' containment reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement
+	 * <em>Semantic Element</em>}' containment reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Semantic Element</em>' containment reference.
+	 * 
+	 * @param value the new value of the '<em>Semantic Element</em>' containment
+	 *              reference.
 	 * @see #getSemanticElement()
 	 * @generated
 	 */

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Dimension.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Dimension.java
@@ -18,16 +18,17 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.ecore.EObject;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Dimension</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Dimension</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth <em>Width</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight <em>Height</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth
+ * <em>Width</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight
+ * <em>Height</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDimension()
@@ -36,9 +37,9 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Dimension extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Width</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Width</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Width</em>' attribute.
 	 * @see #setWidth(double)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDimension_Width()
@@ -48,9 +49,10 @@ public interface Dimension extends EObject {
 	double getWidth();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth <em>Width</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth
+	 * <em>Width</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Width</em>' attribute.
 	 * @see #getWidth()
 	 * @generated
@@ -58,9 +60,9 @@ public interface Dimension extends EObject {
 	void setWidth(double value);
 
 	/**
-	 * Returns the value of the '<em><b>Height</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Height</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Height</em>' attribute.
 	 * @see #setHeight(double)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getDimension_Height()
@@ -70,9 +72,10 @@ public interface Dimension extends EObject {
 	double getHeight();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight <em>Height</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight
+	 * <em>Height</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Height</em>' attribute.
 	 * @see #getHeight()
 	 * @generated

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Edge.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Edge.java
@@ -18,15 +18,15 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.common.util.EList;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Edge</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Edge</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge#getBendPoints <em>Bend Points</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge#getBendPoints
+ * <em>Bend Points</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getEdge()
@@ -35,10 +35,11 @@ import org.eclipse.emf.common.util.EList;
  */
 public interface Edge extends DiagramElement {
 	/**
-	 * Returns the value of the '<em><b>Bend Points</b></em>' containment reference list.
-	 * The list contents are of type {@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point}.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Bend Points</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point}.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Bend Points</em>' containment reference list.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getEdge_BendPoints()
 	 * @model containment="true"

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Point.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Point.java
@@ -18,16 +18,17 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.ecore.EObject;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Point</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Point</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX <em>X</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY <em>Y</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX
+ * <em>X</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY
+ * <em>Y</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getPoint()
@@ -36,9 +37,9 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Point extends EObject {
 	/**
-	 * Returns the value of the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>X</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>X</em>' attribute.
 	 * @see #setX(double)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getPoint_X()
@@ -48,9 +49,10 @@ public interface Point extends EObject {
 	double getX();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX <em>X</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX
+	 * <em>X</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>X</em>' attribute.
 	 * @see #getX()
 	 * @generated
@@ -58,9 +60,9 @@ public interface Point extends EObject {
 	void setX(double value);
 
 	/**
-	 * Returns the value of the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Y</em>' attribute.
 	 * @see #setY(double)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getPoint_Y()
@@ -70,9 +72,10 @@ public interface Point extends EObject {
 	double getY();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY <em>Y</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY
+	 * <em>Y</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Y</em>' attribute.
 	 * @see #getY()
 	 * @generated

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/SemanticProxy.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/SemanticProxy.java
@@ -18,16 +18,17 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.ecore.EObject;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Semantic Proxy</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Semantic
+ * Proxy</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri <em>Uri</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement <em>Resolved Element</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri
+ * <em>Uri</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement
+ * <em>Resolved Element</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getSemanticProxy()
@@ -36,9 +37,9 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface SemanticProxy extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Uri</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Uri</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Uri</em>' attribute.
 	 * @see #setUri(String)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getSemanticProxy_Uri()
@@ -48,9 +49,10 @@ public interface SemanticProxy extends EObject {
 	String getUri();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri <em>Uri</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri
+	 * <em>Uri</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Uri</em>' attribute.
 	 * @see #getUri()
 	 * @generated
@@ -58,9 +60,9 @@ public interface SemanticProxy extends EObject {
 	void setUri(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Resolved Element</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Resolved Element</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Resolved Element</em>' reference.
 	 * @see #setResolvedElement(EObject)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getSemanticProxy_ResolvedElement()
@@ -70,9 +72,11 @@ public interface SemanticProxy extends EObject {
 	EObject getResolvedElement();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement <em>Resolved Element</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement
+	 * <em>Resolved Element</em>}' reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Resolved Element</em>' reference.
 	 * @see #getResolvedElement()
 	 * @generated

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Shape.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/Shape.java
@@ -16,16 +16,17 @@
 package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Shape</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Shape</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition <em>Position</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize <em>Size</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition
+ * <em>Position</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize
+ * <em>Size</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getShape()
@@ -35,8 +36,8 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 public interface Shape extends DiagramElement {
 	/**
 	 * Returns the value of the '<em><b>Position</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Position</em>' containment reference.
 	 * @see #setPosition(Point)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getShape_Position()
@@ -46,9 +47,11 @@ public interface Shape extends DiagramElement {
 	Point getPosition();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition <em>Position</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition
+	 * <em>Position</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Position</em>' containment reference.
 	 * @see #getPosition()
 	 * @generated
@@ -56,9 +59,9 @@ public interface Shape extends DiagramElement {
 	void setPosition(Point value);
 
 	/**
-	 * Returns the value of the '<em><b>Size</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the value of the '<em><b>Size</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Size</em>' containment reference.
 	 * @see #setSize(Dimension)
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#getShape_Size()
@@ -68,9 +71,11 @@ public interface Shape extends DiagramElement {
 	Dimension getSize();
 
 	/**
-	 * Sets the value of the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize <em>Size</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize
+	 * <em>Size</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Size</em>' containment reference.
 	 * @see #getSize()
 	 * @generated

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/WfnotationFactory.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/WfnotationFactory.java
@@ -18,84 +18,83 @@ package com.eclipsesource.glsp.example.modelserver.workflow.wfnotation;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage
  * @generated
  */
 public interface WfnotationFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	WfnotationFactory eINSTANCE = com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationFactoryImpl
 			.init();
 
 	/**
-	 * Returns a new object of class '<em>Diagram</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Diagram</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Diagram</em>'.
 	 * @generated
 	 */
 	Diagram createDiagram();
 
 	/**
-	 * Returns a new object of class '<em>Semantic Proxy</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Semantic Proxy</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Semantic Proxy</em>'.
 	 * @generated
 	 */
 	SemanticProxy createSemanticProxy();
 
 	/**
-	 * Returns a new object of class '<em>Shape</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Shape</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Shape</em>'.
 	 * @generated
 	 */
 	Shape createShape();
 
 	/**
-	 * Returns a new object of class '<em>Edge</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Edge</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Edge</em>'.
 	 * @generated
 	 */
 	Edge createEdge();
 
 	/**
-	 * Returns a new object of class '<em>Point</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Point</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Point</em>'.
 	 * @generated
 	 */
 	Point createPoint();
 
 	/**
-	 * Returns a new object of class '<em>Dimension</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Dimension</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Dimension</em>'.
 	 * @generated
 	 */
 	Dimension createDimension();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	WfnotationPackage getWfnotationPackage();
 
-} //WfnotationFactory
+} // WfnotationFactory

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/WfnotationPackage.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/WfnotationPackage.java
@@ -21,59 +21,57 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each operation of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each operation of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationFactory
  * @model kind="package"
  * @generated
  */
 public interface WfnotationPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "wfnotation";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http://www.eclipsesource.com/glsp/examples/workflow/notation";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "wfnotation";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	WfnotationPackage eINSTANCE = com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl
 			.init();
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl <em>Diagram</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl
+	 * <em>Diagram</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getDiagram()
 	 * @generated
@@ -81,9 +79,11 @@ public interface WfnotationPackage extends EPackage {
 	int DIAGRAM = 1;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl <em>Diagram Element</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl
+	 * <em>Diagram Element</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getDiagramElement()
 	 * @generated
@@ -91,9 +91,9 @@ public interface WfnotationPackage extends EPackage {
 	int DIAGRAM_ELEMENT = 0;
 
 	/**
-	 * The feature id for the '<em><b>Semantic Element</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Semantic Element</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -101,26 +101,26 @@ public interface WfnotationPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Diagram Element</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIAGRAM_ELEMENT_FEATURE_COUNT = 1;
 
 	/**
-	 * The number of operations of the '<em>Diagram Element</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Diagram Element</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIAGRAM_ELEMENT_OPERATION_COUNT = 0;
 
 	/**
-	 * The feature id for the '<em><b>Semantic Element</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Semantic Element</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -128,35 +128,37 @@ public interface WfnotationPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Elements</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIAGRAM__ELEMENTS = DIAGRAM_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Diagram</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Diagram</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIAGRAM_FEATURE_COUNT = DIAGRAM_ELEMENT_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of operations of the '<em>Diagram</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Diagram</em>' class. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIAGRAM_OPERATION_COUNT = DIAGRAM_ELEMENT_OPERATION_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl <em>Semantic Proxy</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl
+	 * <em>Semantic Proxy</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getSemanticProxy()
 	 * @generated
@@ -164,18 +166,18 @@ public interface WfnotationPackage extends EPackage {
 	int SEMANTIC_PROXY = 2;
 
 	/**
-	 * The feature id for the '<em><b>Uri</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Uri</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SEMANTIC_PROXY__URI = 0;
 
 	/**
-	 * The feature id for the '<em><b>Resolved Element</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Resolved Element</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -183,26 +185,27 @@ public interface WfnotationPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Semantic Proxy</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SEMANTIC_PROXY_FEATURE_COUNT = 2;
 
 	/**
-	 * The number of operations of the '<em>Semantic Proxy</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Semantic Proxy</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SEMANTIC_PROXY_OPERATION_COUNT = 0;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl <em>Shape</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl
+	 * <em>Shape</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getShape()
 	 * @generated
@@ -210,54 +213,55 @@ public interface WfnotationPackage extends EPackage {
 	int SHAPE = 3;
 
 	/**
-	 * The feature id for the '<em><b>Semantic Element</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Semantic Element</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SHAPE__SEMANTIC_ELEMENT = DIAGRAM_ELEMENT__SEMANTIC_ELEMENT;
 
 	/**
-	 * The feature id for the '<em><b>Position</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Position</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SHAPE__POSITION = DIAGRAM_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Size</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Size</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SHAPE__SIZE = DIAGRAM_ELEMENT_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Shape</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Shape</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SHAPE_FEATURE_COUNT = DIAGRAM_ELEMENT_FEATURE_COUNT + 2;
 
 	/**
-	 * The number of operations of the '<em>Shape</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Shape</em>' class. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SHAPE_OPERATION_COUNT = DIAGRAM_ELEMENT_OPERATION_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl <em>Edge</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl
+	 * <em>Edge</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getEdge()
 	 * @generated
@@ -265,45 +269,46 @@ public interface WfnotationPackage extends EPackage {
 	int EDGE = 4;
 
 	/**
-	 * The feature id for the '<em><b>Semantic Element</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Semantic Element</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EDGE__SEMANTIC_ELEMENT = DIAGRAM_ELEMENT__SEMANTIC_ELEMENT;
 
 	/**
-	 * The feature id for the '<em><b>Bend Points</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Bend Points</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EDGE__BEND_POINTS = DIAGRAM_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Edge</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Edge</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EDGE_FEATURE_COUNT = DIAGRAM_ELEMENT_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of operations of the '<em>Edge</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Edge</em>' class. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EDGE_OPERATION_COUNT = DIAGRAM_ELEMENT_OPERATION_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl <em>Point</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl
+	 * <em>Point</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getPoint()
 	 * @generated
@@ -311,45 +316,46 @@ public interface WfnotationPackage extends EPackage {
 	int POINT = 5;
 
 	/**
-	 * The feature id for the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>X</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POINT__X = 0;
 
 	/**
-	 * The feature id for the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POINT__Y = 1;
 
 	/**
-	 * The number of structural features of the '<em>Point</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Point</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POINT_FEATURE_COUNT = 2;
 
 	/**
-	 * The number of operations of the '<em>Point</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Point</em>' class. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POINT_OPERATION_COUNT = 0;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl <em>Dimension</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl
+	 * <em>Dimension</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getDimension()
 	 * @generated
@@ -357,45 +363,46 @@ public interface WfnotationPackage extends EPackage {
 	int DIMENSION = 6;
 
 	/**
-	 * The feature id for the '<em><b>Width</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Width</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION__WIDTH = 0;
 
 	/**
-	 * The feature id for the '<em><b>Height</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Height</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION__HEIGHT = 1;
 
 	/**
-	 * The number of structural features of the '<em>Dimension</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Dimension</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION_FEATURE_COUNT = 2;
 
 	/**
-	 * The number of operations of the '<em>Dimension</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of operations of the '<em>Dimension</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION_OPERATION_COUNT = 0;
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram <em>Diagram</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram
+	 * <em>Diagram</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Diagram</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram
 	 * @generated
@@ -403,10 +410,12 @@ public interface WfnotationPackage extends EPackage {
 	EClass getDiagram();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram#getElements <em>Elements</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Elements</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram#getElements
+	 * <em>Elements</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Elements</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram#getElements()
 	 * @see #getDiagram()
 	 * @generated
@@ -414,9 +423,10 @@ public interface WfnotationPackage extends EPackage {
 	EReference getDiagram_Elements();
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement <em>Diagram Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement
+	 * <em>Diagram Element</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Diagram Element</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement
 	 * @generated
@@ -424,10 +434,12 @@ public interface WfnotationPackage extends EPackage {
 	EClass getDiagramElement();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement <em>Semantic Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Semantic Element</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement
+	 * <em>Semantic Element</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference '<em>Semantic
+	 *         Element</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement#getSemanticElement()
 	 * @see #getDiagramElement()
 	 * @generated
@@ -435,9 +447,10 @@ public interface WfnotationPackage extends EPackage {
 	EReference getDiagramElement_SemanticElement();
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy <em>Semantic Proxy</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy
+	 * <em>Semantic Proxy</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Semantic Proxy</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy
 	 * @generated
@@ -445,9 +458,10 @@ public interface WfnotationPackage extends EPackage {
 	EClass getSemanticProxy();
 
 	/**
-	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri <em>Uri</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri
+	 * <em>Uri</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Uri</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getUri()
 	 * @see #getSemanticProxy()
@@ -456,9 +470,10 @@ public interface WfnotationPackage extends EPackage {
 	EAttribute getSemanticProxy_Uri();
 
 	/**
-	 * Returns the meta object for the reference '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement <em>Resolved Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement
+	 * <em>Resolved Element</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Resolved Element</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy#getResolvedElement()
 	 * @see #getSemanticProxy()
@@ -467,9 +482,10 @@ public interface WfnotationPackage extends EPackage {
 	EReference getSemanticProxy_ResolvedElement();
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape <em>Shape</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape
+	 * <em>Shape</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Shape</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape
 	 * @generated
@@ -477,9 +493,10 @@ public interface WfnotationPackage extends EPackage {
 	EClass getShape();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition <em>Position</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition
+	 * <em>Position</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Position</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getPosition()
 	 * @see #getShape()
@@ -488,9 +505,10 @@ public interface WfnotationPackage extends EPackage {
 	EReference getShape_Position();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize <em>Size</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize
+	 * <em>Size</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Size</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape#getSize()
 	 * @see #getShape()
@@ -499,9 +517,10 @@ public interface WfnotationPackage extends EPackage {
 	EReference getShape_Size();
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge <em>Edge</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge
+	 * <em>Edge</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Edge</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge
 	 * @generated
@@ -509,10 +528,12 @@ public interface WfnotationPackage extends EPackage {
 	EClass getEdge();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge#getBendPoints <em>Bend Points</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Bend Points</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge#getBendPoints
+	 * <em>Bend Points</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list '<em>Bend
+	 *         Points</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge#getBendPoints()
 	 * @see #getEdge()
 	 * @generated
@@ -520,9 +541,10 @@ public interface WfnotationPackage extends EPackage {
 	EReference getEdge_BendPoints();
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point <em>Point</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point
+	 * <em>Point</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Point</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point
 	 * @generated
@@ -530,9 +552,10 @@ public interface WfnotationPackage extends EPackage {
 	EClass getPoint();
 
 	/**
-	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX <em>X</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX
+	 * <em>X</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>X</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getX()
 	 * @see #getPoint()
@@ -541,9 +564,10 @@ public interface WfnotationPackage extends EPackage {
 	EAttribute getPoint_X();
 
 	/**
-	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY <em>Y</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY
+	 * <em>Y</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Y</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point#getY()
 	 * @see #getPoint()
@@ -552,9 +576,10 @@ public interface WfnotationPackage extends EPackage {
 	EAttribute getPoint_Y();
 
 	/**
-	 * Returns the meta object for class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension <em>Dimension</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension
+	 * <em>Dimension</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Dimension</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension
 	 * @generated
@@ -562,9 +587,10 @@ public interface WfnotationPackage extends EPackage {
 	EClass getDimension();
 
 	/**
-	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth <em>Width</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth
+	 * <em>Width</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Width</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getWidth()
 	 * @see #getDimension()
@@ -573,9 +599,10 @@ public interface WfnotationPackage extends EPackage {
 	EAttribute getDimension_Width();
 
 	/**
-	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight <em>Height</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight
+	 * <em>Height</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Height</em>'.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension#getHeight()
 	 * @see #getDimension()
@@ -584,32 +611,33 @@ public interface WfnotationPackage extends EPackage {
 	EAttribute getDimension_Height();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	WfnotationFactory getWfnotationFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each operation of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each operation of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl <em>Diagram</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl
+		 * <em>Diagram</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getDiagram()
 		 * @generated
@@ -617,17 +645,19 @@ public interface WfnotationPackage extends EPackage {
 		EClass DIAGRAM = eINSTANCE.getDiagram();
 
 		/**
-		 * The meta object literal for the '<em><b>Elements</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Elements</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DIAGRAM__ELEMENTS = eINSTANCE.getDiagram_Elements();
 
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl <em>Diagram Element</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl
+		 * <em>Diagram Element</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getDiagramElement()
 		 * @generated
@@ -635,17 +665,19 @@ public interface WfnotationPackage extends EPackage {
 		EClass DIAGRAM_ELEMENT = eINSTANCE.getDiagramElement();
 
 		/**
-		 * The meta object literal for the '<em><b>Semantic Element</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Semantic Element</b></em>'
+		 * containment reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DIAGRAM_ELEMENT__SEMANTIC_ELEMENT = eINSTANCE.getDiagramElement_SemanticElement();
 
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl <em>Semantic Proxy</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl
+		 * <em>Semantic Proxy</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getSemanticProxy()
 		 * @generated
@@ -653,25 +685,26 @@ public interface WfnotationPackage extends EPackage {
 		EClass SEMANTIC_PROXY = eINSTANCE.getSemanticProxy();
 
 		/**
-		 * The meta object literal for the '<em><b>Uri</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Uri</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute SEMANTIC_PROXY__URI = eINSTANCE.getSemanticProxy_Uri();
 
 		/**
-		 * The meta object literal for the '<em><b>Resolved Element</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Resolved Element</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SEMANTIC_PROXY__RESOLVED_ELEMENT = eINSTANCE.getSemanticProxy_ResolvedElement();
 
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl <em>Shape</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl
+		 * <em>Shape</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getShape()
 		 * @generated
@@ -679,25 +712,26 @@ public interface WfnotationPackage extends EPackage {
 		EClass SHAPE = eINSTANCE.getShape();
 
 		/**
-		 * The meta object literal for the '<em><b>Position</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Position</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SHAPE__POSITION = eINSTANCE.getShape_Position();
 
 		/**
-		 * The meta object literal for the '<em><b>Size</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Size</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SHAPE__SIZE = eINSTANCE.getShape_Size();
 
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl <em>Edge</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl
+		 * <em>Edge</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getEdge()
 		 * @generated
@@ -705,17 +739,18 @@ public interface WfnotationPackage extends EPackage {
 		EClass EDGE = eINSTANCE.getEdge();
 
 		/**
-		 * The meta object literal for the '<em><b>Bend Points</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Bend Points</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference EDGE__BEND_POINTS = eINSTANCE.getEdge_BendPoints();
 
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl <em>Point</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl
+		 * <em>Point</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getPoint()
 		 * @generated
@@ -723,25 +758,26 @@ public interface WfnotationPackage extends EPackage {
 		EClass POINT = eINSTANCE.getPoint();
 
 		/**
-		 * The meta object literal for the '<em><b>X</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>X</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute POINT__X = eINSTANCE.getPoint_X();
 
 		/**
-		 * The meta object literal for the '<em><b>Y</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Y</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute POINT__Y = eINSTANCE.getPoint_Y();
 
 		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl <em>Dimension</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl
+		 * <em>Dimension</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl
 		 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.WfnotationPackageImpl#getDimension()
 		 * @generated
@@ -750,20 +786,20 @@ public interface WfnotationPackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Width</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute DIMENSION__WIDTH = eINSTANCE.getDimension_Width();
 
 		/**
 		 * The meta object literal for the '<em><b>Height</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute DIMENSION__HEIGHT = eINSTANCE.getDimension_Height();
 
 	}
 
-} //WfnotationPackage
+} // WfnotationPackage

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/DiagramElementImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/DiagramElementImpl.java
@@ -26,23 +26,24 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Diagram Element</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Diagram
+ * Element</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl#getSemanticElement <em>Semantic Element</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramElementImpl#getSemanticElement
+ * <em>Semantic Element</em>}</li>
  * </ul>
  *
  * @generated
  */
 public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container implements DiagramElement {
 	/**
-	 * The cached value of the '{@link #getSemanticElement() <em>Semantic Element</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSemanticElement() <em>Semantic
+	 * Element</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #getSemanticElement()
 	 * @generated
 	 * @ordered
@@ -50,8 +51,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	protected SemanticProxy semanticElement;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public DiagramElementImpl() {
@@ -59,8 +60,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -69,8 +70,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -79,8 +80,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetSemanticElement(SemanticProxy newSemanticElement, NotificationChain msgs) {
@@ -98,8 +99,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -121,8 +122,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -135,8 +136,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -149,8 +150,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -164,8 +165,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,8 +180,8 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -192,4 +193,4 @@ public abstract class DiagramElementImpl extends MinimalEObjectImpl.Container im
 		return super.eIsSet(featureID);
 	}
 
-} //DiagramElementImpl
+} // DiagramElementImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/DiagramImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/DiagramImpl.java
@@ -31,23 +31,23 @@ import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Diagram</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Diagram</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl#getElements <em>Elements</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DiagramImpl#getElements
+ * <em>Elements</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	/**
-	 * The cached value of the '{@link #getElements() <em>Elements</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getElements() <em>Elements</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getElements()
 	 * @generated
 	 * @ordered
@@ -55,8 +55,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	protected EList<DiagramElement> elements;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public DiagramImpl() {
@@ -64,8 +64,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -74,8 +74,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -88,8 +88,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -102,8 +102,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -116,8 +116,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -133,8 +133,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +148,8 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,4 +161,4 @@ public class DiagramImpl extends DiagramElementImpl implements Diagram {
 		return super.eIsSet(featureID);
 	}
 
-} //DiagramImpl
+} // DiagramImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/DimensionImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/DimensionImpl.java
@@ -26,24 +26,25 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Dimension</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Dimension</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl#getWidth <em>Width</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl#getHeight <em>Height</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl#getWidth
+ * <em>Width</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.DimensionImpl#getHeight
+ * <em>Height</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimension {
 	/**
-	 * The default value of the '{@link #getWidth() <em>Width</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getWidth() <em>Width</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getWidth()
 	 * @generated
 	 * @ordered
@@ -51,9 +52,9 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	protected static final double WIDTH_EDEFAULT = 0.0;
 
 	/**
-	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getWidth()
 	 * @generated
 	 * @ordered
@@ -62,8 +63,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 
 	/**
 	 * The default value of the '{@link #getHeight() <em>Height</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getHeight()
 	 * @generated
 	 * @ordered
@@ -72,8 +73,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 
 	/**
 	 * The cached value of the '{@link #getHeight() <em>Height</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getHeight()
 	 * @generated
 	 * @ordered
@@ -81,8 +82,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	protected double height = HEIGHT_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public DimensionImpl() {
@@ -90,8 +91,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -100,8 +101,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -110,8 +111,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -123,8 +124,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -133,8 +134,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -147,8 +148,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,8 +164,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -181,8 +182,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -199,8 +200,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -215,8 +216,8 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,4 +234,4 @@ public class DimensionImpl extends MinimalEObjectImpl.Container implements Dimen
 		return result.toString();
 	}
 
-} //DimensionImpl
+} // DimensionImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/EdgeImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/EdgeImpl.java
@@ -32,23 +32,23 @@ import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Edge</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Edge</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl#getBendPoints <em>Bend Points</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.EdgeImpl#getBendPoints
+ * <em>Bend Points</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class EdgeImpl extends DiagramElementImpl implements Edge {
 	/**
-	 * The cached value of the '{@link #getBendPoints() <em>Bend Points</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getBendPoints() <em>Bend Points</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getBendPoints()
 	 * @generated
 	 * @ordered
@@ -56,8 +56,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	protected EList<Point> bendPoints;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public EdgeImpl() {
@@ -65,8 +65,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -75,8 +75,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -88,8 +88,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -102,8 +102,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -116,8 +116,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -133,8 +133,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +148,8 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,4 +161,4 @@ public class EdgeImpl extends DiagramElementImpl implements Edge {
 		return super.eIsSet(featureID);
 	}
 
-} //EdgeImpl
+} // EdgeImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/PointImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/PointImpl.java
@@ -26,24 +26,25 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Point</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Point</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl#getX <em>X</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl#getY <em>Y</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl#getX
+ * <em>X</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.PointImpl#getY
+ * <em>Y</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	/**
-	 * The default value of the '{@link #getX() <em>X</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getX() <em>X</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getX()
 	 * @generated
 	 * @ordered
@@ -51,9 +52,9 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	protected static final double X_EDEFAULT = 0.0;
 
 	/**
-	 * The cached value of the '{@link #getX() <em>X</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getX() <em>X</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getX()
 	 * @generated
 	 * @ordered
@@ -61,9 +62,9 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	protected double x = X_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getY() <em>Y</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getY() <em>Y</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getY()
 	 * @generated
 	 * @ordered
@@ -71,9 +72,9 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	protected static final double Y_EDEFAULT = 0.0;
 
 	/**
-	 * The cached value of the '{@link #getY() <em>Y</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getY() <em>Y</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getY()
 	 * @generated
 	 * @ordered
@@ -81,8 +82,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	protected double y = Y_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public PointImpl() {
@@ -90,8 +91,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -100,8 +101,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -110,8 +111,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -123,8 +124,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -133,8 +134,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,8 +147,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -162,8 +163,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -180,8 +181,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -198,8 +199,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -214,8 +215,8 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -232,4 +233,4 @@ public class PointImpl extends MinimalEObjectImpl.Container implements Point {
 		return result.toString();
 	}
 
-} //PointImpl
+} // PointImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/SemanticProxyImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/SemanticProxyImpl.java
@@ -28,24 +28,25 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Semantic Proxy</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Semantic Proxy</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl#getUri <em>Uri</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl#getResolvedElement <em>Resolved Element</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl#getUri
+ * <em>Uri</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.SemanticProxyImpl#getResolvedElement
+ * <em>Resolved Element</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements SemanticProxy {
 	/**
-	 * The default value of the '{@link #getUri() <em>Uri</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getUri() <em>Uri</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getUri()
 	 * @generated
 	 * @ordered
@@ -53,9 +54,9 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	protected static final String URI_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getUri() <em>Uri</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getUri() <em>Uri</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getUri()
 	 * @generated
 	 * @ordered
@@ -63,9 +64,9 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	protected String uri = URI_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getResolvedElement() <em>Resolved Element</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getResolvedElement() <em>Resolved
+	 * Element</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getResolvedElement()
 	 * @generated
 	 * @ordered
@@ -73,8 +74,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	protected EObject resolvedElement;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public SemanticProxyImpl() {
@@ -82,8 +83,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -92,8 +93,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -102,8 +103,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -115,8 +116,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -134,8 +135,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public EObject basicGetResolvedElement() {
@@ -143,8 +144,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -157,8 +158,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -175,8 +176,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -193,8 +194,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -211,8 +212,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -227,8 +228,8 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -243,4 +244,4 @@ public class SemanticProxyImpl extends MinimalEObjectImpl.Container implements S
 		return result.toString();
 	}
 
-} //SemanticProxyImpl
+} // SemanticProxyImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/ShapeImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/ShapeImpl.java
@@ -29,24 +29,25 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Shape</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Shape</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl#getPosition <em>Position</em>}</li>
- *   <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl#getSize <em>Size</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl#getPosition
+ * <em>Position</em>}</li>
+ * <li>{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.impl.ShapeImpl#getSize
+ * <em>Size</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class ShapeImpl extends DiagramElementImpl implements Shape {
 	/**
-	 * The cached value of the '{@link #getPosition() <em>Position</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPosition() <em>Position</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getPosition()
 	 * @generated
 	 * @ordered
@@ -54,9 +55,9 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	protected Point position;
 
 	/**
-	 * The cached value of the '{@link #getSize() <em>Size</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSize() <em>Size</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSize()
 	 * @generated
 	 * @ordered
@@ -64,8 +65,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	protected Dimension size;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public ShapeImpl() {
@@ -73,8 +74,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -83,8 +84,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -93,8 +94,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetPosition(Point newPosition, NotificationChain msgs) {
@@ -112,8 +113,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -135,8 +136,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -145,8 +146,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetSize(Dimension newSize, NotificationChain msgs) {
@@ -164,8 +165,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -186,8 +187,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -202,8 +203,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -218,8 +219,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -236,8 +237,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -254,8 +255,8 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -269,4 +270,4 @@ public class ShapeImpl extends DiagramElementImpl implements Shape {
 		return super.eIsSet(featureID);
 	}
 
-} //ShapeImpl
+} // ShapeImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/WfnotationFactoryImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/WfnotationFactoryImpl.java
@@ -26,16 +26,16 @@ import org.eclipse.emf.ecore.impl.EFactoryImpl;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static WfnotationFactory init() {
@@ -52,9 +52,9 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public WfnotationFactoryImpl() {
@@ -62,8 +62,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -87,8 +87,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -98,8 +98,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -109,8 +109,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -120,8 +120,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -131,8 +131,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -142,8 +142,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,8 +153,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,8 +163,8 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -173,4 +173,4 @@ public class WfnotationFactoryImpl extends EFactoryImpl implements WfnotationFac
 		return WfnotationPackage.eINSTANCE;
 	}
 
-} //WfnotationFactoryImpl
+} // WfnotationFactoryImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/WfnotationPackageImpl.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/impl/WfnotationPackageImpl.java
@@ -33,71 +33,71 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass diagramEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass diagramElementEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass semanticProxyEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass shapeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass edgeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass pointEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass dimensionEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage#eNS_URI
 	 * @see #init()
@@ -108,19 +108,22 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 *
-	 * <p>This method is used to initialize {@link WfnotationPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link WfnotationPackage#eINSTANCE} when
+	 * that field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -153,8 +156,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,8 +166,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -173,8 +176,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -183,8 +186,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -193,8 +196,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -203,8 +206,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -213,8 +216,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -223,8 +226,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,8 +236,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -243,8 +246,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -253,8 +256,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -263,8 +266,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -273,8 +276,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -283,8 +286,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -293,8 +296,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -303,8 +306,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -313,8 +316,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -323,8 +326,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -333,8 +336,8 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -343,17 +346,17 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -389,17 +392,17 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -471,4 +474,4 @@ public class WfnotationPackageImpl extends EPackageImpl implements WfnotationPac
 		createResource(eNS_URI);
 	}
 
-} //WfnotationPackageImpl
+} // WfnotationPackageImpl

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/util/WfnotationAdapterFactory.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/util/WfnotationAdapterFactory.java
@@ -25,26 +25,25 @@ import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
 import org.eclipse.emf.ecore.EObject;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage
  * @generated
  */
 public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static WfnotationPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public WfnotationAdapterFactory() {
@@ -54,10 +53,11 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -73,9 +73,9 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected WfnotationSwitch<Adapter> modelSwitch = new WfnotationSwitch<Adapter>() {
@@ -121,9 +121,9 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -134,11 +134,12 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram <em>Diagram</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram
+	 * <em>Diagram</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Diagram
 	 * @generated
@@ -148,11 +149,13 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement <em>Diagram Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement
+	 * <em>Diagram Element</em>}'. <!-- begin-user-doc --> This default
+	 * implementation returns null so that we can easily ignore cases; it's useful
+	 * to ignore a case when inheritance will catch all the cases anyway. <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement
 	 * @generated
@@ -162,11 +165,13 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy <em>Semantic Proxy</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy
+	 * <em>Semantic Proxy</em>}'. <!-- begin-user-doc --> This default
+	 * implementation returns null so that we can easily ignore cases; it's useful
+	 * to ignore a case when inheritance will catch all the cases anyway. <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.SemanticProxy
 	 * @generated
@@ -176,11 +181,12 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape <em>Shape</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape
+	 * <em>Shape</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape
 	 * @generated
@@ -190,11 +196,12 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge <em>Edge</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge
+	 * <em>Edge</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge
 	 * @generated
@@ -204,11 +211,12 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point <em>Point</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point
+	 * <em>Point</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point
 	 * @generated
@@ -218,11 +226,12 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension <em>Dimension</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension
+	 * <em>Dimension</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension
 	 * @generated
@@ -232,10 +241,9 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -243,4 +251,4 @@ public class WfnotationAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //WfnotationAdapterFactory
+} // WfnotationAdapterFactory

--- a/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/util/WfnotationSwitch.java
+++ b/server/example/workflow-modelserver-example/src/main/java-gen/com/eclipsesource/glsp/example/modelserver/workflow/wfnotation/util/WfnotationSwitch.java
@@ -23,31 +23,28 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.util.Switch;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationPackage
  * @generated
  */
 public class WfnotationSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static WfnotationPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public WfnotationSwitch() {
@@ -57,9 +54,9 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @param ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -70,9 +67,10 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -140,13 +138,13 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Diagram</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Diagram</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Diagram</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Diagram</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -155,13 +153,13 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Diagram Element</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Diagram
+	 * Element</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Diagram Element</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Diagram
+	 *         Element</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -170,13 +168,13 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Semantic Proxy</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Semantic
+	 * Proxy</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Semantic Proxy</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Semantic
+	 *         Proxy</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -185,13 +183,13 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Shape</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Shape</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Shape</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Shape</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -200,13 +198,13 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Edge</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Edge</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Edge</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Edge</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -215,13 +213,13 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Point</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Point</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Point</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Point</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -230,13 +228,14 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Dimension</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Dimension</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Dimension</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Dimension</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -245,13 +244,14 @@ public class WfnotationSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -260,4 +260,4 @@ public class WfnotationSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //WfnotationSwitch
+} // WfnotationSwitch

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/AbstractCreateEdgeHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/AbstractCreateEdgeHandler.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import org.eclipse.emf.ecore.EClass;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowFacade;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationFactory;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeeFactory;
+import com.eclipsesource.modelserver.coffee.model.coffee.Flow;
+import com.eclipsesource.modelserver.coffee.model.coffee.Workflow;
+
+public abstract class AbstractCreateEdgeHandler implements OperationHandler {
+
+	protected String type;
+	private EClass eClass;
+
+	public AbstractCreateEdgeHandler(String type, EClass eClass) {
+		super();
+		this.type = type;
+		this.eClass = eClass;
+	}
+
+	@Override
+	public Class<? extends Action> handlesActionType() {
+		return CreateConnectionOperationAction.class;
+	}
+
+	@Override
+	public boolean handles(AbstractOperationAction action) {
+		return OperationHandler.super.handles(action)
+				? ((CreateConnectionOperationAction) action).getElementTypeId().equals(type)
+				: false;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Create edge";
+	}
+
+	@Override
+	public void execute(AbstractOperationAction action, GraphicalModelState modelState) {
+		CreateConnectionOperationAction createConnectionAction = (CreateConnectionOperationAction) action;
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+		WorkflowFacade workflowFacade = modelAccess.getWorkflowFacade();
+		Workflow workflow = workflowFacade.getCurrentWorkflow();
+
+		Flow flow = (Flow) CoffeeFactory.eINSTANCE.create(eClass);
+		flow.setSource(modelAccess.getNodeById(createConnectionAction.getSourceElementId()));
+		flow.setTarget(modelAccess.getNodeById(createConnectionAction.getTargetElementId()));
+		workflow.getFlows().add(flow);
+
+		workflowFacade.findDiagram(workflow).ifPresent(diagram -> {
+			Edge edge = WfnotationFactory.eINSTANCE.createEdge();
+			edge.setSemanticElement(workflowFacade.createProxy(flow));
+			diagram.getElements().add(edge);
+		});
+	}
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/AbstractCreateNodeHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/AbstractCreateNodeHandler.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import org.eclipse.emf.ecore.EClass;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ShapeUtil;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowFacade;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationFactory;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeeFactory;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+import com.eclipsesource.modelserver.coffee.model.coffee.Workflow;
+
+public abstract class AbstractCreateNodeHandler implements OperationHandler {
+
+	protected String type;
+	private EClass eClass;
+
+	public AbstractCreateNodeHandler(String type, EClass eClass) {
+		super();
+		this.type = type;
+		this.eClass = eClass;
+	}
+
+	@Override
+	public Class<? extends Action> handlesActionType() {
+		return CreateNodeOperationAction.class;
+	}
+
+	@Override
+	public boolean handles(AbstractOperationAction action) {
+		return OperationHandler.super.handles(action)
+				? ((CreateNodeOperationAction) action).getElementTypeId().equals(type)
+				: false;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Create node";
+	}
+
+	@Override
+	public void execute(AbstractOperationAction action, GraphicalModelState modelState) {
+		CreateNodeOperationAction createNodeOperationAction = (CreateNodeOperationAction) action;
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+		WorkflowFacade workflowFacade = modelAccess.getWorkflowFacade();
+		Workflow workflow = workflowFacade.getCurrentWorkflow();
+
+		Node node = initializeNode((Node) CoffeeFactory.eINSTANCE.create(eClass), modelState);
+		workflow.getNodes().add(node);
+
+		workflowFacade.findDiagram(workflow).ifPresent(diagram -> {
+			Shape shape = WfnotationFactory.eINSTANCE.createShape();
+			shape.setSemanticElement(workflowFacade.createProxy(node));
+			shape.setPosition(ShapeUtil.point(createNodeOperationAction.getLocation()));
+			diagram.getElements().add(shape);
+		});
+	}
+
+	protected Node initializeNode(Node node, GraphicalModelState modelState) {
+		return node;
+	}
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/AbstractCreateTaskHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/AbstractCreateTaskHandler.java
@@ -13,15 +13,32 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import org.eclipse.emf.ecore.EClass;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+import com.eclipsesource.modelserver.coffee.model.coffee.Task;
+import com.google.common.base.Preconditions;
+
+public abstract class AbstractCreateTaskHandler extends AbstractCreateNodeHandler {
+
+	public AbstractCreateTaskHandler(String type, EClass eClass) {
+		super(type, eClass);
+	}
 
 	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public String getLabel(AbstractOperationAction action) {
+		return "Create task";
+	}
+
+	@Override
+	protected Node initializeNode(Node node, GraphicalModelState modelState) {
+		Preconditions.checkArgument(node instanceof Task);
+		((Task) node).setName("NewTask");
+		return node;
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ApplyLabelEditOperationHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ApplyLabelEditOperationHandler.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.EObject;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.ApplyLabelEditOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.graph.GLabel;
+import com.eclipsesource.glsp.graph.GModelElement;
+import com.eclipsesource.glsp.graph.GNode;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+import com.eclipsesource.modelserver.coffee.model.coffee.Task;
+
+public class ApplyLabelEditOperationHandler implements OperationHandler {
+
+	@Override
+	public Class<? extends Action> handlesActionType() {
+		return ApplyLabelEditOperationAction.class;
+	}
+
+	@Override
+	public void execute(AbstractOperationAction action, GraphicalModelState modelState) {
+		ApplyLabelEditOperationAction editLabelAction = (ApplyLabelEditOperationAction) action;
+		Optional<GModelElement> element = modelState.getIndex().get(editLabelAction.getLabelId());
+		if (!element.isPresent() && !(element.get() instanceof GLabel)) {
+			throw new IllegalArgumentException("Element with provided ID cannot be found or is not a GLabel");
+		}
+
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+		GNode gNode = getParentGNode((GLabel) element.get());
+		Node node = modelAccess.getNodeById(gNode.getId());
+		if (!(node instanceof Task)) {
+			throw new IllegalAccessError("Edited label isn't label representing a task");
+		}
+
+		((Task) node).setName(editLabelAction.getText());
+	}
+
+	public GNode getParentGNode(GLabel sLabel) {
+		EObject parent = sLabel;
+		while (!(parent instanceof GNode) || parent == null) {
+			parent = parent.eContainer();
+		}
+		if (!(parent instanceof GNode)) {
+			throw new IllegalArgumentException("Cannot find node parent of label");
+		}
+		return (GNode) parent;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Apply label";
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ChangeBoundsOperationHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ChangeBoundsOperationHandler.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.util.Optional;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.ChangeBoundsOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.api.types.ElementAndBounds;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ShapeUtil;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape;
+import com.eclipsesource.glsp.graph.GBounds;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+
+public class ChangeBoundsOperationHandler implements OperationHandler {
+
+	@Override
+	public Class<? extends Action> handlesActionType() {
+		return ChangeBoundsOperationAction.class;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Move or resize element";
+	}
+
+	@Override
+	public void execute(AbstractOperationAction action, GraphicalModelState modelState) {
+		ChangeBoundsOperationAction changeBoundsAction = (ChangeBoundsOperationAction) action;
+		for (ElementAndBounds element : changeBoundsAction.getNewBounds()) {
+			changeElementBounds(element.getElementId(), element.getNewBounds(), modelState);
+		}
+	}
+
+	private void changeElementBounds(String elementId, GBounds newBounds, GraphicalModelState modelState) {
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+		Node node = modelAccess.getNodeById(elementId);
+		Optional<DiagramElement> element = modelAccess.getWorkflowFacade().findDiagramElement(node);
+		if (element.isEmpty() || !(element.get() instanceof Shape)) {
+			throw new IllegalArgumentException("Could not find shape for node " + elementId);
+		}
+
+		Shape shape = (Shape) element.get();
+		shape.setPosition(ShapeUtil.point(newBounds.getX(), newBounds.getY()));
+		shape.setSize(ShapeUtil.dimension(newBounds.getWidth(), newBounds.getHeight()));
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateAutomatedTaskHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateAutomatedTaskHandler.java
@@ -13,15 +13,15 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeePackage;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class CreateAutomatedTaskHandler extends AbstractCreateTaskHandler {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public CreateAutomatedTaskHandler() {
+		super(ModelTypes.AUTOMATED_TASK, CoffeePackage.Literals.AUTOMATIC_TASK);
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateDecisionNodeHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateDecisionNodeHandler.java
@@ -13,15 +13,15 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeePackage;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class CreateDecisionNodeHandler extends AbstractCreateNodeHandler {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public CreateDecisionNodeHandler() {
+		super(ModelTypes.DECISION_NODE, CoffeePackage.Literals.DECISION);
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateFlowHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateFlowHandler.java
@@ -13,15 +13,15 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.graph.DefaultTypes;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeePackage;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class CreateFlowHandler extends AbstractCreateEdgeHandler {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public CreateFlowHandler() {
+		super(DefaultTypes.EDGE, CoffeePackage.Literals.FLOW);
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateManualTaskHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateManualTaskHandler.java
@@ -13,15 +13,15 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeePackage;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class CreateManualTaskHandler extends AbstractCreateTaskHandler {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public CreateManualTaskHandler() {
+		super(ModelTypes.MANUAL_TASK, CoffeePackage.Literals.MANUAL_TASK);
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateMergeNodeHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateMergeNodeHandler.java
@@ -13,15 +13,15 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeePackage;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class CreateMergeNodeHandler extends AbstractCreateNodeHandler {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public CreateMergeNodeHandler() {
+		super(ModelTypes.MERGE_NODE, CoffeePackage.Literals.MERGE);
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateWeightedFlowHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/CreateWeightedFlowHandler.java
@@ -13,15 +13,15 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
+import com.eclipsesource.modelserver.coffee.model.coffee.CoffeePackage;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class CreateWeightedFlowHandler extends AbstractCreateEdgeHandler {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	public CreateWeightedFlowHandler() {
+		super(ModelTypes.WEIGHTED_EDGE, CoffeePackage.Literals.WEIGHTED_FLOW);
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/DeleteOperationHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/DeleteOperationHandler.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.DeleteOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Shape;
+import com.eclipsesource.glsp.graph.GEdge;
+import com.eclipsesource.glsp.graph.GModelElement;
+import com.eclipsesource.glsp.graph.GNode;
+import com.eclipsesource.modelserver.coffee.model.coffee.Flow;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+
+public class DeleteOperationHandler implements OperationHandler {
+
+	private Set<EObject> toDelete;
+
+	@Override
+	public boolean handles(AbstractOperationAction action) {
+		return action instanceof DeleteOperationAction;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Delete elements";
+	}
+
+	@Override
+	public void execute(AbstractOperationAction action, GraphicalModelState modelState) {
+		DeleteOperationAction deleteAction = (DeleteOperationAction) action;
+		toDelete = new HashSet<>();
+		deleteAction.getElementIds().forEach(id -> collectElementsToDelete(id, modelState));
+		EcoreUtil.deleteAll(toDelete, true);
+	}
+
+	protected void collectElementsToDelete(String id, GraphicalModelState modelState) {
+		Optional<GModelElement> maybeModelElement = modelState.getIndex().get(id);
+		if (maybeModelElement.isEmpty()) {
+			return;
+		}
+
+		GModelElement element = findTopLevelElement(maybeModelElement.get());
+		if (!isNodeOrEdge(element)) {
+			return;
+		}
+
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+		if (element instanceof GNode) {
+			Node node = modelAccess.getNodeById(element.getId());
+			toDelete.add(node);
+
+			Optional<DiagramElement> diagramElement = modelAccess.getWorkflowFacade().findDiagramElement(node);
+			if (!diagramElement.isEmpty() && diagramElement.get() instanceof Shape) {
+				toDelete.add(diagramElement.get());
+			}
+
+			modelState.getIndex().getIncomingEdges(element)
+					.forEach(edge -> collectElementsToDelete(edge.getId(), modelState));
+			modelState.getIndex().getOutgoingEdges(element)
+					.forEach(edge -> collectElementsToDelete(edge.getId(), modelState));
+		} else if (element instanceof GEdge) {
+			GEdge gEdge = (GEdge) element;
+			Node sourceNode = modelAccess.getNodeById(gEdge.getSourceId());
+			Node targetNode = modelAccess.getNodeById(gEdge.getTargetId());
+			Optional<Flow> maybeFlow = modelAccess.getFlow(sourceNode, targetNode);
+			if (maybeFlow.isEmpty()) {
+				return;
+			}
+			toDelete.add(maybeFlow.get());
+
+			Optional<DiagramElement> edge = maybeFlow
+					.flatMap(flow -> modelAccess.getWorkflowFacade().findDiagramElement(flow));
+			if (edge.isEmpty()) {
+				return;
+			}
+			toDelete.add(edge.get());
+		}
+	}
+
+	protected GModelElement findTopLevelElement(GModelElement element) {
+		if (isNodeOrEdge(element)) {
+			return element;
+		}
+
+		GModelElement parent = element.getParent();
+		if (parent == null) {
+			return element;
+		}
+
+		return findTopLevelElement(parent);
+	}
+
+	public boolean isNodeOrEdge(GModelElement element) {
+		return element instanceof GNode || element instanceof GEdge;
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ModelServerAwareOperationActionHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ModelServerAwareOperationActionHandler.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.util.Optional;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.MappedGModelRoot;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerModelFactory;
+import com.eclipsesource.glsp.server.actionhandler.OperationActionHandler;
+import com.google.inject.Inject;
+
+public class ModelServerAwareOperationActionHandler extends OperationActionHandler {
+
+	@Inject
+	private OperationHandlerProvider operationHandlerProvider;
+
+	@Override
+	public Optional<Action> doHandle(AbstractOperationAction action, GraphicalModelState modelState) {
+		if (operationHandlerProvider.isHandled(action)) {
+			OperationHandler handler = operationHandlerProvider.getHandler(action).get();
+			handler.execute(action, modelState);
+			WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+			// FIXME ugly: this method writes into the parameter modelState rather than
+			// returning it only
+			MappedGModelRoot mappedGModelRoot = WorkflowModelServerModelFactory
+					.populate(modelAccess.getWorkflowFacade(), modelState);
+			modelAccess.setNodeMapping(mappedGModelRoot.getMapping());
+			return Optional.of(new RequestBoundsAction(modelState.getRoot()));
+		}
+		return Optional.empty();
+	}
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ModelServerAwareSaveActionHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ModelServerAwareSaveActionHandler.java
@@ -1,0 +1,42 @@
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.log4j.Logger;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.SaveModelAction;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.server.actionhandler.AbstractActionHandler;
+
+public class ModelServerAwareSaveActionHandler extends AbstractActionHandler {
+
+	private static final Logger LOG = Logger.getLogger(ModelServerAwareSaveActionHandler.class);
+
+	@Override
+	public boolean handles(Action action) {
+		return action instanceof SaveModelAction;
+	}
+
+	@Override
+	protected Optional<Action> execute(Action action, GraphicalModelState modelState) {
+		if (action instanceof SaveModelAction) {
+			SaveModelAction saveAction = (SaveModelAction) action;
+			if (saveAction != null) {
+				saveModelState(modelState);
+			}
+		}
+		return Optional.empty();
+	}
+
+	private void saveModelState(GraphicalModelState modelState) {
+		try {
+			ModelServerAwareModelState.getModelAccess(modelState).save();
+		} catch (IOException e) {
+			LOG.error("Error saving the model", e);
+		}
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ReconnectFlowHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/ReconnectFlowHandler.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.util.Optional;
+
+import com.eclipsesource.glsp.api.action.Action;
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.ReconnectConnectionOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.graph.GEdge;
+import com.eclipsesource.glsp.graph.GModelElement;
+import com.eclipsesource.modelserver.coffee.model.coffee.Flow;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+
+public class ReconnectFlowHandler implements OperationHandler {
+
+	@Override
+	public Class<? extends Action> handlesActionType() {
+		return ReconnectConnectionOperationAction.class;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Reconnect flow";
+	}
+
+	@Override
+	public void execute(AbstractOperationAction action, GraphicalModelState modelState) {
+		ReconnectConnectionOperationAction reconnectAction = (ReconnectConnectionOperationAction) action;
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+
+		Optional<GModelElement> maybeEdge = modelState.getIndex().get(reconnectAction.getConnectionElementId());
+		if (maybeEdge.isEmpty() && !(maybeEdge.get() instanceof GEdge)) {
+			throw new IllegalArgumentException();
+		}
+
+		GEdge oldEdge = (GEdge) maybeEdge.get();
+		Node oldSourceNode = modelAccess.getNodeById(oldEdge.getSourceId());
+		Node oldTargetNode = modelAccess.getNodeById(oldEdge.getTargetId());
+
+		Node newSourceNode = modelAccess.getNodeById(reconnectAction.getSourceElementId());
+		Node newTargetNode = modelAccess.getNodeById(reconnectAction.getTargetElementId());
+
+		Optional<Flow> maybeFlow = modelAccess.getFlow(oldSourceNode, oldTargetNode);
+		if (maybeFlow.isEmpty()) {
+			throw new IllegalArgumentException();
+		}
+
+		maybeFlow.get().setSource(newSourceNode);
+		maybeFlow.get().setTarget(newTargetNode);
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/RerouteEdgeHandler.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/handler/RerouteEdgeHandler.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.example.modelserver.workflow.handler;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.eclipsesource.glsp.api.action.kind.AbstractOperationAction;
+import com.eclipsesource.glsp.api.action.kind.RerouteConnectionOperationAction;
+import com.eclipsesource.glsp.api.handler.OperationHandler;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ModelServerAwareModelState;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.ShapeUtil;
+import com.eclipsesource.glsp.example.modelserver.workflow.model.WorkflowModelServerAccess;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.DiagramElement;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Edge;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point;
+import com.eclipsesource.glsp.graph.GEdge;
+import com.eclipsesource.glsp.graph.GModelIndex;
+import com.eclipsesource.modelserver.coffee.model.coffee.Flow;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
+
+public class RerouteEdgeHandler implements OperationHandler {
+
+	@Override
+	public Class<?> handlesActionType() {
+		return RerouteConnectionOperationAction.class;
+	}
+
+	@Override
+	public String getLabel(AbstractOperationAction action) {
+		return "Reconnect edge";
+	}
+
+	@Override
+	public void execute(AbstractOperationAction operationAction, GraphicalModelState modelState) {
+		if (!(operationAction instanceof RerouteConnectionOperationAction)) {
+			throw new IllegalArgumentException("Unexpected action " + operationAction);
+		}
+
+		// check for null-values
+		final RerouteConnectionOperationAction action = (RerouteConnectionOperationAction) operationAction;
+		if (action.getConnectionElementId() == null || action.getRoutingPoints() == null) {
+			throw new IllegalArgumentException("Incomplete reconnect connection action");
+		}
+
+		// check for existence of matching elements
+		GModelIndex index = modelState.getIndex();
+		Optional<GEdge> gEdge = index.findElementByClass(action.getConnectionElementId(), GEdge.class);
+		if (!gEdge.isPresent()) {
+			throw new IllegalArgumentException("Invalid edge: edge ID " + action.getConnectionElementId());
+		}
+
+		// reroute
+		WorkflowModelServerAccess modelAccess = ModelServerAwareModelState.getModelAccess(modelState);
+		Node sourceNode = modelAccess.getNodeById(gEdge.get().getSourceId());
+		Node targetNode = modelAccess.getNodeById(gEdge.get().getTargetId());
+		Optional<Flow> flow = modelAccess.getFlow(sourceNode, targetNode);
+		Optional<DiagramElement> maybeEdge = flow.flatMap(f -> modelAccess.getWorkflowFacade().findDiagramElement(f));
+		if (maybeEdge.isEmpty() || !(maybeEdge.get() instanceof Edge)) {
+			throw new IllegalArgumentException("Cannot find edge for GEdge ID " + action.getConnectionElementId());
+		}
+
+		Edge edge2 = (Edge) maybeEdge.get();
+		List<Point> bendPoints = action.getRoutingPoints().stream().map(ShapeUtil::point).collect(Collectors.toList());
+		edge2.getBendPoints().clear();
+		edge2.getBendPoints().addAll(bendPoints);
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/MappedGModelRoot.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/MappedGModelRoot.java
@@ -13,15 +13,31 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.model;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import java.util.Map;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+import com.eclipsesource.glsp.graph.GModelRoot;
+import com.eclipsesource.glsp.graph.GNode;
+import com.eclipsesource.modelserver.coffee.model.coffee.Node;
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+public class MappedGModelRoot {
+
+	private GModelRoot root;
+	private Map<Node, GNode> mapping;
+
+	public MappedGModelRoot(GModelRoot root, Map<Node, GNode> mapping) {
+		super();
+		this.root = root;
+		this.mapping = mapping;
+	}
+
+	public Map<Node, GNode> getMapping() {
+		return mapping;
+	}
+
+	public GModelRoot getRoot() {
+		return root;
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/ModelServerAwareModelState.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/ModelServerAwareModelState.java
@@ -13,15 +13,28 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.model;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.server.model.ModelStateImpl;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
+public class ModelServerAwareModelState extends ModelStateImpl {
 
-	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	private WorkflowModelServerAccess modelAccess;
+
+	public static WorkflowModelServerAccess getModelAccess(GraphicalModelState state) {
+		if (!(state instanceof ModelServerAwareModelState)) {
+			throw new IllegalArgumentException("Argument must be a ModelServerAwareModelState");
+		}
+		return ((ModelServerAwareModelState) state).getModelAccess();
+	}
+
+	public void setModelAccess(WorkflowModelServerAccess modelAccess) {
+		this.modelAccess = modelAccess;
+	}
+
+	public WorkflowModelServerAccess getModelAccess() {
+		return modelAccess;
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/ModelServerAwareModelStateProvider.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/ModelServerAwareModelStateProvider.java
@@ -13,15 +13,16 @@
  *  
  *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ******************************************************************************/
-package com.eclipsesource.glsp.example.modelserver.workflow;
+package com.eclipsesource.glsp.example.modelserver.workflow.model;
 
-import com.eclipsesource.glsp.example.workflow.WorfklowDiagramConfiguration;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.server.model.DefaultModelStateProvider;
+import com.google.inject.Singleton;
 
-public class WorfklowDiagramNotationConfiguration extends WorfklowDiagramConfiguration {
-
+@Singleton
+public class ModelServerAwareModelStateProvider extends DefaultModelStateProvider {
 	@Override
-	public String getDiagramType() {
-		return "workflow-diagram-notation";
+	protected GraphicalModelState createModelState() {
+		return new ModelServerAwareModelState();
 	}
-
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/ShapeUtil.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/ShapeUtil.java
@@ -1,0 +1,31 @@
+package com.eclipsesource.glsp.example.modelserver.workflow.model;
+
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Dimension;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.Point;
+import com.eclipsesource.glsp.example.modelserver.workflow.wfnotation.WfnotationFactory;
+import com.eclipsesource.glsp.graph.GPoint;
+
+public class ShapeUtil {
+
+	public static Point point(GPoint location) {
+		Point point = WfnotationFactory.eINSTANCE.createPoint();
+		point.setX(location.getX());
+		point.setY(location.getY());
+		return point;
+	}
+
+	public static Point point(double x, double y) {
+		Point point = WfnotationFactory.eINSTANCE.createPoint();
+		point.setX(x);
+		point.setY(y);
+		return point;
+	}
+
+	public static Dimension dimension(double width, double height) {
+		Dimension dimension = WfnotationFactory.eINSTANCE.createDimension();
+		dimension.setWidth(width);
+		dimension.setHeight(height);
+		return dimension;
+	}
+
+}

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowFacade.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowFacade.java
@@ -35,16 +35,25 @@ import com.eclipsesource.modelserver.coffee.model.coffee.Workflow;
 
 public class WorkflowFacade {
 
-	private Resource coffeeResource;
+	private Resource semanticResource;
 	private Resource notationResource;
+	private Workflow currentWorkflow;
 
 	public WorkflowFacade(Resource coffeeResource, Resource notationResource) {
-		this.coffeeResource = coffeeResource;
+		this.semanticResource = coffeeResource;
 		this.notationResource = notationResource;
 	}
 
+	public Resource getSemanticResource() {
+		return semanticResource;
+	}
+
+	public Resource getNotationResource() {
+		return notationResource;
+	}
+
 	public Optional<Machine> getMachine() {
-		EObject content = this.coffeeResource.getContents().get(0);
+		EObject content = this.semanticResource.getContents().get(0);
 		return content instanceof Machine ? Optional.of((Machine) content) : Optional.empty();
 	}
 
@@ -84,7 +93,7 @@ public class WorkflowFacade {
 	public SemanticProxy createProxy(EObject eObject) {
 		SemanticProxy proxy = WfnotationFactory.eINSTANCE.createSemanticProxy();
 		proxy.setResolvedElement(eObject);
-		proxy.setUri(coffeeResource.getURIFragment(eObject));
+		proxy.setUri(semanticResource.getURIFragment(eObject));
 		return proxy;
 	}
 
@@ -102,7 +111,7 @@ public class WorkflowFacade {
 	}
 
 	public SemanticProxy reResolved(SemanticProxy proxy) {
-		proxy.setResolvedElement(coffeeResource.getEObject(proxy.getUri()));
+		proxy.setResolvedElement(semanticResource.getEObject(proxy.getUri()));
 		return proxy;
 	}
 
@@ -152,6 +161,17 @@ public class WorkflowFacade {
 
 	public boolean isDiagramForWorkflow(EObject diagram, Workflow workflow) {
 		return diagram instanceof Diagram && isDiagramElementForSemanticElement((Diagram) diagram, workflow);
+	}
+
+	public void setCurrentWorkflowIndex(int workflowIndex) {
+		if (workflowIndex < 0 || getMachine().isEmpty() || workflowIndex >= getMachine().get().getWorkflows().size()) {
+			return;
+		}
+		currentWorkflow = getMachine().get().getWorkflows().get(workflowIndex);
+	}
+
+	public Workflow getCurrentWorkflow() {
+		return currentWorkflow;
 	}
 
 	private static <T> T safeCast(Object obj, Class<T> clazz) {

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/GModelChangeNotifier.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/GModelChangeNotifier.java
@@ -28,7 +28,7 @@ public interface GModelChangeNotifier {
 		EObject root = EcoreUtil.getRootContainer(element);
 		GModelChangeNotifier existingNotifier = (GModelChangeNotifierImpl) EcoreUtil.getExistingAdapter(root,
 				GModelChangeNotifierImpl.class);
-		return Optional.ofNullable(existingNotifier).orElseGet(() -> (create(element)));
+		return Optional.ofNullable(existingNotifier).orElseGet(() -> create(element));
 	}
 
 	public static GModelChangeNotifier create(GModelElement element) {

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/GModelIndex.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/GModelIndex.java
@@ -157,4 +157,6 @@ public interface GModelIndex {
 		return Stream.concat(Stream.of(element), element.getChildren().stream());
 	}
 
+	int getTypeCount(EClass eClass);
+
 }

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/impl/GModelIndexImpl.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/impl/GModelIndexImpl.java
@@ -137,6 +137,7 @@ public class GModelIndexImpl extends ECrossReferenceAdapter implements GModelInd
 		return i;
 	}
 
+	@Override
 	public int getTypeCount(EClass eClass) {
 		return typeToElements.computeIfAbsent(eClass, t -> new HashSet<>()).size();
 	}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/DefaultModelStateProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/model/DefaultModelStateProvider.java
@@ -39,9 +39,13 @@ public class DefaultModelStateProvider implements ModelStateProvider {
 
 	@Override
 	public GraphicalModelState create(String clientId) {
-		GraphicalModelState modelState = new ModelStateImpl();
+		GraphicalModelState modelState = createModelState();
 		clientModelStates.put(clientId, modelState);
 		return modelState;
+	}
+
+	protected GraphicalModelState createModelState() {
+		return new ModelStateImpl();
 	}
 
 	@Override

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/util/GModelUtil.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/util/GModelUtil.java
@@ -26,6 +26,7 @@ import com.eclipsesource.glsp.graph.GNode;
 import com.eclipsesource.glsp.graph.GPort;
 
 public class GModelUtil {
+	
 	public static Function<Integer, String> idAndIndex(String id) {
 		return i -> id + i;
 	}


### PR DESCRIPTION
This change enhances the example server for dealing with EMF XMI models
directly by introducing handlers that read from and directly modify the
EMF resources. After each change, the graph factory is retriggered so
that a new GModel is generated out of the EMF resources to reflect the
applied changes.

With this strategy, we avoid a bidirectional synchronization between EMF
models and GModel but rather create a circle in which we translate the
EMF resources into a GModel and handlers only translate changes applied
in the editor to the underlying EMF models directly, which again can be
re-translated into a GModel with the same factory as above.

The access to the EMF models is provided via a model access that is kept
in a specialized graphical model state to avoid reloading the resources
again and again. Once hooked up with the model server, this model access
can be the sole point of communication with the model server.