### PR TITLE
Fix stamp mode for creating connections

### DIFF
--- a/client/packages/sprotty-client/src/features/tools/creation-tool.ts
+++ b/client/packages/sprotty-client/src/features/tools/creation-tool.ts
@@ -173,7 +173,9 @@ export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
     private reinitialize() {
         this.source = undefined;
         this.target = undefined;
-        this.tool.dispatchFeedback([new ApplyCursorCSSFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED)]);
+        this.currentTarget = undefined;
+        this.allowedTarget = false;
+        this.tool.dispatchFeedback([new RemoveFeedbackEdgeAction()]);
     }
 
     nonDraggingMouseUp(element: SModelElement, event: MouseEvent): Action[] {


### PR DESCRIPTION
The issue was caused by the animation framework accessing the parent of the feedback edge's parent, which didn't exist anymore. Therefore, we now make sure that we remove the feedback edge accordingly after the successful creation of an edge in stamp mode.

Resolves #314