### PR TITLE
Add utility method for rebinding default ActionHandlers

### DIFF
--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/layout/WorkflowLayoutEngine.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/layout/WorkflowLayoutEngine.java
@@ -15,18 +15,18 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.example.workflow.layout;
 
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.graph.GGraph;
-import com.eclipsesource.glsp.graph.GModelRoot;
 import com.eclipsesource.glsp.layout.ElkLayoutEngine;
 import com.eclipsesource.glsp.layout.GLSPLayoutConfigurator;
 
 public class WorkflowLayoutEngine extends ElkLayoutEngine {
 	@Override
-	public void layout(GModelRoot root) {
-		if (root instanceof GGraph) {
+	public void layout(GraphicalModelState modelState) {
+		if (modelState.getRoot() instanceof GGraph) {
 			GLSPLayoutConfigurator configurator = new GLSPLayoutConfigurator();
 			configurator.configureByType("graph");
-			this.layout((GGraph) root, configurator);
+			this.layout((GGraph) modelState.getRoot(), configurator);
 		}
 	}
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/layout/ILayoutEngine.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/layout/ILayoutEngine.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.layout;
 
-import com.eclipsesource.glsp.graph.GModelRoot;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
 
 /**
  * A layout engine is able to compute layout information for a model.
@@ -25,14 +25,14 @@ public interface ILayoutEngine {
 	/**
 	 * Compute a layout for the given model and modify the model accordingly.
 	 */
-	public void layout(GModelRoot root);
+	public void layout(GraphicalModelState modelState);
 
 	/**
 	 * An implementation that does nothing.
 	 */
 	public static class NullImpl implements ILayoutEngine {
 		@Override
-		public void layout(GModelRoot root) {
+		public void layout(GraphicalModelState modelState) {
 		}
 	}
 

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GEdgePlacement.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GEdgePlacement.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link com.eclipsesource.glsp.graph.GEdgePlacement#getPosition <em>Position</em>}</li>
  *   <li>{@link com.eclipsesource.glsp.graph.GEdgePlacement#getOffset <em>Offset</em>}</li>
  *   <li>{@link com.eclipsesource.glsp.graph.GEdgePlacement#getSide <em>Side</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.GEdgePlacement#isRotate <em>Rotate</em>}</li>
  * </ul>
  *
  * @see com.eclipsesource.glsp.graph.GraphPackage#getGEdgePlacement()
@@ -85,27 +86,46 @@ public interface GEdgePlacement extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Side</b></em>' attribute.
 	 * The default value is <code>"left"</code>.
-	 * The literals are from the enumeration {@link com.eclipsesource.glsp.graph.GSide}.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Side</em>' attribute.
-	 * @see com.eclipsesource.glsp.graph.GSide
-	 * @see #setSide(GSide)
+	 * @see #setSide(String)
 	 * @see com.eclipsesource.glsp.graph.GraphPackage#getGEdgePlacement_Side()
 	 * @model default="left"
 	 * @generated
 	 */
-	GSide getSide();
+	String getSide();
 
 	/**
 	 * Sets the value of the '{@link com.eclipsesource.glsp.graph.GEdgePlacement#getSide <em>Side</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @param value the new value of the '<em>Side</em>' attribute.
-	 * @see com.eclipsesource.glsp.graph.GSide
 	 * @see #getSide()
 	 * @generated
 	 */
-	void setSide(GSide value);
+	void setSide(String value);
+
+	/**
+	 * Returns the value of the '<em><b>Rotate</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Rotate</em>' attribute.
+	 * @see #setRotate(boolean)
+	 * @see com.eclipsesource.glsp.graph.GraphPackage#getGEdgePlacement_Rotate()
+	 * @model
+	 * @generated
+	 */
+	boolean isRotate();
+
+	/**
+	 * Sets the value of the '{@link com.eclipsesource.glsp.graph.GEdgePlacement#isRotate <em>Rotate</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Rotate</em>' attribute.
+	 * @see #isRotate()
+	 * @generated
+	 */
+	void setRotate(boolean value);
 
 } // GEdgePlacement

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GraphPackage.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/GraphPackage.java
@@ -1691,13 +1691,22 @@ public interface GraphPackage extends EPackage {
 	int GEDGE_PLACEMENT__SIDE = 2;
 
 	/**
+	 * The feature id for the '<em><b>Rotate</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GEDGE_PLACEMENT__ROTATE = 3;
+
+	/**
 	 * The number of structural features of the '<em>GEdge Placement</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int GEDGE_PLACEMENT_FEATURE_COUNT = 3;
+	int GEDGE_PLACEMENT_FEATURE_COUNT = 4;
 
 	/**
 	 * The number of operations of the '<em>GEdge Placement</em>' class.
@@ -2065,16 +2074,6 @@ public interface GraphPackage extends EPackage {
 	int GPRE_RENDERED_ELEMENT_OPERATION_COUNT = GMODEL_ELEMENT_OPERATION_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link com.eclipsesource.glsp.graph.GSide <em>GSide</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see com.eclipsesource.glsp.graph.GSide
-	 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGSide()
-	 * @generated
-	 */
-	int GSIDE = 23;
-
-	/**
 	 * The meta object id for the '{@link com.eclipsesource.glsp.graph.GSeverity <em>GSeverity</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2082,7 +2081,7 @@ public interface GraphPackage extends EPackage {
 	 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGSeverity()
 	 * @generated
 	 */
-	int GSEVERITY = 24;
+	int GSEVERITY = 23;
 
 	/**
 	 * Returns the meta object for class '{@link com.eclipsesource.glsp.graph.GModelElement <em>GModel Element</em>}'.
@@ -2695,6 +2694,17 @@ public interface GraphPackage extends EPackage {
 	EAttribute getGEdgePlacement_Side();
 
 	/**
+	 * Returns the meta object for the attribute '{@link com.eclipsesource.glsp.graph.GEdgePlacement#isRotate <em>Rotate</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Rotate</em>'.
+	 * @see com.eclipsesource.glsp.graph.GEdgePlacement#isRotate()
+	 * @see #getGEdgePlacement()
+	 * @generated
+	 */
+	EAttribute getGEdgePlacement_Rotate();
+
+	/**
 	 * Returns the meta object for class '{@link com.eclipsesource.glsp.graph.GLayouting <em>GLayouting</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2874,16 +2884,6 @@ public interface GraphPackage extends EPackage {
 	 * @generated
 	 */
 	EAttribute getGPreRenderedElement_Code();
-
-	/**
-	 * Returns the meta object for enum '{@link com.eclipsesource.glsp.graph.GSide <em>GSide</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for enum '<em>GSide</em>'.
-	 * @see com.eclipsesource.glsp.graph.GSide
-	 * @generated
-	 */
-	EEnum getGSide();
 
 	/**
 	 * Returns the meta object for enum '{@link com.eclipsesource.glsp.graph.GSeverity <em>GSeverity</em>}'.
@@ -3409,6 +3409,14 @@ public interface GraphPackage extends EPackage {
 		EAttribute GEDGE_PLACEMENT__SIDE = eINSTANCE.getGEdgePlacement_Side();
 
 		/**
+		 * The meta object literal for the '<em><b>Rotate</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute GEDGE_PLACEMENT__ROTATE = eINSTANCE.getGEdgePlacement_Rotate();
+
+		/**
 		 * The meta object literal for the '{@link com.eclipsesource.glsp.graph.GLayouting <em>GLayouting</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -3555,16 +3563,6 @@ public interface GraphPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute GPRE_RENDERED_ELEMENT__CODE = eINSTANCE.getGPreRenderedElement_Code();
-
-		/**
-		 * The meta object literal for the '{@link com.eclipsesource.glsp.graph.GSide <em>GSide</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @see com.eclipsesource.glsp.graph.GSide
-		 * @see com.eclipsesource.glsp.graph.impl.GraphPackageImpl#getGSide()
-		 * @generated
-		 */
-		EEnum GSIDE = eINSTANCE.getGSide();
 
 		/**
 		 * The meta object literal for the '{@link com.eclipsesource.glsp.graph.GSeverity <em>GSeverity</em>}' enum.

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GEdgePlacementImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GEdgePlacementImpl.java
@@ -16,7 +16,6 @@
 package com.eclipsesource.glsp.graph.impl;
 
 import com.eclipsesource.glsp.graph.GEdgePlacement;
-import com.eclipsesource.glsp.graph.GSide;
 import com.eclipsesource.glsp.graph.GraphPackage;
 
 import org.eclipse.emf.common.notify.Notification;
@@ -37,6 +36,7 @@ import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
  *   <li>{@link com.eclipsesource.glsp.graph.impl.GEdgePlacementImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link com.eclipsesource.glsp.graph.impl.GEdgePlacementImpl#getOffset <em>Offset</em>}</li>
  *   <li>{@link com.eclipsesource.glsp.graph.impl.GEdgePlacementImpl#getSide <em>Side</em>}</li>
+ *   <li>{@link com.eclipsesource.glsp.graph.impl.GEdgePlacementImpl#isRotate <em>Rotate</em>}</li>
  * </ul>
  *
  * @generated
@@ -90,7 +90,7 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 	 * @generated
 	 * @ordered
 	 */
-	protected static final GSide SIDE_EDEFAULT = GSide.LEFT;
+	protected static final String SIDE_EDEFAULT = "left";
 
 	/**
 	 * The cached value of the '{@link #getSide() <em>Side</em>}' attribute.
@@ -100,7 +100,27 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 	 * @generated
 	 * @ordered
 	 */
-	protected GSide side = SIDE_EDEFAULT;
+	protected String side = SIDE_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isRotate() <em>Rotate</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isRotate()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean ROTATE_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isRotate() <em>Rotate</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isRotate()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean rotate = ROTATE_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -175,7 +195,7 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 	 * @generated
 	 */
 	@Override
-	public GSide getSide() {
+	public String getSide() {
 		return side;
 	}
 
@@ -185,11 +205,35 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 	 * @generated
 	 */
 	@Override
-	public void setSide(GSide newSide) {
-		GSide oldSide = side;
-		side = newSide == null ? SIDE_EDEFAULT : newSide;
+	public void setSide(String newSide) {
+		String oldSide = side;
+		side = newSide;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GEDGE_PLACEMENT__SIDE, oldSide, side));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean isRotate() {
+		return rotate;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setRotate(boolean newRotate) {
+		boolean oldRotate = rotate;
+		rotate = newRotate;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GEDGE_PLACEMENT__ROTATE, oldRotate,
+					rotate));
 	}
 
 	/**
@@ -206,6 +250,8 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 			return getOffset();
 		case GraphPackage.GEDGE_PLACEMENT__SIDE:
 			return getSide();
+		case GraphPackage.GEDGE_PLACEMENT__ROTATE:
+			return isRotate();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -225,7 +271,10 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 			setOffset((Double) newValue);
 			return;
 		case GraphPackage.GEDGE_PLACEMENT__SIDE:
-			setSide((GSide) newValue);
+			setSide((String) newValue);
+			return;
+		case GraphPackage.GEDGE_PLACEMENT__ROTATE:
+			setRotate((Boolean) newValue);
 			return;
 		}
 		super.eSet(featureID, newValue);
@@ -248,6 +297,9 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 		case GraphPackage.GEDGE_PLACEMENT__SIDE:
 			setSide(SIDE_EDEFAULT);
 			return;
+		case GraphPackage.GEDGE_PLACEMENT__ROTATE:
+			setRotate(ROTATE_EDEFAULT);
+			return;
 		}
 		super.eUnset(featureID);
 	}
@@ -265,7 +317,9 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 		case GraphPackage.GEDGE_PLACEMENT__OFFSET:
 			return OFFSET_EDEFAULT == null ? offset != null : !OFFSET_EDEFAULT.equals(offset);
 		case GraphPackage.GEDGE_PLACEMENT__SIDE:
-			return side != SIDE_EDEFAULT;
+			return SIDE_EDEFAULT == null ? side != null : !SIDE_EDEFAULT.equals(side);
+		case GraphPackage.GEDGE_PLACEMENT__ROTATE:
+			return rotate != ROTATE_EDEFAULT;
 		}
 		return super.eIsSet(featureID);
 	}
@@ -287,6 +341,8 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
 		result.append(offset);
 		result.append(", side: ");
 		result.append(side);
+		result.append(", rotate: ");
+		result.append(rotate);
 		result.append(')');
 		return result.toString();
 	}

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphFactoryImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphFactoryImpl.java
@@ -23,27 +23,6 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.impl.EFactoryImpl;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 
-import com.eclipsesource.glsp.graph.GAlignable;
-import com.eclipsesource.glsp.graph.GBounds;
-import com.eclipsesource.glsp.graph.GButton;
-import com.eclipsesource.glsp.graph.GCompartment;
-import com.eclipsesource.glsp.graph.GDimension;
-import com.eclipsesource.glsp.graph.GEdge;
-import com.eclipsesource.glsp.graph.GEdgePlacement;
-import com.eclipsesource.glsp.graph.GGraph;
-import com.eclipsesource.glsp.graph.GIssue;
-import com.eclipsesource.glsp.graph.GIssueMarker;
-import com.eclipsesource.glsp.graph.GLabel;
-import com.eclipsesource.glsp.graph.GLayoutOptions;
-import com.eclipsesource.glsp.graph.GModelRoot;
-import com.eclipsesource.glsp.graph.GNode;
-import com.eclipsesource.glsp.graph.GPoint;
-import com.eclipsesource.glsp.graph.GPort;
-import com.eclipsesource.glsp.graph.GSeverity;
-import com.eclipsesource.glsp.graph.GSide;
-import com.eclipsesource.glsp.graph.GraphFactory;
-import com.eclipsesource.glsp.graph.GraphPackage;
-
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model <b>Factory</b>.
@@ -136,8 +115,6 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
 	@Override
 	public Object createFromString(EDataType eDataType, String initialValue) {
 		switch (eDataType.getClassifierID()) {
-		case GraphPackage.GSIDE:
-			return createGSideFromString(eDataType, initialValue);
 		case GraphPackage.GSEVERITY:
 			return createGSeverityFromString(eDataType, initialValue);
 		default:
@@ -153,8 +130,6 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
 	@Override
 	public String convertToString(EDataType eDataType, Object instanceValue) {
 		switch (eDataType.getClassifierID()) {
-		case GraphPackage.GSIDE:
-			return convertGSideToString(eDataType, instanceValue);
 		case GraphPackage.GSEVERITY:
 			return convertGSeverityToString(eDataType, instanceValue);
 		default:
@@ -358,28 +333,6 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
 	public GPreRenderedElement createGPreRenderedElement() {
 		GPreRenderedElementImpl gPreRenderedElement = new GPreRenderedElementImpl();
 		return gPreRenderedElement;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public GSide createGSideFromString(EDataType eDataType, String initialValue) {
-		GSide result = GSide.get(initialValue);
-		if (result == null)
-			throw new IllegalArgumentException(
-					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
-		return result;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public String convertGSideToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**

--- a/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphPackageImpl.java
+++ b/server/glsp-graph/src/main/java-gen/com/eclipsesource/glsp/graph/impl/GraphPackageImpl.java
@@ -39,7 +39,6 @@ import com.eclipsesource.glsp.graph.GPort;
 import com.eclipsesource.glsp.graph.GPreRenderedElement;
 import com.eclipsesource.glsp.graph.GSeverity;
 import com.eclipsesource.glsp.graph.GShapeElement;
-import com.eclipsesource.glsp.graph.GSide;
 import com.eclipsesource.glsp.graph.GraphFactory;
 import com.eclipsesource.glsp.graph.GraphPackage;
 
@@ -218,13 +217,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 	 * @generated
 	 */
 	private EClass gPreRenderedElementEClass = null;
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	private EEnum gSideEEnum = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -873,6 +865,16 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 	 * @generated
 	 */
 	@Override
+	public EAttribute getGEdgePlacement_Rotate() {
+		return (EAttribute) gEdgePlacementEClass.getEStructuralFeatures().get(3);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EClass getGLayouting() {
 		return gLayoutingEClass;
 	}
@@ -1043,16 +1045,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 	 * @generated
 	 */
 	@Override
-	public EEnum getGSide() {
-		return gSideEEnum;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
 	public EEnum getGSeverity() {
 		return gSeverityEEnum;
 	}
@@ -1160,6 +1152,7 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 		createEAttribute(gEdgePlacementEClass, GEDGE_PLACEMENT__POSITION);
 		createEAttribute(gEdgePlacementEClass, GEDGE_PLACEMENT__OFFSET);
 		createEAttribute(gEdgePlacementEClass, GEDGE_PLACEMENT__SIDE);
+		createEAttribute(gEdgePlacementEClass, GEDGE_PLACEMENT__ROTATE);
 
 		gLayoutingEClass = createEClass(GLAYOUTING);
 		createEAttribute(gLayoutingEClass, GLAYOUTING__LAYOUT);
@@ -1185,7 +1178,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 		createEAttribute(gPreRenderedElementEClass, GPRE_RENDERED_ELEMENT__CODE);
 
 		// Create enums
-		gSideEEnum = createEEnum(GSIDE);
 		gSeverityEEnum = createEEnum(GSEVERITY);
 	}
 
@@ -1386,8 +1378,11 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 		initEAttribute(getGEdgePlacement_Offset(), ecorePackage.getEDoubleObject(), "offset", "0", 1, 1,
 				GEdgePlacement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, IS_ORDERED);
-		initEAttribute(getGEdgePlacement_Side(), this.getGSide(), "side", "left", 0, 1, GEdgePlacement.class,
+		initEAttribute(getGEdgePlacement_Side(), ecorePackage.getEString(), "side", "left", 0, 1, GEdgePlacement.class,
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGEdgePlacement_Rotate(), ecorePackage.getEBoolean(), "rotate", null, 0, 1,
+				GEdgePlacement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+				!IS_DERIVED, IS_ORDERED);
 
 		initEClass(gLayoutingEClass, GLayouting.class, "GLayouting", IS_ABSTRACT, IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1431,13 +1426,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize enums and add enum literals
-		initEEnum(gSideEEnum, GSide.class, "GSide");
-		addEEnumLiteral(gSideEEnum, GSide.LEFT);
-		addEEnumLiteral(gSideEEnum, GSide.RIGHT);
-		addEEnumLiteral(gSideEEnum, GSide.TOP);
-		addEEnumLiteral(gSideEEnum, GSide.BOTTOM);
-		addEEnumLiteral(gSideEEnum, GSide.ON);
-
 		initEEnum(gSeverityEEnum, GSeverity.class, "GSeverity");
 		addEEnumLiteral(gSeverityEEnum, GSeverity.ERROR);
 		addEEnumLiteral(gSeverityEEnum, GSeverity.WARNING);

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/builder/impl/GEdgePlacementBuilder.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/builder/impl/GEdgePlacementBuilder.java
@@ -16,7 +16,6 @@
 package com.eclipsesource.glsp.graph.builder.impl;
 
 import com.eclipsesource.glsp.graph.GEdgePlacement;
-import com.eclipsesource.glsp.graph.GSide;
 import com.eclipsesource.glsp.graph.GraphFactory;
 import com.eclipsesource.glsp.graph.builder.GBuilder;
 
@@ -24,7 +23,8 @@ public class GEdgePlacementBuilder extends GBuilder<GEdgePlacement> {
 
 	private double position;
 	private double offset;
-	private GSide side;
+	private String side;
+	private boolean rotate;
 
 	@Override
 	protected GEdgePlacement instantiate() {
@@ -32,7 +32,8 @@ public class GEdgePlacementBuilder extends GBuilder<GEdgePlacement> {
 	}
 
 	public GEdgePlacementBuilder position(double position) {
-		this.position = Math.max(1, Math.min(0, position));
+
+		this.position = Math.min(1, Math.max(0, position));
 		return this;
 	}
 
@@ -41,8 +42,13 @@ public class GEdgePlacementBuilder extends GBuilder<GEdgePlacement> {
 		return this;
 	}
 
-	public GEdgePlacementBuilder side(GSide side) {
+	public GEdgePlacementBuilder side(String side) {
 		this.side = side;
+		return this;
+	}
+
+	public GEdgePlacementBuilder rotate(boolean rotate) {
+		this.rotate = rotate;
 		return this;
 	}
 
@@ -51,6 +57,7 @@ public class GEdgePlacementBuilder extends GBuilder<GEdgePlacement> {
 		placement.setPosition(position);
 		placement.setOffset(offset);
 		placement.setSide(side);
+		placement.setRotate(rotate);
 	}
 
 }

--- a/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/util/GConstants.java
+++ b/server/glsp-graph/src/main/java/com/eclipsesource/glsp/graph/util/GConstants.java
@@ -7,6 +7,14 @@ public final class GConstants {
 		public static final String MANHATTAN = "manhattan";
 	}
 
+	public static final class EdgeSide {
+		public static final String LEFT = "left";
+		public static final String RIGHT = "right";
+		public static final String TOP = "top";
+		public static final String BOTTOM = "bottom";
+		public static final String ON = "on";
+	}
+
 	public static final class Layout {
 		public static final String VBOX = "vbox";
 		public static final String HBOX = "hbox";

--- a/server/glsp-graph/src/main/resources/glsp-graph.ecore
+++ b/server/glsp-graph/src/main/resources/glsp-graph.ecore
@@ -92,15 +92,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="offset" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDoubleObject"
         defaultValueLiteral="0"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="side" eType="#//GSide"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="side" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         defaultValueLiteral="left"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EEnum" name="GSide">
-    <eLiterals name="left"/>
-    <eLiterals name="right" value="1"/>
-    <eLiterals name="top" value="2"/>
-    <eLiterals name="bottom" value="3"/>
-    <eLiterals name="on" value="4"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="rotate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GLayouting" abstract="true" interface="true">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="layout" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/server/glsp-graph/src/main/resources/glsp-graph.genmodel
+++ b/server/glsp-graph/src/main/resources/glsp-graph.genmodel
@@ -11,13 +11,6 @@
   <foreignModel>glsp-graph.ecore</foreignModel>
   <genPackages prefix="Graph" basePackage="com.eclipsesource.glsp" disposableProviderFactory="true"
       fileExtensions="graph" ecorePackage="glsp-graph.ecore#/">
-    <genEnums typeSafeEnumCompatible="false" ecoreEnum="glsp-graph.ecore#//GSide">
-      <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSide/left"/>
-      <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSide/right"/>
-      <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSide/top"/>
-      <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSide/bottom"/>
-      <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSide/on"/>
-    </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="glsp-graph.ecore#//GSeverity">
       <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSeverity/error"/>
       <genEnumLiterals ecoreEnumLiteral="glsp-graph.ecore#//GSeverity/warning"/>
@@ -92,6 +85,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GEdgePlacement/position"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GEdgePlacement/offset"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GEdgePlacement/side"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GEdgePlacement/rotate"/>
     </genClasses>
     <genClasses image="false" ecoreClass="glsp-graph.ecore#//GLayouting">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GLayouting/layout"/>

--- a/server/glsp-layout/src/main/java/com/eclipsesource/glsp/layout/ElkLayoutEngine.java
+++ b/server/glsp-layout/src/main/java/com/eclipsesource/glsp/layout/ElkLayoutEngine.java
@@ -48,6 +48,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 
 import com.eclipsesource.glsp.api.layout.ILayoutEngine;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.graph.GBoundsAware;
 import com.eclipsesource.glsp.graph.GDimension;
 import com.eclipsesource.glsp.graph.GEdge;
@@ -56,7 +57,6 @@ import com.eclipsesource.glsp.graph.GGraph;
 import com.eclipsesource.glsp.graph.GLabel;
 import com.eclipsesource.glsp.graph.GLayouting;
 import com.eclipsesource.glsp.graph.GModelElement;
-import com.eclipsesource.glsp.graph.GModelRoot;
 import com.eclipsesource.glsp.graph.GNode;
 import com.eclipsesource.glsp.graph.GPoint;
 import com.eclipsesource.glsp.graph.GPort;
@@ -95,9 +95,9 @@ public class ElkLayoutEngine implements ILayoutEngine {
 	 * for your model using a {@link SprottyLayoutConfigurator}.
 	 */
 	@Override
-	public void layout(GModelRoot root) {
-		if (root instanceof GGraph) {
-			layout((GGraph) root, null);
+	public void layout(GraphicalModelState modelState) {
+		if (modelState.getRoot() instanceof GGraph) {
+			layout((GGraph) modelState.getRoot(), null);
 		}
 	}
 

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/CollapseExpandActionHandler.java
@@ -27,7 +27,7 @@ import com.google.inject.Inject;
 
 public class CollapseExpandActionHandler extends AbstractActionHandler {
 	@Inject
-	ModelExpansionListener expansionListener;
+	protected ModelExpansionListener expansionListener;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ComputedBoundsActionHandler.java
@@ -26,7 +26,7 @@ import com.google.inject.Inject;
 
 public class ComputedBoundsActionHandler extends AbstractActionHandler {
 	@Inject
-	private ModelSubmissionHandler submissionHandler;
+	protected ModelSubmissionHandler submissionHandler;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ExecuteServerCommandActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ExecuteServerCommandActionHandler.java
@@ -26,7 +26,7 @@ import com.google.inject.Inject;
 
 public class ExecuteServerCommandActionHandler extends AbstractActionHandler {
 	@Inject
-	ServerCommandHandlerProvider commandHandlerProvider;
+	protected ServerCommandHandlerProvider commandHandlerProvider;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/LayoutActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/LayoutActionHandler.java
@@ -43,7 +43,7 @@ public class LayoutActionHandler extends AbstractActionHandler {
 	protected Optional<Action> execute(Action action, GraphicalModelState modelState) {
 		if (serverConfiguration.getLayoutKind() == ServerLayoutKind.MANUAL) {
 			if (layoutEngine != null) {
-				layoutEngine.layout(modelState.getRoot());
+				layoutEngine.layout(modelState);
 			}
 			return Optional.of(new RequestBoundsAction(modelState.getRoot()));
 		}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ModelSubmissionHandler.java
@@ -40,7 +40,7 @@ public class ModelSubmissionHandler {
 	public Optional<Action> doSubmitModel(boolean update, GraphicalModelState modelState) {
 		GModelRoot newRoot = modelState.getRoot();
 		if (serverConfiguration.getLayoutKind() == ServerLayoutKind.AUTOMATIC) {
-			layoutEngine.layout(newRoot);
+			layoutEngine.layout(modelState);
 		}
 		synchronized (modelLock) {
 			if (newRoot.getRevision() == revision) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OpenActionHandler.java
@@ -25,7 +25,7 @@ import com.google.inject.Inject;
 
 public class OpenActionHandler extends AbstractActionHandler {
 	@Inject
-	private ModelElementOpenListener modelElementOpenListener;
+	protected ModelElementOpenListener modelElementOpenListener;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/OperationActionHandler.java
@@ -28,7 +28,7 @@ import com.google.inject.Inject;
 
 public class OperationActionHandler extends AbstractActionHandler {
 	@Inject
-	private OperationHandlerProvider operationHandlerProvider;
+	protected OperationHandlerProvider operationHandlerProvider;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestCommandPaletteActionsHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestCommandPaletteActionsHandler.java
@@ -29,7 +29,7 @@ import com.google.inject.Inject;
 
 public class RequestCommandPaletteActionsHandler extends AbstractActionHandler {
 	@Inject
-	private CommandPaletteActionProvider commandPaletteActionProvider;
+	protected CommandPaletteActionProvider commandPaletteActionProvider;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestMarkersHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestMarkersHandler.java
@@ -28,7 +28,7 @@ import com.google.inject.Inject;
 public class RequestMarkersHandler extends AbstractActionHandler {
 
 	@Inject
-	private ModelValidator validator;
+	protected ModelValidator validator;
 
 	@Override
 	public Optional<Action> execute(Action action, GraphicalModelState modelState) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestModelActionHandler.java
@@ -30,7 +30,7 @@ import com.google.inject.Inject;
 public class RequestModelActionHandler extends AbstractActionHandler {
 
 	@Inject
-	private ModelFactory modelFactory;
+	protected ModelFactory modelFactory;
 
 	@Override
 	public Optional<Action> execute(String clientId, Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestPopupModelActionHandler.java
@@ -28,7 +28,7 @@ import com.google.inject.Inject;
 
 public class RequestPopupModelActionHandler extends AbstractActionHandler {
 	@Inject
-	private PopupModelFactory popupModelFactory;
+	protected PopupModelFactory popupModelFactory;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestTypeHintsActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestTypeHintsActionHandler.java
@@ -31,7 +31,7 @@ import com.google.inject.Inject;
 public class RequestTypeHintsActionHandler extends AbstractActionHandler {
 	private Logger LOG = Logger.getLogger(RequestTypeHintsActionHandler.class);
 	@Inject
-	private DiagramConfigurationProvider diagramConfigurationProvider;
+	protected DiagramConfigurationProvider diagramConfigurationProvider;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SaveModelActionHandler.java
@@ -39,7 +39,7 @@ public class SaveModelActionHandler extends AbstractActionHandler {
 	private static final String FILE_PREFIX = "file://";
 
 	@Inject
-	private GraphGsonConfiguratorFactory gsonConfigurationFactory;
+	protected GraphGsonConfiguratorFactory gsonConfigurationFactory;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SelectActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/SelectActionHandler.java
@@ -27,7 +27,7 @@ import com.google.inject.Inject;
 
 public class SelectActionHandler extends AbstractActionHandler {
 	@Inject
-	ModelSelectionListener modelSelectionListener;
+	protected ModelSelectionListener modelSelectionListener;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ValidateLabelEditActionHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/ValidateLabelEditActionHandler.java
@@ -29,7 +29,7 @@ import com.google.inject.Inject;
 public class ValidateLabelEditActionHandler extends AbstractActionHandler {
 
 	@Inject
-	private LabelEditValidator editLabelValidator;
+	protected LabelEditValidator editLabelValidator;
 
 	@Override
 	public boolean handles(Action action) {

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
@@ -17,6 +17,7 @@ package com.eclipsesource.glsp.server.di;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import com.eclipsesource.glsp.api.action.ActionProcessor;
 import com.eclipsesource.glsp.api.di.GLSPModule;
@@ -71,6 +72,14 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 	protected Multibinder<OperationHandler> operationHandler;
 	protected Multibinder<DiagramConfiguration> diagramConfiguration;
 
+	private final List<Class<? extends ActionHandler>> defaultActionHandlers = Lists.newArrayList(
+			CollapseExpandActionHandler.class, ComputedBoundsActionHandler.class, OpenActionHandler.class,
+			OperationActionHandler.class, RequestModelActionHandler.class, RequestOperationsActionHandler.class,
+			RequestPopupModelActionHandler.class, SaveModelActionHandler.class, UndoRedoActionHandler.class,
+			SelectActionHandler.class, ExecuteServerCommandActionHandler.class, RequestTypeHintsActionHandler.class,
+			RequestCommandPaletteActionsHandler.class, RequestMarkersHandler.class, LayoutActionHandler.class,
+			ValidateLabelEditActionHandler.class);
+
 	@Override
 	protected void configure() {
 		super.configure();
@@ -83,6 +92,17 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 		bindServerCommandHandlers().forEach(h -> serverCommandHandler.addBinding().to(h));
 		bindOperationHandlers().forEach(h -> operationHandler.addBinding().to(h));
 		bindDiagramConfigurations().forEach(h -> diagramConfiguration.addBinding().to(h));
+	}
+
+	protected void rebind(Class<? extends ActionHandler> defaultBinding, Class<? extends ActionHandler> newBinding) {
+		if (defaultActionHandlers.contains(defaultBinding)) {
+			defaultActionHandlers.remove(defaultBinding);
+		}
+		defaultActionHandlers.add(newBinding);
+	}
+
+	protected Collection<Class<? extends ActionHandler>> bindActionHandlers() {
+		return defaultActionHandlers;
 	}
 
 	@Override
@@ -134,16 +154,6 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 
 	protected abstract Collection<Class<? extends DiagramConfiguration>> bindDiagramConfigurations();
 
-	protected Collection<Class<? extends ActionHandler>> bindActionHandlers() {
-		return Lists.newArrayList(CollapseExpandActionHandler.class, ComputedBoundsActionHandler.class,
-				OpenActionHandler.class, OperationActionHandler.class, RequestModelActionHandler.class,
-				RequestOperationsActionHandler.class, RequestPopupModelActionHandler.class,
-				SaveModelActionHandler.class, UndoRedoActionHandler.class, SelectActionHandler.class,
-				ExecuteServerCommandActionHandler.class, RequestTypeHintsActionHandler.class,
-				RequestCommandPaletteActionsHandler.class, RequestMarkersHandler.class, LayoutActionHandler.class,
-				ValidateLabelEditActionHandler.class);
-	}
-
 	protected Collection<Class<? extends ServerCommandHandler>> bindServerCommandHandlers() {
 		return Collections.emptySet();
 	}
@@ -152,7 +162,7 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 	protected Class<? extends ActionProcessor> bindActionProcessor() {
 		return DIActionProcessor.class;
 	}
-	
+
 	@Override
 	protected Class<? extends GLSPClientProvider> bindGSLPClientProvider() {
 		return DefaultGLSPClientProvider.class;


### PR DESCRIPTION
Also: 
+ Pass entire modelState to LayoutEngine instead of just the modelroot
+ Add missing rotate attribute to GEdgePlacement and fix wrong serialization of EdgeSide enum by using String instead
+Set visibility of injected fields of default action handlers to protected (for better extensibility)