### PR TITLE
Add label provider for workflow diagrams

### DIFF
--- a/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-diagram-label-provider-contribution.ts
+++ b/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-diagram-label-provider-contribution.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { LabelProviderContribution } from "@theia/core/lib/browser";
+import { FileStat } from "@theia/filesystem/lib/common";
+import URI from "@theia/core/lib/common/uri";
+import { MaybePromise } from "@theia/core";
+import { injectable } from "inversify";
+import { WorkflowNotationLanguage } from "../../common/workflow-language";
+
+@injectable()
+export class WorkflowDiagramLabelProviderContribution implements LabelProviderContribution {
+    canHandle(uri: object): number {
+        let toCheck = uri;
+        if (FileStat.is(toCheck)) {
+          toCheck = new URI(toCheck.uri);
+        }
+        if (toCheck instanceof URI) {
+            if (toCheck.path.ext === WorkflowNotationLanguage.FileExtension) {
+              return 1000;
+            }
+        }
+        return 0;
+    }
+
+    getIcon(): MaybePromise<string> {
+        return 'fa fa-project-diagram';
+    }
+
+    getName(uri: URI): string {
+        return uri.displayName;
+    }
+
+    getLongName(uri: URI): string {
+        return uri.path.toString();
+    }
+}

--- a/client/examples/workflow/workflow-modelserver-theia/src/browser/frontend-module.ts
+++ b/client/examples/workflow/workflow-modelserver-theia/src/browser/frontend-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GLSPClientContribution } from "@glsp/theia-integration/lib/browser";
-import { FrontendApplicationContribution, OpenHandler, WidgetFactory } from "@theia/core/lib/browser";
+import { FrontendApplicationContribution, OpenHandler, WidgetFactory, LabelProviderContribution } from "@theia/core/lib/browser";
 import { ContainerModule, interfaces } from "inversify";
 import { DiagramConfiguration, DiagramManager, DiagramManagerProvider } from "sprotty-theia/lib";
 
@@ -22,6 +22,7 @@ import { WorkflowDiagramConfiguration } from "./diagram/workflow-diagram-configu
 import { WorkflowDiagramManager } from "./diagram/workflow-diagram-manager";
 import { WorkflowGLSPDiagramClient } from "./diagram/workflow-glsp-diagram-client";
 import { WorkflowGLSPClientContribution } from "./language/workflow-glsp-client-contribution";
+import { WorkflowDiagramLabelProviderContribution } from "./diagram/workflow-diagram-label-provider-contribution";
 
 
 
@@ -44,5 +45,6 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
             });
         };
     });
+    bind(LabelProviderContribution).to(WorkflowDiagramLabelProviderContribution);
 
 });


### PR DESCRIPTION
This unifies the icons of workflow diagrams in the editor tab and the file explorer (part of https://github.com/eclipsesource/coffee-editor/issues/122).