### PR TITLE
Provide more flexibility in sending options to the server during open

### DIFF
--- a/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-diagram-manager.ts
+++ b/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-diagram-manager.ts
@@ -52,22 +52,22 @@ export class WorkflowDiagramManager extends GLSPDiagramManager {
         };
     }
 
-    protected createServerOptions(options?: WidgetOpenerOptions) {
+    protected createServerOptions(options?: WidgetOpenerOptions): Object {
         if (WorkflowGLSPServerOpenerOptions.is(options)) {
             return options.serverOptions;
         }
-        return {};
+        return <Object>{};
     }
 
-    protected createQueryOptions(uri: URI) {
-        const queryOptions = {};
+    protected createQueryOptions(uri: URI): Object {
+        const queryOptions = <Object>{};
         if (!uri.query || uri.query.indexOf("=") < 0) {
             return queryOptions;
         }
         const keyValuePairs = uri.query.split("&");
         for (const keyValuePair of keyValuePairs) {
             const keyValue = keyValuePair.split("=");
-            queryOptions[keyValue[0]] = keyValue[1];
+            (<any>queryOptions)[keyValue[0]] = keyValue[1];
         }
         return queryOptions;
     }

--- a/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-diagram-manager.ts
+++ b/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-diagram-manager.ts
@@ -14,13 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GLSPDiagramManager, GLSPTheiaSprottyConnector } from "@glsp/theia-integration/lib/browser";
-import { WidgetManager } from "@theia/core/lib/browser";
+import { WidgetManager, WidgetOpenerOptions } from "@theia/core/lib/browser";
+import URI from "@theia/core/lib/common/uri";
 import { EditorManager } from "@theia/editor/lib/browser";
 import { inject, injectable } from "inversify";
 import { TheiaFileSaver } from "sprotty-theia/lib";
 
 import { WorkflowNotationLanguage } from "../../common/workflow-language";
 import { WorkflowGLSPDiagramClient } from "./workflow-glsp-diagram-client";
+import { WorkflowGLSPServerOpenerOptions } from "./workflow-glsp-server-options";
 
 @injectable()
 export class WorkflowDiagramManager extends GLSPDiagramManager {
@@ -37,6 +39,37 @@ export class WorkflowDiagramManager extends GLSPDiagramManager {
         @inject(EditorManager) editorManager: EditorManager) {
         super();
         this._diagramConnector = new GLSPTheiaSprottyConnector({ diagramClient, fileSaver, editorManager, widgetManager, diagramManager: this });
+    }
+
+    protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): Object {
+        const widgetOptions = super.createWidgetOptions(uri.withoutQuery(), options);
+        const queryOptions = this.createQueryOptions(uri);
+        const serverOptions = this.createServerOptions(options);
+        return {
+            ...widgetOptions,
+            ...queryOptions,
+            ...serverOptions,
+        };
+    }
+
+    protected createServerOptions(options?: WidgetOpenerOptions) {
+        if (WorkflowGLSPServerOpenerOptions.is(options)) {
+            return options.serverOptions;
+        }
+        return {};
+    }
+
+    protected createQueryOptions(uri: URI) {
+        const queryOptions = {};
+        if (!uri.query || uri.query.indexOf("=") < 0) {
+            return queryOptions;
+        }
+        const keyValuePairs = uri.query.split("&");
+        for (const keyValuePair of keyValuePairs) {
+            const keyValue = keyValuePair.split("=");
+            queryOptions[keyValue[0]] = keyValue[1];
+        }
+        return queryOptions;
     }
 
     get fileExtensions() {

--- a/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-glsp-server-options.ts
+++ b/client/examples/workflow/workflow-modelserver-theia/src/browser/diagram/workflow-glsp-server-options.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { OpenerOptions } from "@theia/core/lib/browser";
+
+
+export interface WorkflowGLSPServerOpenerOptions extends OpenerOptions {
+    serverOptions: any;
+}
+
+export namespace WorkflowGLSPServerOpenerOptions {
+    export function is(options: any): options is WorkflowGLSPServerOpenerOptions {
+        return options && options.serverOptions;
+    }
+}

--- a/client/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -63,7 +63,7 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
 
         this.actionDispatcher.dispatch(new RequestModelAction({
             sourceUri: this.options.uri,
-            diagramType: this.options.diagramType
+            ...this.options
         }));
         this.actionDispatcher.dispatch(new RequestOperationsAction());
         this.actionDispatcher.dispatch(new RequestTypeHintsAction(this.options.diagramType));


### PR DESCRIPTION
- Send all available options with the RequestModelAction
- Allow options to be sent to server using 'serverOptions'
- Allow options to be sent as key-value pairs in the uri query string