### PR TITLE
Pass model state to command palette action provider

### DIFF
--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowCommandPaletteActionProvider.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowCommandPaletteActionProvider.java
@@ -25,13 +25,13 @@ import java.util.Set;
 import com.eclipsesource.glsp.api.action.kind.CreateConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
 import com.eclipsesource.glsp.api.action.kind.DeleteOperationAction;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.provider.CommandPaletteActionProvider;
 import com.eclipsesource.glsp.api.types.LabeledAction;
 import com.eclipsesource.glsp.example.workflow.utils.ModelTypes;
 import com.eclipsesource.glsp.example.workflow.wfgraph.TaskNode;
 import com.eclipsesource.glsp.graph.GModelElement;
 import com.eclipsesource.glsp.graph.GModelIndex;
-import com.eclipsesource.glsp.graph.GModelRoot;
 import com.eclipsesource.glsp.graph.GNode;
 import com.google.common.collect.Sets;
 
@@ -49,10 +49,10 @@ public class WorkflowCommandPaletteActionProvider implements CommandPaletteActio
 			CREATE_MANUAL_TASK, CREATE_MERGE_NODE, CREATE_DECISION_NODE);
 
 	@Override
-	public Set<LabeledAction> getActions(GModelRoot root, List<String> selectedElementsIDs) {
+	public Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementsIDs) {
 		Set<LabeledAction> actions = Sets.newLinkedHashSet();
 
-		GModelIndex index = GModelIndex.get(root);
+		GModelIndex index = modelState.getIndex();
 		Set<GModelElement> selectedElements = index.getAll(selectedElementsIDs);
 
 		// Create node actions are always possible

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/CommandPaletteActionProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/CommandPaletteActionProvider.java
@@ -19,16 +19,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.types.LabeledAction;
-import com.eclipsesource.glsp.graph.GModelRoot;
 
 @FunctionalInterface
 public interface CommandPaletteActionProvider {
-	Set<LabeledAction> getActions(GModelRoot model, List<String> selectedElementIds);
+	Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds);
 
 	public static class NullImpl implements CommandPaletteActionProvider {
 		@Override
-		public Set<LabeledAction> getActions(GModelRoot model, List<String> selectedElementIds) {
+		public Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds) {
 			return Collections.emptySet();
 		}
 	}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestCommandPaletteActionsHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestCommandPaletteActionsHandler.java
@@ -25,7 +25,6 @@ import com.eclipsesource.glsp.api.action.kind.SetCommandPaletteActions;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.provider.CommandPaletteActionProvider;
 import com.eclipsesource.glsp.api.types.LabeledAction;
-import com.eclipsesource.glsp.graph.GModelRoot;
 import com.google.inject.Inject;
 
 public class RequestCommandPaletteActionsHandler extends AbstractActionHandler {
@@ -41,9 +40,8 @@ public class RequestCommandPaletteActionsHandler extends AbstractActionHandler {
 	public Optional<Action> execute(Action action, GraphicalModelState modelState) {
 		if (action instanceof RequestCommandPaletteActions) {
 			RequestCommandPaletteActions paletteAction = (RequestCommandPaletteActions) action;
-			GModelRoot root = modelState.getRoot();
 			List<String> selectedElementsIDs = paletteAction.getSelectedElementsIDs();
-			Set<LabeledAction> commandPaletteActions = commandPaletteActionProvider.getActions(root,
+			Set<LabeledAction> commandPaletteActions = commandPaletteActionProvider.getActions(modelState,
 					selectedElementsIDs);
 			return Optional.of(new SetCommandPaletteActions(commandPaletteActions));
 		}


### PR DESCRIPTION
There isn't really a reason why we don't pass the model state on to the
provider directly instead of only providing it the model root. Providing
the root only, however, makes it less flexible for extenders who also
extend the model state with important per-editor data.