### PR TITLE
Avoid background of selected text in SVG

### DIFF
--- a/client/packages/sprotty-client/css/glsp-sprotty.css
+++ b/client/packages/sprotty-client/css/glsp-sprotty.css
@@ -19,6 +19,10 @@
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+.sprotty svg text::selection {
+    background: none;
+}
+
 .sprotty-hidden {
     display: block;
     position: absolute;


### PR DESCRIPTION
Sometimes it happens that a text in the SVG diagram gets selected which
leads to an ugly background of the selected text. With this change, we
deactivate the background of selected text in the SVG.