### PR TITLE
Resolves #341 Refactor ActionDispatcher

### DIFF
--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerModelFactory.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerModelFactory.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.AdapterFactory;
 
-import com.eclipsesource.glsp.api.action.ActionDispatcher;
+import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.action.kind.RequestModelAction;
 import com.eclipsesource.glsp.api.factory.ModelFactory;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
@@ -63,7 +63,7 @@ public class WorkflowModelServerModelFactory implements ModelFactory {
 	private ModelServerClientProvider modelServerClientProvider;
 
 	@Inject
-	private ActionDispatcher actionDispatcher;
+	private ActionProcessor actionProcessor;
 
 	@Inject
 	private AdapterFactory adapterFactory;
@@ -87,7 +87,7 @@ public class WorkflowModelServerModelFactory implements ModelFactory {
 
 		WorkflowModelServerAccess modelAccess = new WorkflowModelServerAccess(sourceURI.get(), modelServerClient.get(),
 				adapterFactory, commandCodec);
-		modelAccess.subscribe(new WorkflowSubscriptionListener(modelState, modelAccess, actionDispatcher));
+		modelAccess.subscribe(new WorkflowSubscriptionListener(modelState, modelAccess, actionProcessor));
 
 		if (modelState instanceof ModelServerAwareModelState) {
 			((ModelServerAwareModelState) modelState).setModelAccess(modelAccess);

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowSubscriptionListener.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowSubscriptionListener.java
@@ -30,7 +30,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.jetbrains.annotations.NotNull;
 
-import com.eclipsesource.glsp.api.action.ActionDispatcher;
+import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
 import com.eclipsesource.glsp.api.action.kind.ServerStatusAction;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
@@ -49,13 +49,13 @@ import com.google.common.collect.Lists;
 public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListener {
 	private static final String TEMP_COMMAND_RESOURCE_URI = "command$1.command";
 	private static Logger LOG = Logger.getLogger(WorkflowSubscriptionListener.class);
-	private ActionDispatcher actionDispatcher;
+	private ActionProcessor actionProcessor;
 	private WorkflowModelServerAccess modelServerAccess;
 	private GraphicalModelState modelState;
 
 	public WorkflowSubscriptionListener(GraphicalModelState modelState, WorkflowModelServerAccess modelServerAccess,
-			ActionDispatcher actionDispatcher) {
-		this.actionDispatcher = actionDispatcher;
+			ActionProcessor actionProcessor) {
+		this.actionProcessor = actionProcessor;
 		this.modelServerAccess = modelServerAccess;
 		this.modelState = modelState;
 	}
@@ -113,7 +113,7 @@ public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListen
 		MappedGModelRoot mappedGModelRoot = WorkflowModelServerModelFactory
 				.populate(modelServerAccess.getWorkflowFacade(), modelState);
 		modelServerAccess.setNodeMapping(mappedGModelRoot.getMapping());
-		actionDispatcher.send(modelState.getClientId(), new RequestBoundsAction(modelState.getRoot()));
+		actionProcessor.send(modelState.getClientId(), new RequestBoundsAction(modelState.getRoot()));
 	}
 
 	private Resource createCommandResource(EditingDomain domain, CCommand command) {
@@ -143,7 +143,7 @@ public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListen
 	@Override
 	public void onError(Optional<String> message) {
 		String errorMsg = message.orElse("Error occurred on model server!");
-		actionDispatcher.send(modelState.getClientId(), new ServerStatusAction(new ServerStatus(Severity.ERROR, errorMsg)));
+		actionProcessor.send(modelState.getClientId(), new ServerStatusAction(new ServerStatus(Severity.ERROR, errorMsg)));
 		LOG.error(errorMsg);
 	}
 	
@@ -155,7 +155,7 @@ public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListen
 	@Override
 	public void onFailure(Throwable t) {
 		String errorMsg = "Subscribtion connection to modelserver failed!";
-		actionDispatcher.send(modelState.getClientId(),
+		actionProcessor.send(modelState.getClientId(),
 				new ServerStatusAction(new ServerStatus(Severity.ERROR, errorMsg, getDetails(t))));
 		LOG.error(errorMsg, t);
 	}
@@ -167,7 +167,7 @@ public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListen
 	@Override
 	public void onClosed(int code, @NotNull String reason) {
 		String errorMsg = "Subscribtion connection to modelserver has been closed!";
-		actionDispatcher.send(modelState.getClientId(),
+		actionProcessor.send(modelState.getClientId(),
 				new ServerStatusAction(new ServerStatus(Severity.ERROR, errorMsg, reason)));
 		LOG.error(errorMsg + "\n" + reason);
 	}
@@ -175,7 +175,7 @@ public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListen
 	@Override
 	public void onFailure(Throwable t, Response<String> response) {
 		String errorMsg = "Subscribtion connection to modelserver failed:" + "\n" + response;
-		actionDispatcher.send(modelState.getClientId(),
+		actionProcessor.send(modelState.getClientId(),
 				new ServerStatusAction(new ServerStatus(Severity.ERROR, errorMsg, getDetails(t))));
 		LOG.error(errorMsg, t);
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -17,7 +17,7 @@ package com.eclipsesource.glsp.api.di;
 
 import java.util.Optional;
 
-import com.eclipsesource.glsp.api.action.ActionDispatcher;
+import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.configuration.ServerConfiguration;
 import com.eclipsesource.glsp.api.diagram.DiagramConfigurationProvider;
 import com.eclipsesource.glsp.api.factory.GraphGsonConfiguratorFactory;
@@ -58,7 +58,7 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(ServerCommandHandlerProvider.class).to(bindServerCommandHandlerProvider());
 		bind(CommandPaletteActionProvider.class).to(bindCommandPaletteActionProvider());
 		bind(ModelValidator.class).to(bindModelValidator());
-		bind(ActionDispatcher.class).to(bindActionDispatcher());
+		bind(ActionProcessor.class).to(bindActionProcessor());
 		bind(DiagramConfigurationProvider.class).to(bindDiagramConfigurationProvider());
 		bind(LabelEditValidator.class).to(bindLabelEditValidator());
 		bind(ModelStateProvider.class).to(bindModelStateProvider());
@@ -126,8 +126,8 @@ public abstract class GLSPModule extends AbstractModule {
 		return ModelValidator.NullImpl.class;
 	}
 
-	protected Class<? extends ActionDispatcher> bindActionDispatcher() {
-		return ActionDispatcher.NullImpl.class;
+	protected Class<? extends ActionProcessor> bindActionProcessor() {
+		return ActionProcessor.NullImpl.class;
 	}
 
 	protected Class<? extends LabelEditValidator> bindLabelEditValidator() {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/DIActionProcessor.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/DIActionProcessor.java
@@ -18,7 +18,7 @@ package com.eclipsesource.glsp.server.actionhandler;
 import java.util.Optional;
 
 import com.eclipsesource.glsp.api.action.Action;
-import com.eclipsesource.glsp.api.action.ActionDispatcher;
+import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.action.ActionMessage;
 import com.eclipsesource.glsp.api.handler.ActionHandler;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPClient;
@@ -26,7 +26,7 @@ import com.eclipsesource.glsp.api.jsonrpc.GLSPClientProvider;
 import com.eclipsesource.glsp.api.provider.ActionHandlerProvider;
 import com.google.inject.Inject;
 
-public class DIActionDispatcher implements ActionDispatcher {
+public class DIActionProcessor implements ActionProcessor {
 
 	@Inject
 	protected GLSPClientProvider clientProvider;

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
@@ -18,7 +18,7 @@ package com.eclipsesource.glsp.server.di;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.eclipsesource.glsp.api.action.ActionDispatcher;
+import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.di.GLSPModule;
 import com.eclipsesource.glsp.api.diagram.DiagramConfiguration;
 import com.eclipsesource.glsp.api.diagram.DiagramConfigurationProvider;
@@ -36,7 +36,7 @@ import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
 import com.eclipsesource.glsp.api.provider.ServerCommandHandlerProvider;
 import com.eclipsesource.glsp.server.actionhandler.CollapseExpandActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.ComputedBoundsActionHandler;
-import com.eclipsesource.glsp.server.actionhandler.DIActionDispatcher;
+import com.eclipsesource.glsp.server.actionhandler.DIActionProcessor;
 import com.eclipsesource.glsp.server.actionhandler.ExecuteServerCommandActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.LayoutActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.OpenActionHandler;
@@ -149,8 +149,8 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 	}
 
 	@Override
-	protected Class<? extends ActionDispatcher> bindActionDispatcher() {
-		return DIActionDispatcher.class;
+	protected Class<? extends ActionProcessor> bindActionProcessor() {
+		return DIActionProcessor.class;
 	}
 	
 	@Override


### PR DESCRIPTION
Resolve #341 
* Rename `ActionDispatcher` to `ActionProcessor`
* Introduce `process` Method that dispatches to the corresponding action handler and sends the response to the client
* Remove redundant code from `DefaultGLSPServer`