### PR TITLE
Ensure that notation initialization reuses existing diagrams

### DIFF
--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowFacade.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowFacade.java
@@ -58,9 +58,16 @@ public class WorkflowFacade {
 	}
 
 	public Diagram initializeNotation(Workflow workflow) {
+		Optional<Diagram> existingDiagram = findDiagram(workflow);
+		Diagram diagram = existingDiagram.isPresent() ? existingDiagram.get() : createDiagram(workflow);
+		return initializeMissing(diagram);
+	}
+
+	private Diagram createDiagram(Workflow workflow) {
 		Diagram diagram = WfnotationFactory.eINSTANCE.createDiagram();
 		diagram.setSemanticElement(createProxy(workflow));
-		return initializeMissing(diagram);
+		notationResource.getContents().add(diagram);
+		return diagram;
 	}
 
 	public Diagram initializeMissing(Diagram diagram) {


### PR DESCRIPTION
This change ensures that `WorkflowFacace.initializeNotation()` reuses diagrams that already exist in the notation resource instead of creating new ones.
If a new diagram is created at runtime it`s also added to the notation resource.

This ensures that the GLSP server also can handle and process empty notation files accordingly