### PR TITLE
Use stricter scope for exceptions that are returned to the client

### DIFF
--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/jsonrpc/DefaultGLSPServer.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/jsonrpc/DefaultGLSPServer.java
@@ -26,6 +26,7 @@ import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPClient;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPClientProvider;
 import com.eclipsesource.glsp.api.jsonrpc.GLSPServer;
+import com.eclipsesource.glsp.api.jsonrpc.GLSPServerException;
 import com.eclipsesource.glsp.api.jsonrpc.InitializeParameters;
 import com.eclipsesource.glsp.api.model.ModelStateProvider;
 import com.eclipsesource.glsp.api.types.ServerStatus;
@@ -92,7 +93,7 @@ public class DefaultGLSPServer<T> implements GLSPServer {
 			// is currently the earliest we can register the clientProxy
 			this.clientProxyProvider.register(clientId, clientProxy);
 			actionProcessor.process(message);
-		} catch (RuntimeException e) {
+		} catch (GLSPServerException e) {
 			log.error(e);
 			actionProcessor.send(clientId, error(e));
 		}


### PR DESCRIPTION
Restrict the exceptions that are returned to the client to instances of GLSPServerException.
Returning all RuntimeExceptions led to some unwanted side-effects (e.g action handlers might get canceled when non-critical runtime exceptions are thrown)