### PR TITLE
Resolve #396 RouterKind for FeedbackEdge

### DIFF
--- a/client/packages/sprotty-client/src/features/tool-feedback/creation-tool-feedback.ts
+++ b/client/packages/sprotty-client/src/features/tool-feedback/creation-tool-feedback.ts
@@ -31,20 +31,21 @@ import {
     SChildElement,
     SConnectableElement,
     SDanglingAnchor,
+    SEdgeSchema,
     SModelElement,
     SModelRoot,
     SRoutableElement,
     TYPES
 } from "sprotty/lib";
 
-import { getAbsolutePosition } from "../../utils/viewpoint-util";
+import { getAbsolutePosition, toAbsolutePosition } from "../../utils/viewpoint-util";
 import { isRoutable } from "../reconnect/model";
 import { FeedbackCommand } from "./model";
 
 
 export class DrawFeedbackEdgeAction implements Action {
     kind = DrawFeedbackEdgeCommand.KIND;
-    constructor(readonly elementTypeId: string, readonly sourceId: string) { }
+    constructor(readonly elementTypeId: string, readonly sourceId: string, readonly routerKind?: string) { }
 }
 
 
@@ -57,7 +58,7 @@ export class DrawFeedbackEdgeCommand extends FeedbackCommand {
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
-        drawFeedbackEdge(context, this.action.sourceId, this.action.elementTypeId);
+        drawFeedbackEdge(context, this.action.sourceId, this.action.elementTypeId, this.action.routerKind);
         return context.root;
     }
 }
@@ -126,7 +127,7 @@ export function feedbackEdgeEndId(root: SModelRoot): string {
     return root.id + '_feedback_anchor';
 }
 
-function drawFeedbackEdge(context: CommandExecutionContext, sourceId: string, elementTypeId: string) {
+function drawFeedbackEdge(context: CommandExecutionContext, sourceId: string, elementTypeId: string, routerKind?: string) {
     const root = context.root;
     const sourceChild = root.index.getById(sourceId);
     if (!sourceChild) {
@@ -140,13 +141,15 @@ function drawFeedbackEdge(context: CommandExecutionContext, sourceId: string, el
 
     const edgeEnd = new FeedbackEdgeEnd(source.id, elementTypeId);
     edgeEnd.id = feedbackEdgeEndId(root);
-    edgeEnd.position = { x: source.bounds.x, y: source.bounds.y };
+    edgeEnd.position = toAbsolutePosition(source);
 
-    const feedbackEdgeSchema = {
+    const feedbackEdgeSchema = <SEdgeSchema>{
         type: 'edge',
         id: feedbackEdgeId(root),
         sourceId: source.id,
         targetId: edgeEnd.id,
+        cssClasses: ["feedback-edge"],
+        routerKind,
         opacity: 0.3
     };
 

--- a/client/packages/sprotty-client/src/utils/viewpoint-util.ts
+++ b/client/packages/sprotty-client/src/utils/viewpoint-util.ts
@@ -13,12 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Point } from "sprotty/lib";
-import { SModelElement } from "sprotty/lib";
-import { Viewport } from "sprotty/lib";
-
-import { findParentByFeature } from "sprotty/lib";
-import { isViewport } from "sprotty/lib";
+import {
+    Bounds,
+    BoundsAware,
+    Dimension,
+    findParentByFeature,
+    isAlignable,
+    isViewport,
+    ORIGIN_POINT,
+    Point,
+    SModelElement,
+    translateBounds,
+    Viewport
+} from "sprotty/lib";
 
 /**
  * Return the position corresponding to this mouse event (Browser coordinates)
@@ -55,4 +62,39 @@ export function getAbsolutePosition(target: SModelElement, mouseEvent: MouseEven
         x: xPos,
         y: yPos
     };
+}
+
+/**
+ * Translates the bounds of the diagram element (local coordinates) into the diagram coordinates system
+ * (i.e. relative to the Diagram's 0;0 point)
+ *
+ * @param target  A bounds-aware element from the diagram
+ */
+export function toAbsolutBounds(element: SModelElement & BoundsAware): Bounds {
+    const location = isAlignable(element) ? element.alignment : ORIGIN_POINT;
+    const x = location.x;
+    const y = location.y;
+    const width = element.bounds.width;
+    const height = element.bounds.height;
+    return translateBounds({ x, y, width, height }, element, element.root);
+}
+
+/**
+ * Translates the position of the diagram element (local coordinates) into the diagram coordinates system
+ * (i.e. relative to the Diagram's 0;0 point)
+ *
+ * @param target  A bounds-aware element from the diagram
+ */
+export function toAbsolutePosition(target: SModelElement & BoundsAware): Point {
+    return toAbsolutBounds(target);
+}
+
+/**
+ * Translates the size of the diagram element (local coordinates) into the diagram coordinates system
+ * (i.e. relative to the Diagram's 0;0 point)
+ *
+ * @param target  A bounds-aware element from the diagram
+ */
+export function toAbsoluteSize(target: SModelElement & BoundsAware): Dimension {
+    return toAbsolutBounds(target);
 }

--- a/client/packages/sprotty-client/src/utils/viewpoint-util.ts
+++ b/client/packages/sprotty-client/src/utils/viewpoint-util.ts
@@ -70,7 +70,7 @@ export function getAbsolutePosition(target: SModelElement, mouseEvent: MouseEven
  *
  * @param target  A bounds-aware element from the diagram
  */
-export function toAbsolutBounds(element: SModelElement & BoundsAware): Bounds {
+export function toAbsoluteBounds(element: SModelElement & BoundsAware): Bounds {
     const location = isAlignable(element) ? element.alignment : ORIGIN_POINT;
     const x = location.x;
     const y = location.y;
@@ -86,7 +86,7 @@ export function toAbsolutBounds(element: SModelElement & BoundsAware): Bounds {
  * @param target  A bounds-aware element from the diagram
  */
 export function toAbsolutePosition(target: SModelElement & BoundsAware): Point {
-    return toAbsolutBounds(target);
+    return toAbsoluteBounds(target);
 }
 
 /**
@@ -96,5 +96,5 @@ export function toAbsolutePosition(target: SModelElement & BoundsAware): Point {
  * @param target  A bounds-aware element from the diagram
  */
 export function toAbsoluteSize(target: SModelElement & BoundsAware): Dimension {
-    return toAbsolutBounds(target);
+    return toAbsoluteBounds(target);
 }


### PR DESCRIPTION
Make routerKind of feedback edge configurable
- Add cssClass to enable dedicated feedback edge styling
- Fix issue with the initial location calculation of the feedback edge (Was incorrect for nested element like ports)
- Add utility methods to viewport-utils