### PR TITLE
Ensure Command Package is registered for GLSP workflow model server

### DIFF
--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/ModelServerSubscriptionListener.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/ModelServerSubscriptionListener.java
@@ -1,1 +1,0 @@
-package com.eclipsesource.glsp.example.modelserver.workflow;

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/WorkflowModelServerGLSPServerLauncher.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/WorkflowModelServerGLSPServerLauncher.java
@@ -21,12 +21,14 @@ import org.eclipse.elk.alg.layered.options.LayeredMetaDataProvider;
 import com.eclipsesource.glsp.layout.ElkLayoutEngine;
 import com.eclipsesource.glsp.server.launch.DefaultGLSPServerLauncher;
 import com.eclipsesource.glsp.server.launch.GLSPServerLauncher;
+import com.eclipsesource.modelserver.command.CCommandPackage;
 
 public class WorkflowModelServerGLSPServerLauncher {
 	public static void main(String[] args) {
 		BasicConfigurator.configure();
 		ElkLayoutEngine.initialize(new LayeredMetaDataProvider());
 		GLSPServerLauncher launcher = new DefaultGLSPServerLauncher(new WorkflowModelServerGLSPModule());
+		CCommandPackage.eINSTANCE.eClass();
 		launcher.start("localhost", 5008);
 	}
 }

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerModelFactory.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerModelFactory.java
@@ -87,7 +87,7 @@ public class WorkflowModelServerModelFactory implements ModelFactory {
 
 		WorkflowModelServerAccess modelAccess = new WorkflowModelServerAccess(sourceURI.get(), modelServerClient.get(),
 				adapterFactory, commandCodec);
-		modelAccess.subscribe(new WorkflowSubscriptionListener(modelState, modelAccess, actionProcessor));
+		modelAccess.subscribe(new WorkflowModelServerSubscriptionListener(modelState, modelAccess, actionProcessor));
 
 		if (modelState instanceof ModelServerAwareModelState) {
 			((ModelServerAwareModelState) modelState).setModelAccess(modelAccess);

--- a/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerSubscriptionListener.java
+++ b/server/example/workflow-modelserver-example/src/main/java/com/eclipsesource/glsp/example/modelserver/workflow/model/WorkflowModelServerSubscriptionListener.java
@@ -46,14 +46,14 @@ import com.eclipsesource.modelserver.command.CCommand;
 import com.eclipsesource.modelserver.common.codecs.DecodingException;
 import com.google.common.collect.Lists;
 
-public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListener {
+public class WorkflowModelServerSubscriptionListener extends XmiToEObjectSubscriptionListener {
 	private static final String TEMP_COMMAND_RESOURCE_URI = "command$1.command";
-	private static Logger LOG = Logger.getLogger(WorkflowSubscriptionListener.class);
+	private static Logger LOG = Logger.getLogger(WorkflowModelServerSubscriptionListener.class);
 	private ActionProcessor actionProcessor;
 	private WorkflowModelServerAccess modelServerAccess;
 	private GraphicalModelState modelState;
 
-	public WorkflowSubscriptionListener(GraphicalModelState modelState, WorkflowModelServerAccess modelServerAccess,
+	public WorkflowModelServerSubscriptionListener(GraphicalModelState modelState, WorkflowModelServerAccess modelServerAccess,
 			ActionProcessor actionProcessor) {
 		this.actionProcessor = actionProcessor;
 		this.modelServerAccess = modelServerAccess;
@@ -130,7 +130,7 @@ public class WorkflowSubscriptionListener extends XmiToEObjectSubscriptionListen
 	@Override
 	public void onUnknown(ModelServerNotification notification) {
 		// Try to see if we have an update if the notification type is not set properly
-		EObject data = notification.getData().flatMap(WorkflowSubscriptionListener::decode).orElse(null);
+		EObject data = notification.getData().flatMap(WorkflowModelServerSubscriptionListener::decode).orElse(null);
 		if(data instanceof CCommand) {
 			onIncrementalUpdate((CCommand)data);
 		} else if(data instanceof Machine) {


### PR DESCRIPTION
- Remove empty ModelServerSubscriptionListener commited by mistake
- Rename WorkflowSubscriptionListener to WorkflowModelServerSubscriptionListener to better fit with the general naming