### PR TITLE
Add support for context menu and harmonize with command palette

### DIFF
--- a/client/examples/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/examples/workflow/workflow-sprotty/src/di.config.ts
@@ -26,6 +26,7 @@ import {
     decorationModule,
     defaultGLSPModule,
     defaultModule,
+    DeleteContextMenuProviderRegistry,
     DiamondNodeView,
     edgeLayoutModule,
     editLabelFeature,
@@ -35,6 +36,7 @@ import {
     fadeModule,
     GLSP_TYPES,
     glspCommandPaletteModule,
+    glspContextMenuModule,
     glspEditLabelValidationModule,
     GLSPGraph,
     glspMouseToolModule,
@@ -55,6 +57,7 @@ import {
     PreRenderedElement,
     PreRenderedView,
     requestResponseModule,
+    RevealNamedElementActionProvider,
     routingModule,
     saveModule,
     SButton,
@@ -82,13 +85,13 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
     bind(GLSP_TYPES.IMovementRestrictor).to(NoCollisionMovementRestrictor).inSingletonScope();
+    bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
+    bind(GLSP_TYPES.IContextMenuProvider).to(DeleteContextMenuProviderRegistry);
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, 'graph', GLSPGraph, SGraphView);
     configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);
     configureModelElement(context, 'task:manual', TaskNode, TaskNodeView);
-    configureModelElement(context, 'label:heading', SLabel, SLabelView, {
-        enable: [editLabelFeature]
-    });
+    configureModelElement(context, 'label:heading', SLabel, SLabelView, { enable: [editLabelFeature] });
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
     configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
     configureModelElement(context, 'label:icon', SLabel, SLabelView);
@@ -111,7 +114,7 @@ export default function createContainer(widgetId: string): Container {
 
     container.load(decorationModule, validationModule, defaultModule, glspMouseToolModule, defaultGLSPModule, glspSelectModule, boundsModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule, labelEditModule, labelEditUiModule, glspEditLabelValidationModule,
-        workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule,
+        workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule, glspContextMenuModule,
         commandPaletteModule, glspCommandPaletteModule, paletteModule, requestResponseModule, routingModule, edgeLayoutModule,
         layoutCommandsModule, zorderModule);
 

--- a/client/examples/workflow/workflow-theia/src/browser/diagram/workflow-diagram-configuration.ts
+++ b/client/examples/workflow/workflow-theia/src/browser/diagram/workflow-diagram-configuration.ts
@@ -16,8 +16,9 @@
 import "sprotty-theia/css/theia-sprotty.css";
 
 import { createWorkflowDiagramContainer } from "@glsp-examples/workflow-sprotty/lib";
-import { registerDefaultTools, TYPES } from "@glsp/sprotty-client/lib";
+import { GLSP_TYPES, IActionDispatcher, registerDefaultTools, TYPES } from "@glsp/sprotty-client/lib";
 import { GLSPTheiaDiagramServer } from "@glsp/theia-integration/lib/browser";
+import { TheiaContextMenuService } from "@glsp/theia-integration/lib/browser/diagram/glsp-theia-context-menu-service";
 import { SelectionService } from "@theia/core";
 import { Container, inject, injectable } from "inversify";
 import { DiagramConfiguration, TheiaDiagramServer, TheiaSprottySelectionForwarder } from "sprotty-theia/lib";
@@ -27,6 +28,8 @@ import { WorkflowLanguage } from "../../common/workflow-language";
 @injectable()
 export class WorkflowDiagramConfiguration implements DiagramConfiguration {
     @inject(SelectionService) protected selectionService: SelectionService;
+    @inject(TheiaContextMenuService) protected readonly contextMenuService: TheiaContextMenuService;
+
     diagramType: string = WorkflowLanguage.DiagramType;
 
     createContainer(widgetId: string): Container {
@@ -36,6 +39,10 @@ export class WorkflowDiagramConfiguration implements DiagramConfiguration {
         // container.rebind(KeyTool).to(TheiaKeyTool).inSingletonScope()
         container.bind(TYPES.IActionHandlerInitializer).to(TheiaSprottySelectionForwarder);
         container.bind(SelectionService).toConstantValue(this.selectionService);
+        container.bind(GLSP_TYPES.IContextMenuService).toConstantValue(this.contextMenuService);
+        if (this.contextMenuService instanceof TheiaContextMenuService) {
+            this.contextMenuService.connect(container.get<IActionDispatcher>(TYPES.IActionDispatcher));
+        }
         registerDefaultTools(container);
         return container;
     }

--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "**/@theia/console": "^0.11.0",
     "**/@theia/preferences": "^0.11.0",
     "**/@theia/core": "^0.11.0",
-    "**/sprotty": "0.8.0-next.ff11b36",
+    "**/sprotty": "0.8.0-next.1d772ad",
     "**/sprotty-theia": "0.7.0-next.1c6b386"
   },
   "devDependencies": {

--- a/client/packages/sprotty-client/src/base/model/update-model-command.ts
+++ b/client/packages/sprotty-client/src/base/model/update-model-command.ts
@@ -38,13 +38,12 @@ import { GLSP_TYPES } from "../../types";
 *  UpdateModel behaves the same as SetModel if no model is present yet.*/
 @injectable()
 export class SetModelActionHandler implements IActionHandler {
+    handledActionKinds = [SetModelCommand.KIND];
     handle(action: Action): Action | void {
         if (isSetModelAction(action)) {
             return new UpdateModelAction(action.newRoot, false);
         }
     }
-
-    handledActionKinds = [SetModelCommand.KIND];
 }
 
 export function isSetModelAction(action: Action): action is SetModelAction {

--- a/client/packages/sprotty-client/src/base/model/update-model-command.ts
+++ b/client/packages/sprotty-client/src/base/model/update-model-command.ts
@@ -38,7 +38,6 @@ import { GLSP_TYPES } from "../../types";
 *  UpdateModel behaves the same as SetModel if no model is present yet.*/
 @injectable()
 export class SetModelActionHandler implements IActionHandler {
-    handledActionKinds = [SetModelCommand.KIND];
     handle(action: Action): Action | void {
         if (isSetModelAction(action)) {
             return new UpdateModelAction(action.newRoot, false);

--- a/client/packages/sprotty-client/src/features/command-palette/di.config.ts
+++ b/client/packages/sprotty-client/src/features/command-palette/di.config.ts
@@ -18,11 +18,9 @@ import "../../../css/command-palette.css";
 import { ContainerModule } from "inversify";
 import { TYPES } from "sprotty/lib";
 
-import { NavigationCommandPaletteActionProvider, ServerCommandPaletteActionProvider } from "./action-provider";
+import { ServerCommandPaletteActionProvider } from "./server-command-palette-provider";
 
-const glspCommandPaletteModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(TYPES.ICommandPaletteActionProvider).to(NavigationCommandPaletteActionProvider);
-    bind(ServerCommandPaletteActionProvider).toSelf().inSingletonScope();
+const glspCommandPaletteModule = new ContainerModule((bind) => {
     bind(TYPES.ICommandPaletteActionProvider).to(ServerCommandPaletteActionProvider);
 });
 

--- a/client/packages/sprotty-client/src/features/command-palette/server-command-palette-provider.ts
+++ b/client/packages/sprotty-client/src/features/command-palette/server-command-palette-provider.ts
@@ -31,12 +31,12 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
 
     constructor(@inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher) { }
 
-    getActions(root: Readonly<SModelElement>, text: string, lastMousePosition?: Point): Promise<LabeledAction[]> {
+    getActions(root: Readonly<SModelElement>, text: string, lastMousePosition?: Point, index?: number): Promise<LabeledAction[]> {
         const selectedElementIds = Array.from(root.index.all().filter(isSelected).map(e => e.id));
         const requestAction = new RequestContextActions(selectedElementIds, lastMousePosition, {
             [ContextActions.UI_CONTROL_KEY]: ServerCommandPalette.KEY,
             [ServerCommandPalette.TEXT]: text,
-            [ServerCommandPalette.INDEX]: 0
+            [ServerCommandPalette.INDEX]: index ? index : 0
         });
         return this.actionDispatcher.requestUntil(requestAction).then(response => this.getPaletteActionsFromResponse(response));
     }

--- a/client/packages/sprotty-client/src/features/context-actions/action-definitions.ts
+++ b/client/packages/sprotty-client/src/features/context-actions/action-definitions.ts
@@ -15,25 +15,28 @@
  ********************************************************************************/
 import { Action, generateRequestId, LabeledAction, Point, RequestAction, ResponseAction } from "sprotty/lib";
 
-export class RequestCommandPaletteActions implements RequestAction<SetCommandPaletteActions> {
-    static readonly KIND = "requestCommandPaletteActions";
-    kind = RequestCommandPaletteActions.KIND;
+export namespace ContextActions {
+    export const UI_CONTROL_KEY = "ui-control";
+}
+
+export class RequestContextActions implements RequestAction<SetContextActions> {
+    static readonly KIND = "requestContextActions";
+    kind = RequestContextActions.KIND;
     constructor(
         public readonly selectedElementIds: string[] = [],
-        public readonly text: string,
         public readonly lastMousePosition?: Point,
+        public readonly args?: { [key: string]: string | number | boolean },
         public readonly requestId: string = generateRequestId()) { }
 }
 
-export class SetCommandPaletteActions implements ResponseAction {
-    static readonly KIND = "setCommandPaletteActions";
-    kind = SetCommandPaletteActions.KIND;
-    constructor(
-        public readonly actions: LabeledAction[],
+export class SetContextActions implements ResponseAction {
+    static readonly KIND = "setContextActions";
+    kind = SetContextActions.KIND;
+    constructor(public readonly actions: LabeledAction[],
         public readonly responseId: string = '') { }
 }
 
-export function isSetCommandPaletteActionsAction(action: Action): action is SetCommandPaletteActions {
-    return action !== undefined && (action.kind === SetCommandPaletteActions.KIND)
-        && (<SetCommandPaletteActions>action).actions !== undefined;
+export function isSetContextActionsAction(action: Action): action is SetContextActions {
+    return action !== undefined && (action.kind === SetContextActions.KIND)
+        && (<SetContextActions>action).actions !== undefined;
 }

--- a/client/packages/sprotty-client/src/features/context-menu/context-menu-service.ts
+++ b/client/packages/sprotty-client/src/features/context-menu/context-menu-service.ts
@@ -29,11 +29,11 @@ export interface MenuItem extends LabeledAction {
      */
     readonly parentId?: string;
     /** Function determining whether the element is enabled. */
-    readonly isEnabled?: () => boolean | boolean;
+    readonly isEnabled?: () => boolean;
     /** Function determining whether the element is visible. */
-    readonly isVisible?: () => boolean | boolean;
+    readonly isVisible?: () => boolean;
     /** Function determining whether the element is toggled on or off. */
-    readonly isToggled?: () => boolean | boolean;
+    readonly isToggled?: () => boolean;
     /** Children of this item. If this item has children, they will be added into a submenu of this item. */
     children?: MenuItem[];
 }

--- a/client/packages/sprotty-client/src/features/context-menu/context-menu-service.ts
+++ b/client/packages/sprotty-client/src/features/context-menu/context-menu-service.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { LabeledAction } from "sprotty";
+
+export interface MenuItem extends LabeledAction {
+    /** Technical id of the menu item. */
+    readonly id: string;
+    /** String indicating the order. */
+    readonly sortString?: string;
+    /** String indicating the grouping (separators). Items with equal group will be in the same group. */
+    readonly group?: string;
+    /**
+     * The optional parent id can be used to add this element as a child of another element provided by anohter menu provider.
+     * The `parentId` must be fully qualified in the form of `a.b.c`, whereas `a`, `b` and `c` are referring to the IDs of other elements.
+     * Note that this attribute will only be considered for root items of a provider and not for children of provided items.
+     */
+    readonly parentId?: string;
+    /** Function determining whether the element is enabled. */
+    readonly isEnabled?: () => boolean | boolean;
+    /** Function determining whether the element is visible. */
+    readonly isVisible?: () => boolean | boolean;
+    /** Function determining whether the element is toggled on or off. */
+    readonly isToggled?: () => boolean | boolean;
+    /** Children of this item. If this item has children, they will be added into a submenu of this item. */
+    children?: MenuItem[];
+}
+
+export type Anchor = MouseEvent | { x: number, y: number };
+
+export function toAnchor(anchor: HTMLElement | { x: number, y: number }): Anchor {
+    return anchor instanceof HTMLElement ? { x: anchor.offsetLeft, y: anchor.offsetTop } : anchor;
+}
+
+export interface IContextMenuService {
+    show(items: MenuItem[], anchor: Anchor, onHide?: () => void): void;
+}
+
+export type IContextMenuServiceProvider = () => Promise<IContextMenuService>;

--- a/client/packages/sprotty-client/src/features/context-menu/di.config.ts
+++ b/client/packages/sprotty-client/src/features/context-menu/di.config.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from "inversify";
+import { TYPES } from "sprotty/lib";
+
+import { GLSP_TYPES } from "../../types";
+import { IContextMenuService } from "./context-menu-service";
+import { ContextMenuProviderRegistry } from "./menu-providers";
+import { ContextMenuMouseListener } from "./mouse-listener";
+import { ServerContextMenuItemProvider } from "./server-context-menu-provider";
+
+const glspContextMenuModule = new ContainerModule(bind => {
+    bind(GLSP_TYPES.IContextMenuServiceProvider).toProvider<IContextMenuService>(ctx => {
+        return () => {
+            return new Promise<IContextMenuService>((resolve, reject) => {
+                if (ctx.container.isBound(GLSP_TYPES.IContextMenuService)) {
+                    resolve(ctx.container.get<IContextMenuService>(GLSP_TYPES.IContextMenuService));
+                } else {
+                    reject();
+                }
+            });
+        };
+    });
+    bind(TYPES.MouseListener).to(ContextMenuMouseListener);
+    bind(GLSP_TYPES.IContextMenuProviderRegistry).to(ContextMenuProviderRegistry);
+    bind(GLSP_TYPES.IContextMenuProvider).to(ServerContextMenuItemProvider);
+});
+
+export default glspContextMenuModule;

--- a/client/packages/sprotty-client/src/features/context-menu/menu-providers.ts
+++ b/client/packages/sprotty-client/src/features/context-menu/menu-providers.ts
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable, multiInject, optional } from "inversify";
+import { DeleteElementAction, isDeletable, LabeledAction, Point, SModelRoot } from "sprotty";
+
+import { GLSP_TYPES } from "../../types";
+import { isSelected } from "../../utils/smodel-util";
+import { MenuItem } from "./context-menu-service";
+
+export interface IContextMenuItemProvider {
+    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<LabeledAction[]>;
+}
+
+@injectable()
+export class ContextMenuProviderRegistry implements IContextMenuItemProvider {
+
+    constructor(@multiInject(GLSP_TYPES.IContextMenuProvider) @optional() protected menuProviders: IContextMenuItemProvider[] = []) { }
+
+    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point) {
+        const menues = this.menuProviders.map(provider => provider.getItems(root, lastMousePosition));
+        return Promise.all(menues).then(this.flattenAndRestructure);
+    }
+
+    private flattenAndRestructure(p: MenuItem[][]): MenuItem[] {
+        let menuItems = p.reduce((acc, promise) => promise !== undefined ? acc.concat(promise) : acc, []);
+        const menuItemsWithParentId = menuItems.filter(menuItem => menuItem.parentId);
+        for (const menuItem of menuItemsWithParentId) {
+            if (menuItem.parentId) {
+                const fragments = menuItem.parentId.split(".");
+                let matchingParent: MenuItem | undefined = undefined;
+                let nextParents = menuItems;
+                for (const fragment of fragments) {
+                    matchingParent = nextParents.find(item => fragment === item.id);
+                    if (matchingParent && matchingParent.children)
+                        nextParents = matchingParent.children;
+                }
+                if (matchingParent) {
+                    if (matchingParent.children) {
+                        matchingParent.children.push(menuItem);
+                    } else {
+                        matchingParent.children = [menuItem];
+                    }
+                    menuItems = menuItems.filter(item => item !== menuItem);
+                }
+            }
+        }
+        return menuItems;
+    }
+}
+
+@injectable()
+export class DeleteContextMenuProviderRegistry implements IContextMenuItemProvider {
+    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<MenuItem[]> {
+        const selectedElements = Array.from(root.index.all().filter(isSelected).filter(isDeletable));
+        return Promise.resolve([
+            {
+                id: "delete",
+                label: "Delete",
+                sortString: "t",
+                group: "edit",
+                actions: [new DeleteElementAction(selectedElements.map(e => e.id))],
+                isEnabled: () => selectedElements.length > 0,
+                isVisible: () => true,
+                isToggled: () => false
+            }
+        ]);
+    }
+}

--- a/client/packages/sprotty-client/src/features/context-menu/mouse-listener.ts
+++ b/client/packages/sprotty-client/src/features/context-menu/mouse-listener.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, optional } from "inversify";
+import { Action, findParentByFeature, isSelectable, MouseListener, SModelElement, TYPES } from "sprotty/lib";
+import { DOMHelper } from "sprotty/lib/base/views/dom-helper";
+
+import { GLSP_TYPES } from "../../types";
+import { IContextMenuServiceProvider } from "./context-menu-service";
+import { ContextMenuProviderRegistry } from "./menu-providers";
+
+export class ContextMenuMouseListener extends MouseListener {
+
+    constructor(
+        @inject(GLSP_TYPES.IContextMenuServiceProvider) @optional() protected readonly contextMenuService: IContextMenuServiceProvider,
+        @inject(GLSP_TYPES.IContextMenuProviderRegistry) @optional() protected readonly menuProvider: ContextMenuProviderRegistry,
+        @inject(TYPES.DOMHelper) protected domHelper: DOMHelper) {
+        super();
+    }
+
+    mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+        if (event.button === 2 && this.contextMenuService && this.menuProvider) {
+            const mousePosition = { x: event.x, y: event.y };
+            let isTargetSelected = false;
+            const selectableTarget = findParentByFeature(target, isSelectable);
+            if (selectableTarget) {
+                isTargetSelected = selectableTarget.selected;
+                selectableTarget.selected = true;
+            }
+            const restoreSelection = () => { if (selectableTarget) selectableTarget.selected = isTargetSelected; };
+            Promise.all([this.contextMenuService(), this.menuProvider.getItems(target.root, mousePosition)])
+                .then(([menuService, menuItems]) => menuService.show(menuItems, mousePosition, restoreSelection));
+        }
+        return [];
+    }
+}

--- a/client/packages/sprotty-client/src/features/context-menu/server-context-menu-provider.ts
+++ b/client/packages/sprotty-client/src/features/context-menu/server-context-menu-provider.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable } from "inversify";
+import { Action, LabeledAction, Point, SModelElement, subtract, TYPES } from "sprotty/lib";
+
+import { isSelected } from "../../utils/smodel-util";
+import { ContextActions, isSetContextActionsAction, RequestContextActions } from "../context-actions/action-definitions";
+import { GLSPActionDispatcher } from "../request-response/glsp-action-dispatcher";
+import { IContextMenuItemProvider } from "./menu-providers";
+
+export namespace ServerContextMenu {
+    export const KEY = "context-menu";
+}
+
+@injectable()
+export class ServerContextMenuItemProvider implements IContextMenuItemProvider {
+
+    constructor(@inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher) { }
+
+    getItems(root: Readonly<SModelElement>, lastMousePosition?: Point): Promise<LabeledAction[]> {
+        const selectedElementIds = Array.from(root.index.all().filter(isSelected).map(e => e.id));
+        const localPosition = lastMousePosition ? root.root.parentToLocal(subtract(lastMousePosition, root.root.canvasBounds)) : undefined;
+        const requestAction = new RequestContextActions(selectedElementIds, localPosition, { [ContextActions.UI_CONTROL_KEY]: ServerContextMenu.KEY });
+        return this.actionDispatcher.requestUntil(requestAction).then(response => this.getContextActionsFromResponse(response));
+    }
+
+    getContextActionsFromResponse(action: Action): LabeledAction[] {
+        if (isSetContextActionsAction(action)) {
+            return action.actions;
+        }
+        return [];
+    }
+}

--- a/client/packages/sprotty-client/src/index.ts
+++ b/client/packages/sprotty-client/src/index.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 import defaultGLSPModule from "./base/di.config";
 import glspCommandPaletteModule from "./features/command-palette/di.config";
+import glspContextMenuModule from "./features/context-menu/di.config";
 import glspEditLabelValidationModule from "./features/edit-label-validation/di.config";
 import executeModule from "./features/execute/di.config";
 import modelHintsModule from "./features/hints/di.config";
@@ -34,8 +35,11 @@ export * from './base/tool-manager/tool-manager-action-handler';
 export * from './base/command-stack';
 export * from './features/change-bounds/model';
 export * from './features/change-bounds/movement-restrictor';
-export * from './features/command-palette/action-definitions';
-export * from './features/command-palette/action-provider';
+export * from './features/context-actions/action-definitions';
+export * from './features/command-palette/server-command-palette-provider';
+export * from './features/context-menu/mouse-listener';
+export * from './features/context-menu/context-menu-service';
+export * from './features/context-menu/menu-providers';
 export * from './features/edit-label-validation/edit-label-validator';
 export * from './features/execute/execute-command';
 export * from './features/execute/model';
@@ -79,7 +83,7 @@ export * from './model-source/websocket-diagram-server';
 export * from "./model-source/glsp-server-status";
 export {
     validationModule, saveModule, executeModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, glspCommandPaletteModule, requestResponseModule, //
-    glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelValidationModule
+    glspContextMenuModule, glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelValidationModule
 };
 
 

--- a/client/packages/sprotty-client/src/model-source/websocket-diagram-server.ts
+++ b/client/packages/sprotty-client/src/model-source/websocket-diagram-server.ts
@@ -23,7 +23,7 @@ import {
 } from "sprotty";
 import * as rpc from "vscode-ws-jsonrpc";
 import { NotificationType } from "vscode-ws-jsonrpc";
-import { RequestCommandPaletteActions } from "../features/command-palette/action-definitions";
+import { RequestContextActions } from "../features/context-actions/action-definitions";
 import { ExecuteServerCommandAction } from "../features/execute/execute-command";
 import { RequestTypeHintsAction } from "../features/hints/request-type-hints-action";
 import { OperationKind, RequestOperationsAction } from "../features/operation/set-operations";
@@ -46,7 +46,6 @@ export class GLSPWebsocketDiagramServer extends DiagramServer {
                 this.connection = connection;
             }
         });
-
     }
 
     protected sendMessage(message: ActionMessage): void {
@@ -99,7 +98,7 @@ export function registerDefaultGLSPServerActions(registry: ActionHandlerRegistry
     registry.register(ServerStatusAction.KIND, diagramServer);
     registry.register(RequestModelAction.KIND, diagramServer);
     registry.register(ExportSvgAction.KIND, diagramServer);
-    registry.register(RequestCommandPaletteActions.KIND, diagramServer);
+    registry.register(RequestContextActions.KIND, diagramServer);
     registry.register(ValidateLabelEditAction.KIND, diagramServer);
     registry.register(RequestMarkersAction.KIND, diagramServer);
     registry.register(LayoutAction.KIND, diagramServer);

--- a/client/packages/sprotty-client/src/types.ts
+++ b/client/packages/sprotty-client/src/types.ts
@@ -22,5 +22,9 @@ export const GLSP_TYPES = {
     SelectionService: Symbol.for("SelectionService"),
     SelectionListener: Symbol.for("SelectionListener"),
     SModelRootListener: Symbol.for("SModelRootListener"),
-    MouseTool: Symbol.for("MouseTool")
+    MouseTool: Symbol.for("MouseTool"),
+    IContextMenuService: Symbol.for("IContextMenuService"),
+    IContextMenuServiceProvider: Symbol.for("IContextMenuServiceProvider"),
+    IContextMenuProviderRegistry: Symbol.for("IContextMenuProviderRegistry"),
+    IContextMenuProvider: Symbol.for("IContextMenuProvider")
 };

--- a/client/packages/theia-integration/src/browser/diagram/glsp-diagram-client.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-diagram-client.ts
@@ -34,27 +34,19 @@ export class GLSPDiagramClient {
 
     constructor(readonly glspClientContribution: GLSPClientContribution,
         readonly editorManager: EditorManager) {
-        this.glspClientContribution.glspClient.then(
-            gc => {
-                gc.onNotification(ActionMessageNotification.type, this.onMessageReceived.bind(this));
-            }
-        ).catch(
-            err => console.error(err)
-        );
+        this.glspClientContribution.glspClient
+            .then(gc => gc.onNotification(ActionMessageNotification.type, this.onMessageReceived.bind(this)))
+            .catch(err => console.error(err));
     }
 
     sendThroughLsp(message: ActionMessage) {
-        this.glspClientContribution.glspClient.then(gc =>
-            gc.onReady().then(() =>
-                gc.sendNotification(ActionMessageNotification.type, message)
-            )
-        );
+        this.glspClientContribution.glspClient
+            .then(gc => gc.onReady()
+                .then(() => gc.sendNotification(ActionMessageNotification.type, message)));
     }
 
     onMessageReceived(message: ActionMessage) {
-        this.actionMessageReceivers.forEach(client => {
-            client.onMessageReceived(message);
-        });
+        this.actionMessageReceivers.forEach(client => client.onMessageReceived(message));
     }
 
     get glspClient(): Promise<GLSPClient> {

--- a/client/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -33,11 +33,11 @@ export abstract class GLSPDiagramManager extends DiagramManager {
             const clientId = this.createClientId();
             const config = this.diagramConfigurationRegistry.get(options.diagramType);
             const diContainer = config.createContainer(clientId);
-            const diagramWidget = new GLSPDiagramWidget(options, clientId + '_widget', diContainer, this.editorPreferences, this.diagramConnector);
-            return diagramWidget;
+            return new GLSPDiagramWidget(options, clientId + '_widget', diContainer, this.editorPreferences, this.diagramConnector);
         }
         throw Error('DiagramWidgetFactory needs DiagramWidgetOptions but got ' + JSON.stringify(options));
     }
+
     canHandle(uri: URI, options?: WidgetOpenerOptions | undefined): number {
         for (const extension of this.fileExtensions) {
             if (uri.path.toString().endsWith(extension)) {

--- a/client/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -34,6 +34,7 @@ import { DiagramWidget, DiagramWidgetOptions, TheiaSprottyConnector } from "spro
 import { GLSPTheiaDiagramServer, NotifyingModelSource } from "./glsp-theia-diagram-server";
 
 export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
+
     saveable = new SaveableGLSPModelSource(this.actionDispatcher, this.diContainer.get<ModelSource>(TYPES.ModelSource));
 
     constructor(options: DiagramWidgetOptions, readonly widgetId: string, readonly diContainer: Container,
@@ -56,6 +57,7 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
             modelSource.clientId = this.id;
         if (modelSource instanceof GLSPTheiaDiagramServer && this.connector)
             this.connector.connect(modelSource);
+
         this.disposed.connect(() => {
             if (modelSource instanceof GLSPTheiaDiagramServer && this.connector)
                 this.connector.disconnect(modelSource);

--- a/client/packages/theia-integration/src/browser/diagram/glsp-theia-context-menu-service.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-theia-context-menu-service.ts
@@ -1,0 +1,148 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Anchor, IContextMenuService, MenuItem } from "@glsp/sprotty-client/lib";
+import { Command, CommandHandler, CommandRegistry, Disposable, MenuAction, MenuModelRegistry, MenuPath } from "@theia/core";
+import { ContextMenuRenderer } from "@theia/core/lib/browser";
+import { inject, injectable } from "inversify";
+import { IActionDispatcher } from "sprotty";
+
+export namespace TheiaGlspContextMenu {
+    export const CONTEXT_MENU: MenuPath = ['glsp-context-menu'];
+}
+
+@injectable()
+export class TheiaContextMenuService implements IContextMenuService {
+
+    protected actionDispatcher?: IActionDispatcher;
+
+    constructor(@inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry,
+        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry) { }
+
+    connect(actionDispatcher: IActionDispatcher) {
+        this.actionDispatcher = actionDispatcher;
+    }
+
+    show(items: MenuItem[], anchor: Anchor, onHide?: () => void): void {
+        const disposables = this.register(TheiaGlspContextMenu.CONTEXT_MENU, items);
+        const renderOptions = {
+            menuPath: TheiaGlspContextMenu.CONTEXT_MENU, anchor: anchor,
+            onHide: () => { if (onHide) onHide(); window.setTimeout(() => this.cleanUp(disposables), 500); }
+        };
+        this.contextMenuRenderer.render(renderOptions);
+    }
+
+    protected register(menuPath: string[], items: MenuItem[]): DisposableItem[] {
+        const disposables: DisposableItem[] = [];
+        for (const item of items) {
+            if (item.children && item.children.length > 0) {
+                const menuPathOfItem = item.group ? [...menuPath, item.group] : menuPath;
+                disposables.push(this.registerSubmenu(menuPathOfItem, item));
+                disposables.push(...this.register([...menuPathOfItem, item.id], item.children));
+            } else {
+                disposables.push(this.registerCommand(menuPath, item));
+                disposables.push(this.registerMenuAction(menuPath, item));
+            }
+        }
+        return disposables;
+    }
+
+    protected registerSubmenu(menuPath: string[], item: MenuItem): DisposableItem {
+        return this.menuProvider.registerSubmenu([...menuPath, item.id], item.label);
+    }
+
+    protected registerCommand(menuPath: string[], item: MenuItem): DisposableItem {
+        const command: Command = { id: commandId(menuPath, item), label: item.label, iconClass: item.icon };
+        const disposable = this.commandRegistry.registerCommand(command, new GlspCommandHandler(item, this.actionDispatcher));
+        return new DisposableCommand(command, disposable);
+    }
+
+    protected registerMenuAction(menuPath: string[], item: MenuItem): DisposableItem {
+        const menuAction = { label: item.label, order: item.sortString, commandId: commandId(menuPath, item) };
+        const menuPathOfItem = item.group ? [...menuPath, item.group] : menuPath;
+        const disposable = this.menuProvider.registerMenuAction(menuPathOfItem, menuAction);
+        return new DisposableMenuAction(menuAction, disposable);
+    }
+
+    protected cleanUp(disposables: DisposableItem[]) {
+        disposables.forEach(disposable => disposable.dispose(this.menuProvider, this.commandRegistry));
+    }
+}
+
+class GlspCommandHandler implements CommandHandler {
+
+    constructor(readonly menuItem: MenuItem, readonly actionDispatcher?: IActionDispatcher) { }
+
+    execute(...args: any[]) {
+        if (this.actionDispatcher && this.menuItem.actions) {
+            this.actionDispatcher.dispatchAll(this.menuItem.actions);
+        }
+    }
+
+    isEnabled(...args: any[]): boolean {
+        return getBooleanValue(this.menuItem.isEnabled, true);
+    }
+
+    isVisible(...args: any[]): boolean {
+        return getBooleanValue(this.menuItem.isVisible, true);
+    }
+
+    isToggled(...args: any[]): boolean {
+        return getBooleanValue(this.menuItem.isToggled, false);
+    }
+}
+
+interface DisposableItem {
+    dispose(menuProvider: MenuModelRegistry, commandRegistry: CommandRegistry): void;
+}
+
+class DisposableMenuAction implements DisposableItem {
+    constructor(protected readonly menuAction: MenuAction, protected readonly disposable: Disposable) { }
+    dispose(menuProvider: MenuModelRegistry, commandRegistry: CommandRegistry): void {
+        menuProvider.unregisterMenuAction(this.menuAction);
+        this.disposable.dispose();
+    }
+}
+
+class DisposableCommand implements DisposableItem {
+    constructor(protected readonly command: Command, protected readonly disposable: Disposable) { }
+    dispose(menuProvider: MenuModelRegistry, commandRegistry: CommandRegistry): void {
+        commandRegistry.unregisterCommand(this.command);
+        this.disposable.dispose();
+    }
+}
+
+function commandId(menuPath: string[], item: any): string {
+    return menuPath.join(".") + "." + item.id;
+}
+
+function getBooleanValue(value: any, defaultValue: boolean) {
+    let returnVal = defaultValue;
+    if (isFunction(value)) {
+        returnVal = value();
+    } else if (isBoolean(value)) {
+        returnVal = value;
+    }
+    return returnVal;
+}
+
+function isFunction(value: () => boolean | boolean): value is () => boolean {
+    return !!(value && value.constructor && value.call && value.apply);
+}
+
+function isBoolean(value: () => boolean | boolean): boolean {
+    return typeof value === "boolean";
+}

--- a/client/packages/theia-integration/src/browser/diagram/glsp-theia-context-menu-service.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-theia-context-menu-service.ts
@@ -26,11 +26,16 @@ export namespace TheiaGlspContextMenu {
 @injectable()
 export class TheiaContextMenuService implements IContextMenuService {
 
-    protected actionDispatcher?: IActionDispatcher;
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
 
-    constructor(@inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
-        @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry,
-        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry) { }
+    @inject(MenuModelRegistry)
+    protected readonly menuProvider: MenuModelRegistry;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    protected actionDispatcher?: IActionDispatcher;
 
     connect(actionDispatcher: IActionDispatcher) {
         this.actionDispatcher = actionDispatcher;

--- a/client/packages/theia-integration/src/browser/diagram/glsp-theia-sprotty-connector.ts
+++ b/client/packages/theia-integration/src/browser/diagram/glsp-theia-sprotty-connector.ts
@@ -85,7 +85,6 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         this.diagramClient.sendThroughLsp(message);
     }
 
-
     getGLSPClient(): Promise<GLSPClient> {
         return this.diagramClient.glspClient;
     }
@@ -99,7 +98,5 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
 }
 
 export function showErrorDialog(title: string, msg: string) {
-    new ConfirmDialog({
-        title, msg
-    }).open();
+    new ConfirmDialog({ title, msg }).open();
 }

--- a/client/packages/theia-integration/src/browser/frontend-module.ts
+++ b/client/packages/theia-integration/src/browser/frontend-module.ts
@@ -13,22 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { CommandContribution } from "@theia/core";
+import { bindContributionProvider, CommandContribution, MenuContribution } from "@theia/core";
+import { FrontendApplicationContribution, KeybindingContribution } from "@theia/core/lib/browser";
 import { ContainerModule } from "inversify";
-import { FrontendApplicationContribution } from "@theia/core/lib/browser";
-import { GLSPClientContribution } from "./language/glsp-client-contribution";
-import { GLSPClientFactory } from "./language/glsp-client";
-import { GLSPClientProvider } from "./language/glsp-client-provider";
-import { GLSPClientProviderImpl } from "./language/glsp-client-provider";
-import { GLSPDiagramCommandContribution } from "./diagram/glsp-diagram-commands";
-import { GLSPDiagramKeybindingContribution } from "./diagram/glsp-diagram-commands";
-import { GLSPDiagramMenuContribution } from "./diagram/glsp-diagram-commands";
-import { GLSPFrontendContribution } from "./language/glsp-frontend-contribution";
-import { GLSPTheiaSprottyConnector } from "./diagram/glsp-theia-sprotty-connector";
-import { KeybindingContribution } from "@theia/core/lib/browser";
-import { MenuContribution } from "@theia/core";
 
-import { bindContributionProvider } from "@theia/core";
+import {
+    GLSPDiagramCommandContribution,
+    GLSPDiagramKeybindingContribution,
+    GLSPDiagramMenuContribution
+} from "./diagram/glsp-diagram-commands";
+import { TheiaContextMenuService } from "./diagram/glsp-theia-context-menu-service";
+import { GLSPTheiaSprottyConnector } from "./diagram/glsp-theia-sprotty-connector";
+import { GLSPClientFactory } from "./language/glsp-client";
+import { GLSPClientContribution } from "./language/glsp-client-contribution";
+import { GLSPClientProvider, GLSPClientProviderImpl } from "./language/glsp-client-provider";
+import { GLSPFrontendContribution } from "./language/glsp-frontend-contribution";
 
 
 export default new ContainerModule(bind => {
@@ -45,4 +44,6 @@ export default new ContainerModule(bind => {
     bind(CommandContribution).to(GLSPDiagramCommandContribution).inSingletonScope();
     bind(MenuContribution).to(GLSPDiagramMenuContribution).inSingletonScope();
     bind(KeybindingContribution).to(GLSPDiagramKeybindingContribution).inSingletonScope();
+
+    bind(TheiaContextMenuService).toSelf().inSingletonScope();
 });

--- a/client/packages/theia-integration/src/browser/language/glsp-client-contribution.ts
+++ b/client/packages/theia-integration/src/browser/language/glsp-client-contribution.ts
@@ -28,7 +28,6 @@ import { InitializeParameters } from "../../common";
 import { GLSPClientFactory } from "./glsp-client";
 import { GLSPClient, GLSPClientOptions } from "./glsp-client-services";
 
-
 export const GLSPClientContribution = Symbol.for('GLSPClientContribution');
 
 export interface GLSPClientContribution extends LanguageContribution {
@@ -42,6 +41,7 @@ export interface GLSPClientContribution extends LanguageContribution {
 
 @injectable()
 export abstract class BaseGLSPClientContribution implements GLSPClientContribution, Commands {
+
     abstract readonly id: string;
     abstract readonly name: string;
     abstract readonly fileExtensions: string[];
@@ -58,6 +58,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
     @inject(CommandRegistry) protected readonly registry: CommandRegistry;
     @inject(EditorManager) protected readonly editorManager: EditorManager;
     @multiInject(DiagramManagerProvider) protected diagramManagerProviders: DiagramManagerProvider[];
+
     constructor() {
         this.waitForReady();
     }
@@ -105,6 +106,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
             });
         }));
     }
+
     protected readonly toDeactivate = new DisposableCollection();
 
     activate(): Disposable {
@@ -169,9 +171,11 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
     }
 
     protected state: State | undefined;
+
     get running(): boolean {
         return !this.toDeactivate.disposed && this.state === State.Running;
     }
+
     restart(): void {
         this.deactivate();
         this.activate();
@@ -186,6 +190,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         this.resolveReady(this._glspClient);
         this.waitForReady();
     }
+
     protected readonly toRestart = new DisposableCollection();
 
     protected waitForReady(): void {
@@ -198,7 +203,6 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         const clientOptions = this.createOptions();
         return this.languageClientFactory.get(this, clientOptions, connection);
     }
-
 
     protected createOptions(): GLSPClientOptions {
         return {
@@ -216,6 +220,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         });
         return false;
     }
+
     protected deferredConnection = new Deferred<MessageConnection>();
 
     protected get workspaceContains(): string[] {
@@ -233,6 +238,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
             }
         }
     }
+
     protected async waitForItemInWorkspace(): Promise<any> {
         const doesContain = await this.workspaceService.containsSome(this.workspaceContains);
         if (!doesContain) {
@@ -241,11 +247,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         return doesContain;
     }
 
-
-
-
     protected stop = Promise.resolve();
-
 
     registerCommand(id: string, callback: (...args: any[]) => any, thisArg?: any): Disposable {
         const execute = callback.bind(thisArg);

--- a/client/packages/theia-integration/src/browser/language/glsp-client.ts
+++ b/client/packages/theia-integration/src/browser/language/glsp-client.ts
@@ -52,7 +52,6 @@ export class BaseGLSPClient implements GLSPClient {
         this.onStop = undefined;
         this._onReady = Promise.resolve();
         this.state = ClientState.Initial;
-
     }
 
     start(): Disposable {
@@ -135,6 +134,7 @@ export class BaseGLSPClient implements GLSPClient {
         }
         this.resolvedConnection!.onNotification(type, handler);
     }
+
     sendNotification<P, RO>(type: NotificationType<P, RO>, params?: P): void {
         if (!this.isConnectionActive()) {
             throw new Error('GLSP client is not ready yet');

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10498,10 +10498,10 @@ sprotty-theia@0.7.0-next.1c6b386:
     "@theia/monaco" next
     sprotty next
 
-sprotty@0.8.0-next.ff11b36, sprotty@next:
-  version "0.8.0-next.ff11b36"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.8.0-next.ff11b36.tgz#9344213553b451db5e0c9a12198497519d5026f4"
-  integrity sha512-zzwyabew8dSaE0PtDCC+T6SccyK8FkCOAWKNID4t+PBZeI+co/ZrHfzMO+d8fxtya+ZHsR8sKjIWlHfReYEw/w==
+sprotty@0.8.0-next.1d772ad, sprotty@0.8.0-next.ff11b36, sprotty@next:
+  version "0.8.0-next.1d772ad"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.8.0-next.1d772ad.tgz#fa5e83d74882bf9e07830990b31335b9b44e1797"
+  integrity sha512-kUa86D0tQHc9nRONtdhxoi04EBd6KX1VN7DNVaRBuudD25zOIorhz6T7VTdFoSS3gAsTfy7HcWQBH5UttBz+Ig==
   dependencies:
     autocompleter "5.1.0"
     file-saver "2.0.2"

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowCommandPaletteActionProvider.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowCommandPaletteActionProvider.java
@@ -20,6 +20,7 @@ import static com.eclipsesource.glsp.graph.util.GraphUtil.point;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -40,8 +41,8 @@ import com.google.common.collect.Sets;
 public class WorkflowCommandPaletteActionProvider implements CommandPaletteActionProvider {
 
 	@Override
-	public Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedIds, String text,
-			Optional<GPoint> lastMousePosition) {
+	public Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedIds,
+			Optional<GPoint> lastMousePosition, Map<String, String> args) {
 		Set<LabeledAction> actions = Sets.newLinkedHashSet();
 
 		GModelIndex index = modelState.getIndex();

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowContextMenuItemProvider.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowContextMenuItemProvider.java
@@ -1,0 +1,33 @@
+package com.eclipsesource.glsp.example.workflow;
+
+import static com.eclipsesource.glsp.example.workflow.utils.ModelTypes.AUTOMATED_TASK;
+import static com.eclipsesource.glsp.example.workflow.utils.ModelTypes.MANUAL_TASK;
+import static com.eclipsesource.glsp.graph.util.GraphUtil.point;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.eclipsesource.glsp.api.action.kind.CreateNodeOperationAction;
+import com.eclipsesource.glsp.api.model.GraphicalModelState;
+import com.eclipsesource.glsp.api.provider.ContextMenuItemProvider;
+import com.eclipsesource.glsp.api.types.MenuItem;
+import com.eclipsesource.glsp.graph.GPoint;
+import com.google.common.collect.Sets;
+
+public class WorkflowContextMenuItemProvider implements ContextMenuItemProvider {
+
+	@Override
+	public Set<MenuItem> getItems(GraphicalModelState modelState, List<String> selectedElementIds,
+			Optional<GPoint> position, Map<String, String> args) {
+		MenuItem newAutTask = new MenuItem("newAutoTask", "Automated Task",
+				Arrays.asList(new CreateNodeOperationAction(AUTOMATED_TASK, position.orElse(point(0, 0)))), true);
+		MenuItem newManTask = new MenuItem("newManualTask", "Manual Task",
+				Arrays.asList(new CreateNodeOperationAction(MANUAL_TASK, position.orElse(point(0, 0)))), true);
+		MenuItem newChildMenu = new MenuItem("new", "New", Arrays.asList(newAutTask, newManTask), "add", "0_new");
+		return Sets.newHashSet(newChildMenu);
+	}
+
+}

--- a/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowGLSPModule.java
+++ b/server/example/workflow-example/src/main/java/com/eclipsesource/glsp/example/workflow/WorkflowGLSPModule.java
@@ -32,6 +32,7 @@ import com.eclipsesource.glsp.api.model.ModelElementOpenListener;
 import com.eclipsesource.glsp.api.model.ModelExpansionListener;
 import com.eclipsesource.glsp.api.model.ModelSelectionListener;
 import com.eclipsesource.glsp.api.provider.CommandPaletteActionProvider;
+import com.eclipsesource.glsp.api.provider.ContextMenuItemProvider;
 import com.eclipsesource.glsp.example.workflow.handler.CreateAutomatedTaskHandler;
 import com.eclipsesource.glsp.example.workflow.handler.CreateDecisionNodeHandler;
 import com.eclipsesource.glsp.example.workflow.handler.CreateEdgeHandler;
@@ -122,7 +123,12 @@ public class WorkflowGLSPModule extends DefaultGLSPModule {
 	protected Class<? extends CommandPaletteActionProvider> bindCommandPaletteActionProvider() {
 		return WorkflowCommandPaletteActionProvider.class;
 	}
-
+	
+	@Override
+	protected Class<? extends ContextMenuItemProvider> bindContextMenuItemProvider() {
+		return WorkflowContextMenuItemProvider.class;
+	}
+	
 	@Override
 	protected Collection<Class<? extends ServerCommandHandler>> bindServerCommandHandlers() {
 		return Arrays.asList(SimulateCommandHandler.class);

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/Action.java
@@ -104,8 +104,8 @@ public abstract class Action {
 		public static final String APPLY_LABEL_EDIT_OPERATION = Operation.Kind.APPLY_LABEL_EDIT;
 		public static final String GENERIC_OPERATION = Operation.Kind.GENERIC;
 		public static final String EXECUTE_SERVER_COMMAND = "executeServerCommand";
-		public static final String REQUEST_COMMAND_PALETTE_ACTIONS = "requestCommandPaletteActions";
-		public static final String SET_COMMAND_PALETTE_ACTIONS = "setCommandPaletteActions";
+		public static final String REQUEST_CONTEXT_ACTIONS = "requestContextActions";
+		public static final String SET_CONTEXT_ACTIONS = "setContextActions";
 		public static final String REQUEST_MARKERS = "requestMarkers";
 		public static final String SET_MARKERS = "setMarkers";
 		public static final String LAYOUT = "layout";

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestContextActions.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/RequestContextActions.java
@@ -16,30 +16,31 @@
 package com.eclipsesource.glsp.api.action.kind;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.RequestAction;
 import com.eclipsesource.glsp.graph.GPoint;
 
-public class RequestCommandPaletteActions extends RequestAction<SetCommandPaletteActions> {
+public class RequestContextActions  extends RequestAction<SetContextActions> {
 
 	private List<String> selectedElementIds;
-	private String text;
+	private Map<String, String> args;
 	private GPoint lastMousePosition = null;
 
-	public RequestCommandPaletteActions() {
-		super(Action.Kind.REQUEST_COMMAND_PALETTE_ACTIONS);
+	public RequestContextActions() {
+		super(Action.Kind.REQUEST_CONTEXT_ACTIONS);
 	}
 	
-	public RequestCommandPaletteActions(List<String> selectedElementIds, String text) {
-		this(selectedElementIds, text, null);
+	public RequestContextActions(List<String> selectedElementIds, Map<String, String> args) {
+		this(selectedElementIds, null, args);
 	}
 
-	public RequestCommandPaletteActions(List<String> selectedElementIds, String text, GPoint lastMousePosition) {
+	public RequestContextActions(List<String> selectedElementIds, GPoint lastMousePosition, Map<String, String> args) {
 		this();
 		this.selectedElementIds = selectedElementIds;
-		this.text = text;
+		this.args = args;
 		this.lastMousePosition = lastMousePosition;
 	}
 
@@ -51,14 +52,14 @@ public class RequestCommandPaletteActions extends RequestAction<SetCommandPalett
 		this.selectedElementIds = selectedElementsIDs;
 	}
 	
-	public String getText() {
-		return text;
+	public Map<String, String> getArgs() {
+		return args;
 	}
-	
-	public void setText(String text) {
-		this.text = text;
+
+	public void setArgs(Map<String, String> args) {
+		this.args = args;
 	}
-	
+
 	public Optional<GPoint> getLastMousePosition() {
 		return Optional.ofNullable(lastMousePosition);
 	}
@@ -71,9 +72,9 @@ public class RequestCommandPaletteActions extends RequestAction<SetCommandPalett
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
+		result = prime * result + ((args == null) ? 0 : args.hashCode());
 		result = prime * result + ((lastMousePosition == null) ? 0 : lastMousePosition.hashCode());
 		result = prime * result + ((selectedElementIds == null) ? 0 : selectedElementIds.hashCode());
-		result = prime * result + ((text == null) ? 0 : text.hashCode());
 		return result;
 	}
 
@@ -85,7 +86,12 @@ public class RequestCommandPaletteActions extends RequestAction<SetCommandPalett
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		RequestCommandPaletteActions other = (RequestCommandPaletteActions) obj;
+		RequestContextActions other = (RequestContextActions) obj;
+		if (args == null) {
+			if (other.args != null)
+				return false;
+		} else if (!args.equals(other.args))
+			return false;
 		if (lastMousePosition == null) {
 			if (other.lastMousePosition != null)
 				return false;
@@ -95,11 +101,6 @@ public class RequestCommandPaletteActions extends RequestAction<SetCommandPalett
 			if (other.selectedElementIds != null)
 				return false;
 		} else if (!selectedElementIds.equals(other.selectedElementIds))
-			return false;
-		if (text == null) {
-			if (other.text != null)
-				return false;
-		} else if (!text.equals(other.text))
 			return false;
 		return true;
 	}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetContextActions.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/action/kind/SetContextActions.java
@@ -15,23 +15,26 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.api.action.kind;
 
+import java.util.Map;
 import java.util.Set;
 
 import com.eclipsesource.glsp.api.action.Action;
 import com.eclipsesource.glsp.api.action.ResponseAction;
 import com.eclipsesource.glsp.api.types.LabeledAction;
 
-public class SetCommandPaletteActions extends ResponseAction {
+public class SetContextActions extends ResponseAction {
 
 	private Set<LabeledAction> actions;
+	private Map<String, String> args;
 
-	public SetCommandPaletteActions() {
-		super(Action.Kind.SET_COMMAND_PALETTE_ACTIONS);
+	public SetContextActions() {
+		super(Action.Kind.SET_CONTEXT_ACTIONS);
 	}
 
-	public SetCommandPaletteActions(Set<LabeledAction> actions) {
+	public SetContextActions(Set<LabeledAction> actions, Map<String, String> map) {
 		this();
 		this.actions = actions;
+		this.args = map;
 	}
 
 	public Set<LabeledAction> getActions() {
@@ -42,33 +45,42 @@ public class SetCommandPaletteActions extends ResponseAction {
 		this.actions = commandPaletteActions;
 	}
 
+	public Map<String, String> getArgs() {
+		return args;
+	}
+
+	public void setArgs(Map<String, String> args) {
+		this.args = args;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((actions == null) ? 0 : actions.hashCode());
+		result = prime * result + ((args == null) ? 0 : args.hashCode());
 		return result;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) {
+		if (this == obj)
 			return true;
-		}
-		if (!super.equals(obj)) {
+		if (!super.equals(obj))
 			return false;
-		}
-		if (!(obj instanceof SetCommandPaletteActions)) {
+		if (getClass() != obj.getClass())
 			return false;
-		}
-		SetCommandPaletteActions other = (SetCommandPaletteActions) obj;
+		SetContextActions other = (SetContextActions) obj;
 		if (actions == null) {
-			if (other.actions != null) {
+			if (other.actions != null)
 				return false;
-			}
-		} else if (!actions.equals(other.actions)) {
+		} else if (!actions.equals(other.actions))
 			return false;
-		}
+		if (args == null) {
+			if (other.args != null)
+				return false;
+		} else if (!args.equals(other.args))
+			return false;
 		return true;
 	}
 

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/di/GLSPModule.java
@@ -35,6 +35,7 @@ import com.eclipsesource.glsp.api.model.ModelStateProvider;
 import com.eclipsesource.glsp.api.provider.ActionHandlerProvider;
 import com.eclipsesource.glsp.api.provider.ActionProvider;
 import com.eclipsesource.glsp.api.provider.CommandPaletteActionProvider;
+import com.eclipsesource.glsp.api.provider.ContextMenuItemProvider;
 import com.eclipsesource.glsp.api.provider.OperationHandlerProvider;
 import com.eclipsesource.glsp.api.provider.ServerCommandHandlerProvider;
 import com.eclipsesource.glsp.graph.GraphExtension;
@@ -57,8 +58,9 @@ public abstract class GLSPModule extends AbstractModule {
 		bind(OperationHandlerProvider.class).to(bindOperatioHandlerProvider());
 		bind(ServerCommandHandlerProvider.class).to(bindServerCommandHandlerProvider());
 		bind(CommandPaletteActionProvider.class).to(bindCommandPaletteActionProvider());
+		bind(ContextMenuItemProvider.class).to(bindContextMenuItemProvider());
 		bind(ModelValidator.class).to(bindModelValidator());
-		bind(ActionProcessor.class).to(bindActionProcessor()).in(Singleton.class);;
+		bind(ActionProcessor.class).to(bindActionProcessor()).in(Singleton.class);
 		bind(DiagramConfigurationProvider.class).to(bindDiagramConfigurationProvider());
 		bind(LabelEditValidator.class).to(bindLabelEditValidator());
 		bind(ModelStateProvider.class).to(bindModelStateProvider());
@@ -80,6 +82,10 @@ public abstract class GLSPModule extends AbstractModule {
 
 	protected Class<? extends CommandPaletteActionProvider> bindCommandPaletteActionProvider() {
 		return CommandPaletteActionProvider.NullImpl.class;
+	}
+
+	protected Class<? extends ContextMenuItemProvider> bindContextMenuItemProvider() {
+		return ContextMenuItemProvider.NullImpl.class;
 	}
 
 	protected Class<? extends ActionProvider> bindActionProvider() {

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/ContextMenuItemProvider.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/provider/ContextMenuItemProvider.java
@@ -22,25 +22,25 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
-import com.eclipsesource.glsp.api.types.LabeledAction;
+import com.eclipsesource.glsp.api.types.MenuItem;
 import com.eclipsesource.glsp.graph.GPoint;
 
 @FunctionalInterface
-public interface CommandPaletteActionProvider {
-	
-	public static String KEY = "command-palette";
+public interface ContextMenuItemProvider {
 
-	Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds,
+	public static String KEY = "context-menu";
+
+	Set<MenuItem> getItems(GraphicalModelState modelState, List<String> selectedElementIds,
 			Optional<GPoint> lastMousePosition, Map<String, String> args);
 
-	default Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds,
+	default Set<MenuItem> getItems(GraphicalModelState modelState, List<String> selectedElementIds,
 			GPoint lastMousePosition, Map<String, String> args) {
-		return getActions(modelState, selectedElementIds, Optional.ofNullable(lastMousePosition), args);
+		return getItems(modelState, selectedElementIds, Optional.ofNullable(lastMousePosition), args);
 	}
 
-	public static class NullImpl implements CommandPaletteActionProvider {
+	public static class NullImpl implements ContextMenuItemProvider {
 		@Override
-		public Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds,
+		public Set<MenuItem> getItems(GraphicalModelState modelState, List<String> selectedElementIds,
 				Optional<GPoint> lastMousePosition, Map<String, String> args) {
 			return Collections.emptySet();
 		}

--- a/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/MenuItem.java
+++ b/server/glsp-api/src/main/java/com/eclipsesource/glsp/api/types/MenuItem.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *  
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v. 2.0 which is available at
+ *   http://www.eclipse.org/legal/epl-2.0.
+ *  
+ *   This Source Code may also be made available under the following Secondary
+ *   Licenses when the conditions for such availability set forth in the Eclipse
+ *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ *   with the GNU Classpath Exception which is available at
+ *   https://www.gnu.org/software/classpath/license.html.
+ *  
+ *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package com.eclipsesource.glsp.api.types;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.eclipsesource.glsp.api.action.Action;
+
+public class MenuItem extends LabeledAction {
+
+	private String id;
+	private String sortString;
+	private String group;
+	private String parentId;
+	private boolean isEnabled;
+	private boolean isToggled;
+	private List<MenuItem> children;
+
+	public MenuItem(String id, String label, List<Action> actions, boolean isEnabled) {
+		this(id, label, actions, isEnabled, null);
+	}
+
+	public MenuItem(String id, String label, List<Action> actions, boolean isEnabled, String icon) {
+		this(id, label, actions, isEnabled, icon, null);
+	}
+
+	public MenuItem(String id, String label, List<Action> actions, boolean isEnabled, String icon, String sortString) {
+		this(id, label, actions, icon, sortString, null, null, isEnabled, false, Collections.emptyList());
+	}
+
+	public MenuItem(String id, String label, List<MenuItem> children) {
+		this(id, label, children, null);
+	}
+
+	public MenuItem(String id, String label, List<MenuItem> children, String group) {
+		this(id, label, children, group, null);
+	}
+
+	public MenuItem(String id, String label, List<MenuItem> children, String group, String sortString) {
+		this(id, label, Collections.emptyList(), null, sortString, group, null, true, false, children);
+	}
+
+	public MenuItem(String id, String label, List<Action> actions, String icon, String sortString, String group,
+			String parentId, boolean isEnabled, boolean isToggled, List<MenuItem> children) {
+		super(label, icon, actions);
+		this.id = id;
+		this.sortString = sortString;
+		this.group = group;
+		this.parentId = parentId;
+		this.isEnabled = isEnabled;
+		this.isToggled = isToggled;
+		this.children = children;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getSortString() {
+		return sortString;
+	}
+
+	public void setSortString(String sortString) {
+		this.sortString = sortString;
+	}
+
+	public String getGroup() {
+		return group;
+	}
+
+	public void setGroup(String group) {
+		this.group = group;
+	}
+
+	public String getParentId() {
+		return parentId;
+	}
+
+	public void setParentId(String parentId) {
+		this.parentId = parentId;
+	}
+
+	public boolean isEnabled() {
+		return isEnabled;
+	}
+
+	public void setEnabled(boolean isEnabled) {
+		this.isEnabled = isEnabled;
+	}
+
+	public boolean isToggled() {
+		return isToggled;
+	}
+
+	public void setToggled(boolean isToggled) {
+		this.isToggled = isToggled;
+	}
+
+	public List<MenuItem> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<MenuItem> children) {
+		this.children = children;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((children == null) ? 0 : children.hashCode());
+		result = prime * result + ((group == null) ? 0 : group.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + (isEnabled ? 1231 : 1237);
+		result = prime * result + (isToggled ? 1231 : 1237);
+		result = prime * result + ((parentId == null) ? 0 : parentId.hashCode());
+		result = prime * result + ((sortString == null) ? 0 : sortString.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MenuItem other = (MenuItem) obj;
+		if (children == null) {
+			if (other.children != null)
+				return false;
+		} else if (!children.equals(other.children))
+			return false;
+		if (group == null) {
+			if (other.group != null)
+				return false;
+		} else if (!group.equals(other.group))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (isEnabled != other.isEnabled)
+			return false;
+		if (isToggled != other.isToggled)
+			return false;
+		if (parentId == null) {
+			if (other.parentId != null)
+				return false;
+		} else if (!parentId.equals(other.parentId))
+			return false;
+		if (sortString == null) {
+			if (other.sortString != null)
+				return false;
+		} else if (!sortString.equals(other.sortString))
+			return false;
+		return true;
+	}
+
+}

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestContextActionsHandler.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/actionhandler/RequestContextActionsHandler.java
@@ -15,36 +15,57 @@
  ******************************************************************************/
 package com.eclipsesource.glsp.server.actionhandler;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import com.eclipsesource.glsp.api.action.Action;
-import com.eclipsesource.glsp.api.action.kind.RequestCommandPaletteActions;
-import com.eclipsesource.glsp.api.action.kind.SetCommandPaletteActions;
+import com.eclipsesource.glsp.api.action.kind.RequestContextActions;
+import com.eclipsesource.glsp.api.action.kind.SetContextActions;
 import com.eclipsesource.glsp.api.model.GraphicalModelState;
 import com.eclipsesource.glsp.api.provider.CommandPaletteActionProvider;
+import com.eclipsesource.glsp.api.provider.ContextMenuItemProvider;
 import com.eclipsesource.glsp.api.types.LabeledAction;
 import com.google.inject.Inject;
 
-public class RequestCommandPaletteActionsHandler extends AbstractActionHandler {
+public class RequestContextActionsHandler extends AbstractActionHandler {
+
+	public static String UI_CONTROL_KEY = "ui-control";
+
 	@Inject
 	protected CommandPaletteActionProvider commandPaletteActionProvider;
 
+	@Inject
+	protected ContextMenuItemProvider contextMenuItemProvider;
+
 	@Override
 	public boolean handles(Action action) {
-		return action instanceof RequestCommandPaletteActions;
+		return action instanceof RequestContextActions;
 	}
 
 	@Override
 	public Optional<Action> execute(Action action, GraphicalModelState modelState) {
-		if (action instanceof RequestCommandPaletteActions) {
-			RequestCommandPaletteActions paletteAction = (RequestCommandPaletteActions) action;
-			List<String> selectedElementIds = paletteAction.getSelectedElementIds();
-			Set<LabeledAction> commandPaletteActions = commandPaletteActionProvider.getActions(modelState,
-					selectedElementIds, paletteAction.getText(), paletteAction.getLastMousePosition());
-			return Optional.of(new SetCommandPaletteActions(commandPaletteActions));
+		if (action instanceof RequestContextActions) {
+			RequestContextActions requestContextAction = (RequestContextActions) action;
+			List<String> selectedElementIds = requestContextAction.getSelectedElementIds();
+			Map<String, String> args = requestContextAction.getArgs();
+			Set<LabeledAction> items = new HashSet<>();
+			if (equalsUiControl(args, CommandPaletteActionProvider.KEY)) {
+				items.addAll(commandPaletteActionProvider.getActions(modelState, selectedElementIds,
+						requestContextAction.getLastMousePosition(), args));
+			} else if (equalsUiControl(args, ContextMenuItemProvider.KEY)) {
+				items.addAll(contextMenuItemProvider.getItems(modelState, selectedElementIds,
+						requestContextAction.getLastMousePosition(), args));
+
+			}
+			return Optional.of(new SetContextActions(items, requestContextAction.getArgs()));
 		}
 		return Optional.empty();
+	}
+
+	protected boolean equalsUiControl(Map<String, String> args, String uiControlKey) {
+		return args.containsKey(UI_CONTROL_KEY) && args.get(UI_CONTROL_KEY).equals(uiControlKey);
 	}
 }

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/di/DefaultGLSPModule.java
@@ -42,7 +42,7 @@ import com.eclipsesource.glsp.server.actionhandler.ExecuteServerCommandActionHan
 import com.eclipsesource.glsp.server.actionhandler.LayoutActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.OpenActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.OperationActionHandler;
-import com.eclipsesource.glsp.server.actionhandler.RequestCommandPaletteActionsHandler;
+import com.eclipsesource.glsp.server.actionhandler.RequestContextActionsHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestMarkersHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestModelActionHandler;
 import com.eclipsesource.glsp.server.actionhandler.RequestOperationsActionHandler;
@@ -77,7 +77,7 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 			OperationActionHandler.class, RequestModelActionHandler.class, RequestOperationsActionHandler.class,
 			RequestPopupModelActionHandler.class, SaveModelActionHandler.class, UndoRedoActionHandler.class,
 			SelectActionHandler.class, ExecuteServerCommandActionHandler.class, RequestTypeHintsActionHandler.class,
-			RequestCommandPaletteActionsHandler.class, RequestMarkersHandler.class, LayoutActionHandler.class,
+			RequestContextActionsHandler.class, RequestMarkersHandler.class, LayoutActionHandler.class,
 			ValidateLabelEditActionHandler.class);
 
 	@Override

--- a/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
+++ b/server/glsp-server/src/main/java/com/eclipsesource/glsp/server/provider/DefaultActionProvider.java
@@ -37,7 +37,7 @@ import com.eclipsesource.glsp.api.action.kind.OpenAction;
 import com.eclipsesource.glsp.api.action.kind.ReconnectConnectionOperationAction;
 import com.eclipsesource.glsp.api.action.kind.RedoAction;
 import com.eclipsesource.glsp.api.action.kind.RequestBoundsAction;
-import com.eclipsesource.glsp.api.action.kind.RequestCommandPaletteActions;
+import com.eclipsesource.glsp.api.action.kind.RequestContextActions;
 import com.eclipsesource.glsp.api.action.kind.RequestExportSvgAction;
 import com.eclipsesource.glsp.api.action.kind.RequestLayersAction;
 import com.eclipsesource.glsp.api.action.kind.RequestMarkersAction;
@@ -107,7 +107,7 @@ public class DefaultActionProvider implements ActionProvider {
 		defaultActions.add(new ToogleLayerAction());
 		defaultActions.add(new UpdateModelAction());
 		defaultActions.add(new ExecuteServerCommandAction());
-		defaultActions.add(new RequestCommandPaletteActions());
+		defaultActions.add(new RequestContextActions());
 		defaultActions.add(new ReconnectConnectionOperationAction());
 		defaultActions.add(new RerouteConnectionOperationAction());
 		defaultActions.add(new LayoutAction());


### PR DESCRIPTION
This change introduces client-side support for context menus including an implementation for Theia, as well as a server-side provider mechanism for context menu items. This mechanism has been harmonized with the provider for command palette actions so that there is only one "context commands" request/set pair. The server as well as the client framework separates them, however, to
make it clearer for implementers.

Alongside this new feature, this change also applies a few of cleanups.