### PR TITLE
Improve extensibility of tool mouse listeners

### DIFF
--- a/client/packages/sprotty-client/src/features/tools/change-bounds-tool.ts
+++ b/client/packages/sprotty-client/src/features/tools/change-bounds-tool.ts
@@ -98,12 +98,12 @@ export class ChangeBoundsTool implements Tool {
 
 class ChangeBoundsListener extends MouseListener implements SelectionListener {
     // members for calculating the correct position change
-    private lastDragPosition: Point | undefined = undefined;
-    private positionDelta: Point = { x: 0, y: 0 };
+    protected lastDragPosition: Point | undefined = undefined;
+    protected positionDelta: Point = { x: 0, y: 0 };
 
     // members for resize mode
-    private activeResizeElementId: string | undefined = undefined;
-    private activeResizeHandle: SResizeHandle | undefined = undefined;
+    protected activeResizeElementId: string | undefined = undefined;
+    protected activeResizeHandle: SResizeHandle | undefined = undefined;
 
     constructor(protected tool: ChangeBoundsTool) {
         super();
@@ -183,7 +183,7 @@ class ChangeBoundsListener extends MouseListener implements SelectionListener {
         }
     }
 
-    private setActiveResizeElement(target: SModelElement): boolean {
+    protected setActiveResizeElement(target: SModelElement): boolean {
         // check if we have a selected, moveable element (multi-selection allowed)
         const moveableElement = findParentByFeature(target, isBoundsAwareMoveable);
         if (isSelected(moveableElement)) {
@@ -195,15 +195,15 @@ class ChangeBoundsListener extends MouseListener implements SelectionListener {
         return false;
     }
 
-    private isActiveResizeElement(element: SModelElement | undefined): element is SParentElement & BoundsAware {
+    protected isActiveResizeElement(element: SModelElement | undefined): element is SParentElement & BoundsAware {
         return element !== undefined && element.id === this.activeResizeElementId;
     }
 
-    private initPosition(event: MouseEvent) {
+    protected initPosition(event: MouseEvent) {
         this.lastDragPosition = { x: event.pageX, y: event.pageY };
     }
 
-    private updatePosition(target: SModelElement, event: MouseEvent): boolean {
+    protected updatePosition(target: SModelElement, event: MouseEvent): boolean {
         if (this.lastDragPosition) {
             const viewport = findParentByFeature(target, isViewport);
             const zoom = viewport ? viewport.zoom : 1;
@@ -217,22 +217,22 @@ class ChangeBoundsListener extends MouseListener implements SelectionListener {
         return false;
     }
 
-    private reset() {
+    protected reset() {
         this.tool.dispatchFeedback([new HideChangeBoundsToolResizeFeedbackAction()]);
         this.resetPosition();
     }
 
-    private resetPosition() {
+    protected resetPosition() {
         this.activeResizeHandle = undefined;
         this.lastDragPosition = undefined;
         this.positionDelta = { x: 0, y: 0 };
     }
 
-    private hasPositionDelta(): boolean {
+    protected hasPositionDelta(): boolean {
         return this.positionDelta.x !== 0 || this.positionDelta.y !== 0;
     }
 
-    private handleElementResize(): Action[] {
+    protected handleElementResize(): Action[] {
         if (!this.activeResizeHandle) {
             return [];
         }

--- a/client/packages/sprotty-client/src/features/tools/creation-tool.ts
+++ b/client/packages/sprotty-client/src/features/tools/creation-tool.ts
@@ -80,12 +80,12 @@ export class NodeCreationTool implements Tool, TypeAware {
 
 @injectable()
 export class NodeCreationToolMouseListener extends DragAwareMouseListener {
-    private container?: SModelElement;
+    protected container?: SModelElement;
     constructor(protected elementTypeId: string, protected tool: NodeCreationTool) {
         super();
     }
 
-    private creationAllowed(target: SModelElement) {
+    protected creationAllowed(target: SModelElement) {
         return this.container || target instanceof SModelRoot;
     }
 
@@ -156,11 +156,11 @@ export class EdgeCreationTool implements Tool, TypeAware {
 
 @injectable()
 export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
-    private source?: string;
-    private target?: string;
-    private currentTarget?: SModelElement;
-    private allowedTarget: boolean = false;
-    private edgeEditConfig?: EdgeEditConfig;
+    protected source?: string;
+    protected target?: string;
+    protected currentTarget?: SModelElement;
+    protected allowedTarget: boolean = false;
+    protected edgeEditConfig?: EdgeEditConfig;
 
     constructor(protected elementTypeId: string, protected tool: EdgeCreationTool) {
         super();
@@ -170,7 +170,7 @@ export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
         }
     }
 
-    private reinitialize() {
+    protected reinitialize() {
         this.source = undefined;
         this.target = undefined;
         this.currentTarget = undefined;
@@ -205,11 +205,11 @@ export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
         return result;
     }
 
-    private isSourceSelected() {
+    protected isSourceSelected() {
         return this.source !== undefined;
     }
 
-    private isTargetSelected() {
+    protected isTargetSelected() {
         return this.target !== undefined;
     }
 
@@ -235,11 +235,11 @@ export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
         return [];
     }
 
-    private isAllowedSource(element: SModelElement | undefined): boolean {
+    protected isAllowedSource(element: SModelElement | undefined): boolean {
         return element !== undefined && this.edgeEditConfig ? this.edgeEditConfig.isAllowedSource(element) : false;
     }
 
-    private isAllowedTarget(element: SModelElement | undefined): boolean {
+    protected isAllowedTarget(element: SModelElement | undefined): boolean {
         return element !== undefined && this.edgeEditConfig ? this.edgeEditConfig.isAllowedTarget(element) : false;
     }
 }

--- a/client/packages/sprotty-client/src/features/tools/drag-aware-mouse-listener.ts
+++ b/client/packages/sprotty-client/src/features/tools/drag-aware-mouse-listener.ts
@@ -58,4 +58,8 @@ export class DragAwareMouseListener extends MouseListener {
         return [];
     }
 
+    get isDragging() {
+        return this.isMouseDrag;
+    }
+
 }

--- a/client/packages/sprotty-client/src/features/tools/edge-edit-tool.ts
+++ b/client/packages/sprotty-client/src/features/tools/edge-edit-tool.ts
@@ -102,27 +102,27 @@ export class EdgeEditTool implements Tool {
 }
 
 class ReconnectEdgeListener extends MouseListener implements SelectionListener {
-    private isMouseDown: boolean;
+    protected isMouseDown: boolean;
 
     // active selection data
-    private edge?: SRoutableElement;
-    private routingHandle?: SRoutingHandle;
+    protected edge?: SRoutableElement;
+    protected routingHandle?: SRoutingHandle;
 
     // new connectable (source or target) for edge
-    private newConnectable?: SModelElement & Connectable;
+    protected newConnectable?: SModelElement & Connectable;
 
     // active reconnect handle data
-    private reconnectMode?: 'NEW_SOURCE' | 'NEW_TARGET';
+    protected reconnectMode?: 'NEW_SOURCE' | 'NEW_TARGET';
 
     constructor(protected tool: EdgeEditTool) {
         super();
     }
 
-    private isValidEdge(edge?: SRoutableElement): edge is SRoutableElement {
+    protected isValidEdge(edge?: SRoutableElement): edge is SRoutableElement {
         return edge !== undefined && edge.id !== feedbackEdgeId(edge.root) && isSelected(edge);
     }
 
-    private setEdgeSelected(edge: SRoutableElement) {
+    protected setEdgeSelected(edge: SRoutableElement) {
         if (this.edge && this.edge.id !== edge.id) {
             // reset from a previously selected edge
             this.reset();
@@ -133,11 +133,11 @@ class ReconnectEdgeListener extends MouseListener implements SelectionListener {
         this.tool.dispatchFeedback([new SwitchRoutingModeAction([this.edge.id], []), new ShowEdgeReconnectHandlesFeedbackAction(this.edge.id)]);
     }
 
-    private isEdgeSelected(): boolean {
+    protected isEdgeSelected(): boolean {
         return this.edge !== undefined && isSelected(this.edge);
     }
 
-    private setReconnectHandleSelected(edge: SRoutableElement, reconnectHandle: SReconnectHandle) {
+    protected setReconnectHandleSelected(edge: SRoutableElement, reconnectHandle: SReconnectHandle) {
         if (this.edge && this.edge.target && this.edge.source) {
             if (isSourceRoutingHandle(edge, reconnectHandle)) {
                 this.tool.dispatchFeedback([new HideEdgeReconnectHandlesFeedbackAction(),
@@ -153,33 +153,33 @@ class ReconnectEdgeListener extends MouseListener implements SelectionListener {
         }
     }
 
-    private isReconnecting(): boolean {
+    protected isReconnecting(): boolean {
         return this.reconnectMode !== undefined;
     }
 
-    private isReconnectingNewSource(): boolean {
+    protected isReconnectingNewSource(): boolean {
         return this.reconnectMode === "NEW_SOURCE";
     }
 
-    private setRoutingHandleSelected(edge: SRoutableElement, routingHandle: SRoutingHandle) {
+    protected setRoutingHandleSelected(edge: SRoutableElement, routingHandle: SRoutingHandle) {
         if (this.edge && this.edge.target && this.edge.source) {
             this.routingHandle = routingHandle;
         }
     }
 
-    private requiresReconnect(sourceId: string, targetId: string): boolean {
+    protected requiresReconnect(sourceId: string, targetId: string): boolean {
         return this.edge !== undefined && (this.edge.sourceId !== sourceId || this.edge.targetId !== targetId);
     }
 
-    private setNewConnectable(connectable?: SModelElement & Connectable) {
+    protected setNewConnectable(connectable?: SModelElement & Connectable) {
         this.newConnectable = connectable;
     }
 
-    private isReadyToReconnect() {
+    protected isReadyToReconnect() {
         return this.edge && this.isReconnecting() && this.newConnectable !== undefined;
     }
 
-    private isReadyToReroute() {
+    protected isReadyToReroute() {
         return this.routingHandle !== undefined;
     }
 
@@ -292,7 +292,7 @@ class ReconnectEdgeListener extends MouseListener implements SelectionListener {
         this.resetData();
     }
 
-    private resetData() {
+    protected resetData() {
         this.isMouseDown = false;
         this.edge = undefined;
         this.reconnectMode = undefined;
@@ -300,7 +300,7 @@ class ReconnectEdgeListener extends MouseListener implements SelectionListener {
         this.routingHandle = undefined;
     }
 
-    private resetFeedback() {
+    protected resetFeedback() {
         const result: Action[] = [];
         if (this.edge) {
             result.push(new SwitchRoutingModeAction([], [this.edge.id]));


### PR DESCRIPTION
Change visibility of members and methods to protected (if private is not strictly necessary). This enables easier customization of the provided default tools without unnecessary code duplication.

