### PR TITLE
Fixes #333: Support SET command for renaming tasks

### DIFF
--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/WorkflowModelServerGLSPModule.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/WorkflowModelServerGLSPModule.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+
 import com.eclipsesource.glsp.api.diagram.DiagramConfiguration;
 import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.handler.ActionHandler;
@@ -44,6 +47,8 @@ import com.eclipsesource.glsp.example.workflow.WorkflowGLSPModule;
 import com.eclipsesource.glsp.server.actionhandler.OperationActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.SaveModelActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.UndoRedoActionHandler;
+import com.eclipsesource.modelserver.edit.CommandCodec;
+import com.eclipsesource.modelserver.edit.DefaultCommandCodec;
 
 @SuppressWarnings("serial")
 public class WorkflowModelServerGLSPModule extends WorkflowGLSPModule {
@@ -99,6 +104,13 @@ public class WorkflowModelServerGLSPModule extends WorkflowGLSPModule {
 	@Override
 	protected Collection<Class<? extends DiagramConfiguration>> bindDiagramConfigurations() {
 		return Arrays.asList(WorfklowDiagramNotationConfiguration.class);
+	}
+	
+	@Override
+	protected void configure() {
+		super.configure();
+		bind(AdapterFactory.class).toInstance(new ComposedAdapterFactory());
+		bind(CommandCodec.class).toInstance(new DefaultCommandCodec());
 	}
 
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerModelFactory.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerModelFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
+import org.eclipse.emf.common.notify.AdapterFactory;
 
 import com.eclipsesource.glsp.api.action.ActionDispatcher;
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
@@ -49,6 +50,7 @@ import com.eclipsesource.modelserver.coffee.model.coffee.Node;
 import com.eclipsesource.modelserver.coffee.model.coffee.Task;
 import com.eclipsesource.modelserver.coffee.model.coffee.WeightedFlow;
 import com.eclipsesource.modelserver.coffee.model.coffee.Workflow;
+import com.eclipsesource.modelserver.edit.CommandCodec;
 import com.google.inject.Inject;
 
 public class WorkflowModelServerModelFactory implements ModelFactory {
@@ -59,8 +61,15 @@ public class WorkflowModelServerModelFactory implements ModelFactory {
 
 	@Inject
 	private ModelServerClientProvider modelServerClientProvider;
+
 	@Inject
 	private ActionDispatcher actionDispatcher;
+
+	@Inject
+	private AdapterFactory adapterFactory;
+
+	@Inject
+	private CommandCodec commandCodec;
 
 	@Override
 	public GModelRoot loadModel(RequestModelAction action, GraphicalModelState modelState) {
@@ -76,7 +85,8 @@ public class WorkflowModelServerModelFactory implements ModelFactory {
 			return createEmptyRoot();
 		}
 
-		WorkflowModelServerAccess modelAccess = new WorkflowModelServerAccess(sourceURI.get(), modelServerClient.get());
+		WorkflowModelServerAccess modelAccess = new WorkflowModelServerAccess(sourceURI.get(), modelServerClient.get(),
+				adapterFactory, commandCodec);
 		modelAccess.subscribe(new WorkflowSubscriptionListener(modelState, modelAccess, actionDispatcher));
 
 		if (modelState instanceof ModelServerAwareModelState) {


### PR DESCRIPTION
- Provide dedicated operation handler that provides model access
- Adapt label edit to send SET command to model server for task rename
- Execute any command received from model server on local model